### PR TITLE
Make .gitignore patterns more specific

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # Bundle files are generated
-bundle
+/bundle
 
 # Operator's binaries
-manager
+/manager
 
 # Binaries for programs and plugins
 *.exe
@@ -10,7 +10,7 @@ manager
 *.dll
 *.so
 *.dylib
-bin
+/bin
 testbin/*
 
 # Test binary, build with `go test -c`

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/manager/doc.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/manager/doc.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+Package manager is required to create Controllers and provides shared dependencies such as clients, caches, schemes,
+etc.  Controllers must be started by calling Manager.Start.
+*/
+package manager

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/manager/internal.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/manager/internal.go
@@ -1,0 +1,652 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	kerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/tools/record"
+
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/internal/httpserver"
+	intrec "sigs.k8s.io/controller-runtime/pkg/internal/recorder"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+const (
+	// Values taken from: https://github.com/kubernetes/component-base/blob/master/config/v1alpha1/defaults.go
+	defaultLeaseDuration          = 15 * time.Second
+	defaultRenewDeadline          = 10 * time.Second
+	defaultRetryPeriod            = 2 * time.Second
+	defaultGracefulShutdownPeriod = 30 * time.Second
+
+	defaultReadinessEndpoint = "/readyz"
+	defaultLivenessEndpoint  = "/healthz"
+	defaultMetricsEndpoint   = "/metrics"
+)
+
+var _ Runnable = &controllerManager{}
+
+type controllerManager struct {
+	sync.Mutex
+	started bool
+
+	stopProcedureEngaged *int64
+	errChan              chan error
+	runnables            *runnables
+
+	// cluster holds a variety of methods to interact with a cluster. Required.
+	cluster cluster.Cluster
+
+	// recorderProvider is used to generate event recorders that will be injected into Controllers
+	// (and EventHandlers, Sources and Predicates).
+	recorderProvider *intrec.Provider
+
+	// resourceLock forms the basis for leader election
+	resourceLock resourcelock.Interface
+
+	// leaderElectionReleaseOnCancel defines if the manager should step back from the leader lease
+	// on shutdown
+	leaderElectionReleaseOnCancel bool
+
+	// metricsListener is used to serve prometheus metrics
+	metricsListener net.Listener
+
+	// metricsExtraHandlers contains extra handlers to register on http server that serves metrics.
+	metricsExtraHandlers map[string]http.Handler
+
+	// healthProbeListener is used to serve liveness probe
+	healthProbeListener net.Listener
+
+	// Readiness probe endpoint name
+	readinessEndpointName string
+
+	// Liveness probe endpoint name
+	livenessEndpointName string
+
+	// Readyz probe handler
+	readyzHandler *healthz.Handler
+
+	// Healthz probe handler
+	healthzHandler *healthz.Handler
+
+	// controllerOptions are the global controller options.
+	controllerOptions v1alpha1.ControllerConfigurationSpec
+
+	// Logger is the logger that should be used by this manager.
+	// If none is set, it defaults to log.Log global logger.
+	logger logr.Logger
+
+	// leaderElectionStopped is an internal channel used to signal the stopping procedure that the
+	// LeaderElection.Run(...) function has returned and the shutdown can proceed.
+	leaderElectionStopped chan struct{}
+
+	// leaderElectionCancel is used to cancel the leader election. It is distinct from internalStopper,
+	// because for safety reasons we need to os.Exit() when we lose the leader election, meaning that
+	// it must be deferred until after gracefulShutdown is done.
+	leaderElectionCancel context.CancelFunc
+
+	// elected is closed when this manager becomes the leader of a group of
+	// managers, either because it won a leader election or because no leader
+	// election was configured.
+	elected chan struct{}
+
+	// port is the port that the webhook server serves at.
+	port int
+	// host is the hostname that the webhook server binds to.
+	host string
+	// CertDir is the directory that contains the server key and certificate.
+	// if not set, webhook server would look up the server key and certificate in
+	// {TempDir}/k8s-webhook-server/serving-certs
+	certDir string
+
+	webhookServer *webhook.Server
+	// webhookServerOnce will be called in GetWebhookServer() to optionally initialize
+	// webhookServer if unset, and Add() it to controllerManager.
+	webhookServerOnce sync.Once
+
+	// leaseDuration is the duration that non-leader candidates will
+	// wait to force acquire leadership.
+	leaseDuration time.Duration
+	// renewDeadline is the duration that the acting controlplane will retry
+	// refreshing leadership before giving up.
+	renewDeadline time.Duration
+	// retryPeriod is the duration the LeaderElector clients should wait
+	// between tries of actions.
+	retryPeriod time.Duration
+
+	// gracefulShutdownTimeout is the duration given to runnable to stop
+	// before the manager actually returns on stop.
+	gracefulShutdownTimeout time.Duration
+
+	// onStoppedLeading is callled when the leader election lease is lost.
+	// It can be overridden for tests.
+	onStoppedLeading func()
+
+	// shutdownCtx is the context that can be used during shutdown. It will be cancelled
+	// after the gracefulShutdownTimeout ended. It must not be accessed before internalStop
+	// is closed because it will be nil.
+	shutdownCtx context.Context
+
+	internalCtx    context.Context
+	internalCancel context.CancelFunc
+
+	// internalProceduresStop channel is used internally to the manager when coordinating
+	// the proper shutdown of servers. This channel is also used for dependency injection.
+	internalProceduresStop chan struct{}
+}
+
+type hasCache interface {
+	Runnable
+	GetCache() cache.Cache
+}
+
+// Add sets dependencies on i, and adds it to the list of Runnables to start.
+func (cm *controllerManager) Add(r Runnable) error {
+	cm.Lock()
+	defer cm.Unlock()
+	return cm.add(r)
+}
+
+func (cm *controllerManager) add(r Runnable) error {
+	// Set dependencies on the object
+	if err := cm.SetFields(r); err != nil {
+		return err
+	}
+	return cm.runnables.Add(r)
+}
+
+// Deprecated: use the equivalent Options field to set a field. This method will be removed in v0.10.
+func (cm *controllerManager) SetFields(i interface{}) error {
+	if err := cm.cluster.SetFields(i); err != nil {
+		return err
+	}
+	if _, err := inject.InjectorInto(cm.SetFields, i); err != nil {
+		return err
+	}
+	if _, err := inject.StopChannelInto(cm.internalProceduresStop, i); err != nil {
+		return err
+	}
+	if _, err := inject.LoggerInto(cm.logger, i); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// AddMetricsExtraHandler adds extra handler served on path to the http server that serves metrics.
+func (cm *controllerManager) AddMetricsExtraHandler(path string, handler http.Handler) error {
+	cm.Lock()
+	defer cm.Unlock()
+
+	if cm.started {
+		return fmt.Errorf("unable to add new metrics handler because metrics endpoint has already been created")
+	}
+
+	if path == defaultMetricsEndpoint {
+		return fmt.Errorf("overriding builtin %s endpoint is not allowed", defaultMetricsEndpoint)
+	}
+
+	if _, found := cm.metricsExtraHandlers[path]; found {
+		return fmt.Errorf("can't register extra handler by duplicate path %q on metrics http server", path)
+	}
+
+	cm.metricsExtraHandlers[path] = handler
+	cm.logger.V(2).Info("Registering metrics http server extra handler", "path", path)
+	return nil
+}
+
+// AddHealthzCheck allows you to add Healthz checker.
+func (cm *controllerManager) AddHealthzCheck(name string, check healthz.Checker) error {
+	cm.Lock()
+	defer cm.Unlock()
+
+	if cm.started {
+		return fmt.Errorf("unable to add new checker because healthz endpoint has already been created")
+	}
+
+	if cm.healthzHandler == nil {
+		cm.healthzHandler = &healthz.Handler{Checks: map[string]healthz.Checker{}}
+	}
+
+	cm.healthzHandler.Checks[name] = check
+	return nil
+}
+
+// AddReadyzCheck allows you to add Readyz checker.
+func (cm *controllerManager) AddReadyzCheck(name string, check healthz.Checker) error {
+	cm.Lock()
+	defer cm.Unlock()
+
+	if cm.started {
+		return fmt.Errorf("unable to add new checker because healthz endpoint has already been created")
+	}
+
+	if cm.readyzHandler == nil {
+		cm.readyzHandler = &healthz.Handler{Checks: map[string]healthz.Checker{}}
+	}
+
+	cm.readyzHandler.Checks[name] = check
+	return nil
+}
+
+func (cm *controllerManager) GetConfig() *rest.Config {
+	return cm.cluster.GetConfig()
+}
+
+func (cm *controllerManager) GetClient() client.Client {
+	return cm.cluster.GetClient()
+}
+
+func (cm *controllerManager) GetScheme() *runtime.Scheme {
+	return cm.cluster.GetScheme()
+}
+
+func (cm *controllerManager) GetFieldIndexer() client.FieldIndexer {
+	return cm.cluster.GetFieldIndexer()
+}
+
+func (cm *controllerManager) GetCache() cache.Cache {
+	return cm.cluster.GetCache()
+}
+
+func (cm *controllerManager) GetEventRecorderFor(name string) record.EventRecorder {
+	return cm.cluster.GetEventRecorderFor(name)
+}
+
+func (cm *controllerManager) GetRESTMapper() meta.RESTMapper {
+	return cm.cluster.GetRESTMapper()
+}
+
+func (cm *controllerManager) GetAPIReader() client.Reader {
+	return cm.cluster.GetAPIReader()
+}
+
+func (cm *controllerManager) GetWebhookServer() *webhook.Server {
+	cm.webhookServerOnce.Do(func() {
+		if cm.webhookServer == nil {
+			cm.webhookServer = &webhook.Server{
+				Port:    cm.port,
+				Host:    cm.host,
+				CertDir: cm.certDir,
+			}
+		}
+		if err := cm.Add(cm.webhookServer); err != nil {
+			panic(fmt.Sprintf("unable to add webhook server to the controller manager: %s", err))
+		}
+	})
+	return cm.webhookServer
+}
+
+func (cm *controllerManager) GetLogger() logr.Logger {
+	return cm.logger
+}
+
+func (cm *controllerManager) GetControllerOptions() v1alpha1.ControllerConfigurationSpec {
+	return cm.controllerOptions
+}
+
+func (cm *controllerManager) serveMetrics() {
+	handler := promhttp.HandlerFor(metrics.Registry, promhttp.HandlerOpts{
+		ErrorHandling: promhttp.HTTPErrorOnError,
+	})
+	// TODO(JoelSpeed): Use existing Kubernetes machinery for serving metrics
+	mux := http.NewServeMux()
+	mux.Handle(defaultMetricsEndpoint, handler)
+	for path, extraHandler := range cm.metricsExtraHandlers {
+		mux.Handle(path, extraHandler)
+	}
+
+	server := httpserver.New(mux)
+	go cm.httpServe("metrics", cm.logger.WithValues("path", defaultMetricsEndpoint), server, cm.metricsListener)
+}
+
+func (cm *controllerManager) serveHealthProbes() {
+	mux := http.NewServeMux()
+	server := httpserver.New(mux)
+
+	if cm.readyzHandler != nil {
+		mux.Handle(cm.readinessEndpointName, http.StripPrefix(cm.readinessEndpointName, cm.readyzHandler))
+		// Append '/' suffix to handle subpaths
+		mux.Handle(cm.readinessEndpointName+"/", http.StripPrefix(cm.readinessEndpointName, cm.readyzHandler))
+	}
+	if cm.healthzHandler != nil {
+		mux.Handle(cm.livenessEndpointName, http.StripPrefix(cm.livenessEndpointName, cm.healthzHandler))
+		// Append '/' suffix to handle subpaths
+		mux.Handle(cm.livenessEndpointName+"/", http.StripPrefix(cm.livenessEndpointName, cm.healthzHandler))
+	}
+
+	go cm.httpServe("health probe", cm.logger, server, cm.healthProbeListener)
+}
+
+func (cm *controllerManager) httpServe(kind string, log logr.Logger, server *http.Server, ln net.Listener) {
+	log = log.WithValues("kind", kind, "addr", ln.Addr())
+
+	go func() {
+		log.Info("Starting server")
+		if err := server.Serve(ln); err != nil {
+			if errors.Is(err, http.ErrServerClosed) {
+				return
+			}
+			if atomic.LoadInt64(cm.stopProcedureEngaged) > 0 {
+				// There might be cases where connections are still open and we try to shutdown
+				// but not having enough time to close the connection causes an error in Serve
+				//
+				// In that case we want to avoid returning an error to the main error channel.
+				log.Error(err, "error on Serve after stop has been engaged")
+				return
+			}
+			cm.errChan <- err
+		}
+	}()
+
+	// Shutdown the server when stop is closed.
+	<-cm.internalProceduresStop
+	if err := server.Shutdown(cm.shutdownCtx); err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			// Avoid logging context related errors.
+			return
+		}
+		if atomic.LoadInt64(cm.stopProcedureEngaged) > 0 {
+			cm.logger.Error(err, "error on Shutdown after stop has been engaged")
+			return
+		}
+		cm.errChan <- err
+	}
+}
+
+// Start starts the manager and waits indefinitely.
+// There is only two ways to have start return:
+// An error has occurred during in one of the internal operations,
+// such as leader election, cache start, webhooks, and so on.
+// Or, the context is cancelled.
+func (cm *controllerManager) Start(ctx context.Context) (err error) {
+	cm.Lock()
+	if cm.started {
+		cm.Unlock()
+		return errors.New("manager already started")
+	}
+	var ready bool
+	defer func() {
+		// Only unlock the manager if we haven't reached
+		// the internal readiness condition.
+		if !ready {
+			cm.Unlock()
+		}
+	}()
+
+	// Initialize the internal context.
+	cm.internalCtx, cm.internalCancel = context.WithCancel(ctx)
+
+	// This chan indicates that stop is complete, in other words all runnables have returned or timeout on stop request
+	stopComplete := make(chan struct{})
+	defer close(stopComplete)
+	// This must be deferred after closing stopComplete, otherwise we deadlock.
+	defer func() {
+		// https://hips.hearstapps.com/hmg-prod.s3.amazonaws.com/images/gettyimages-459889618-1533579787.jpg
+		stopErr := cm.engageStopProcedure(stopComplete)
+		if stopErr != nil {
+			if err != nil {
+				// Utilerrors.Aggregate allows to use errors.Is for all contained errors
+				// whereas fmt.Errorf allows wrapping at most one error which means the
+				// other one can not be found anymore.
+				err = kerrors.NewAggregate([]error{err, stopErr})
+			} else {
+				err = stopErr
+			}
+		}
+	}()
+
+	// Add the cluster runnable.
+	if err := cm.add(cm.cluster); err != nil {
+		return fmt.Errorf("failed to add cluster to runnables: %w", err)
+	}
+
+	// Metrics should be served whether the controller is leader or not.
+	// (If we don't serve metrics for non-leaders, prometheus will still scrape
+	// the pod but will get a connection refused).
+	if cm.metricsListener != nil {
+		cm.serveMetrics()
+	}
+
+	// Serve health probes.
+	if cm.healthProbeListener != nil {
+		cm.serveHealthProbes()
+	}
+
+	// First start any webhook servers, which includes conversion, validation, and defaulting
+	// webhooks that are registered.
+	//
+	// WARNING: Webhooks MUST start before any cache is populated, otherwise there is a race condition
+	// between conversion webhooks and the cache sync (usually initial list) which causes the webhooks
+	// to never start because no cache can be populated.
+	if err := cm.runnables.Webhooks.Start(cm.internalCtx); err != nil {
+		if !errors.Is(err, wait.ErrWaitTimeout) {
+			return err
+		}
+	}
+
+	// Start and wait for caches.
+	if err := cm.runnables.Caches.Start(cm.internalCtx); err != nil {
+		if !errors.Is(err, wait.ErrWaitTimeout) {
+			return err
+		}
+	}
+
+	// Start the non-leaderelection Runnables after the cache has synced.
+	if err := cm.runnables.Others.Start(cm.internalCtx); err != nil {
+		if !errors.Is(err, wait.ErrWaitTimeout) {
+			return err
+		}
+	}
+
+	// Start the leader election and all required runnables.
+	{
+		ctx, cancel := context.WithCancel(context.Background())
+		cm.leaderElectionCancel = cancel
+		go func() {
+			if cm.resourceLock != nil {
+				if err := cm.startLeaderElection(ctx); err != nil {
+					cm.errChan <- err
+				}
+			} else {
+				// Treat not having leader election enabled the same as being elected.
+				if err := cm.startLeaderElectionRunnables(); err != nil {
+					cm.errChan <- err
+				}
+				close(cm.elected)
+			}
+		}()
+	}
+
+	ready = true
+	cm.Unlock()
+	select {
+	case <-ctx.Done():
+		// We are done
+		return nil
+	case err := <-cm.errChan:
+		// Error starting or running a runnable
+		return err
+	}
+}
+
+// engageStopProcedure signals all runnables to stop, reads potential errors
+// from the errChan and waits for them to end. It must not be called more than once.
+func (cm *controllerManager) engageStopProcedure(stopComplete <-chan struct{}) error {
+	if !atomic.CompareAndSwapInt64(cm.stopProcedureEngaged, 0, 1) {
+		return errors.New("stop procedure already engaged")
+	}
+
+	// Populate the shutdown context, this operation MUST be done before
+	// closing the internalProceduresStop channel.
+	//
+	// The shutdown context immediately expires if the gracefulShutdownTimeout is not set.
+	var shutdownCancel context.CancelFunc
+	cm.shutdownCtx, shutdownCancel = context.WithTimeout(context.Background(), cm.gracefulShutdownTimeout)
+	defer shutdownCancel()
+
+	// Start draining the errors before acquiring the lock to make sure we don't deadlock
+	// if something that has the lock is blocked on trying to write into the unbuffered
+	// channel after something else already wrote into it.
+	var closeOnce sync.Once
+	go func() {
+		for {
+			// Closing in the for loop is required to avoid race conditions between
+			// the closure of all internal procedures and making sure to have a reader off the error channel.
+			closeOnce.Do(func() {
+				// Cancel the internal stop channel and wait for the procedures to stop and complete.
+				close(cm.internalProceduresStop)
+				cm.internalCancel()
+			})
+			select {
+			case err, ok := <-cm.errChan:
+				if ok {
+					cm.logger.Error(err, "error received after stop sequence was engaged")
+				}
+			case <-stopComplete:
+				return
+			}
+		}
+	}()
+
+	// We want to close this after the other runnables stop, because we don't
+	// want things like leader election to try and emit events on a closed
+	// channel
+	defer cm.recorderProvider.Stop(cm.shutdownCtx)
+	defer func() {
+		// Cancel leader election only after we waited. It will os.Exit() the app for safety.
+		if cm.resourceLock != nil {
+			// After asking the context to be cancelled, make sure
+			// we wait for the leader stopped channel to be closed, otherwise
+			// we might encounter race conditions between this code
+			// and the event recorder, which is used within leader election code.
+			cm.leaderElectionCancel()
+			<-cm.leaderElectionStopped
+		}
+	}()
+
+	go func() {
+		// First stop the non-leader election runnables.
+		cm.logger.Info("Stopping and waiting for non leader election runnables")
+		cm.runnables.Others.StopAndWait(cm.shutdownCtx)
+
+		// Stop all the leader election runnables, which includes reconcilers.
+		cm.logger.Info("Stopping and waiting for leader election runnables")
+		cm.runnables.LeaderElection.StopAndWait(cm.shutdownCtx)
+
+		// Stop the caches before the leader election runnables, this is an important
+		// step to make sure that we don't race with the reconcilers by receiving more events
+		// from the API servers and enqueueing them.
+		cm.logger.Info("Stopping and waiting for caches")
+		cm.runnables.Caches.StopAndWait(cm.shutdownCtx)
+
+		// Webhooks should come last, as they might be still serving some requests.
+		cm.logger.Info("Stopping and waiting for webhooks")
+		cm.runnables.Webhooks.StopAndWait(cm.shutdownCtx)
+
+		// Proceed to close the manager and overall shutdown context.
+		cm.logger.Info("Wait completed, proceeding to shutdown the manager")
+		shutdownCancel()
+	}()
+
+	<-cm.shutdownCtx.Done()
+	if err := cm.shutdownCtx.Err(); err != nil && !errors.Is(err, context.Canceled) {
+		if errors.Is(err, context.DeadlineExceeded) {
+			if cm.gracefulShutdownTimeout > 0 {
+				return fmt.Errorf("failed waiting for all runnables to end within grace period of %s: %w", cm.gracefulShutdownTimeout, err)
+			}
+			return nil
+		}
+		// For any other error, return the error.
+		return err
+	}
+
+	return nil
+}
+
+func (cm *controllerManager) startLeaderElectionRunnables() error {
+	return cm.runnables.LeaderElection.Start(cm.internalCtx)
+}
+
+func (cm *controllerManager) startLeaderElection(ctx context.Context) (err error) {
+	l, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
+		Lock:          cm.resourceLock,
+		LeaseDuration: cm.leaseDuration,
+		RenewDeadline: cm.renewDeadline,
+		RetryPeriod:   cm.retryPeriod,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: func(_ context.Context) {
+				if err := cm.startLeaderElectionRunnables(); err != nil {
+					cm.errChan <- err
+					return
+				}
+				close(cm.elected)
+			},
+			OnStoppedLeading: func() {
+				if cm.onStoppedLeading != nil {
+					cm.onStoppedLeading()
+				}
+				// Make sure graceful shutdown is skipped if we lost the leader lock without
+				// intending to.
+				cm.gracefulShutdownTimeout = time.Duration(0)
+				// Most implementations of leader election log.Fatal() here.
+				// Since Start is wrapped in log.Fatal when called, we can just return
+				// an error here which will cause the program to exit.
+				cm.errChan <- errors.New("leader election lost")
+			},
+		},
+		ReleaseOnCancel: cm.leaderElectionReleaseOnCancel,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Start the leader elector process
+	go func() {
+		l.Run(ctx)
+		<-ctx.Done()
+		close(cm.leaderElectionStopped)
+	}()
+	return nil
+}
+
+func (cm *controllerManager) Elected() <-chan struct{} {
+	return cm.elected
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/manager/manager.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/manager/manager.go
@@ -1,0 +1,620 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package manager
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"reflect"
+	"time"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/config"
+	"sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	intrec "sigs.k8s.io/controller-runtime/pkg/internal/recorder"
+	"sigs.k8s.io/controller-runtime/pkg/leaderelection"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+	"sigs.k8s.io/controller-runtime/pkg/recorder"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// Manager initializes shared dependencies such as Caches and Clients, and provides them to Runnables.
+// A Manager is required to create Controllers.
+type Manager interface {
+	// Cluster holds a variety of methods to interact with a cluster.
+	cluster.Cluster
+
+	// Add will set requested dependencies on the component, and cause the component to be
+	// started when Start is called.  Add will inject any dependencies for which the argument
+	// implements the inject interface - e.g. inject.Client.
+	// Depending on if a Runnable implements LeaderElectionRunnable interface, a Runnable can be run in either
+	// non-leaderelection mode (always running) or leader election mode (managed by leader election if enabled).
+	Add(Runnable) error
+
+	// Elected is closed when this manager is elected leader of a group of
+	// managers, either because it won a leader election or because no leader
+	// election was configured.
+	Elected() <-chan struct{}
+
+	// AddMetricsExtraHandler adds an extra handler served on path to the http server that serves metrics.
+	// Might be useful to register some diagnostic endpoints e.g. pprof. Note that these endpoints meant to be
+	// sensitive and shouldn't be exposed publicly.
+	// If the simple path -> handler mapping offered here is not enough, a new http server/listener should be added as
+	// Runnable to the manager via Add method.
+	AddMetricsExtraHandler(path string, handler http.Handler) error
+
+	// AddHealthzCheck allows you to add Healthz checker
+	AddHealthzCheck(name string, check healthz.Checker) error
+
+	// AddReadyzCheck allows you to add Readyz checker
+	AddReadyzCheck(name string, check healthz.Checker) error
+
+	// Start starts all registered Controllers and blocks until the context is cancelled.
+	// Returns an error if there is an error starting any controller.
+	//
+	// If LeaderElection is used, the binary must be exited immediately after this returns,
+	// otherwise components that need leader election might continue to run after the leader
+	// lock was lost.
+	Start(ctx context.Context) error
+
+	// GetWebhookServer returns a webhook.Server
+	GetWebhookServer() *webhook.Server
+
+	// GetLogger returns this manager's logger.
+	GetLogger() logr.Logger
+
+	// GetControllerOptions returns controller global configuration options.
+	GetControllerOptions() v1alpha1.ControllerConfigurationSpec
+}
+
+// Options are the arguments for creating a new Manager.
+type Options struct {
+	// Scheme is the scheme used to resolve runtime.Objects to GroupVersionKinds / Resources.
+	// Defaults to the kubernetes/client-go scheme.Scheme, but it's almost always better
+	// to pass your own scheme in. See the documentation in pkg/scheme for more information.
+	Scheme *runtime.Scheme
+
+	// MapperProvider provides the rest mapper used to map go types to Kubernetes APIs
+	MapperProvider func(c *rest.Config) (meta.RESTMapper, error)
+
+	// SyncPeriod determines the minimum frequency at which watched resources are
+	// reconciled. A lower period will correct entropy more quickly, but reduce
+	// responsiveness to change if there are many watched resources. Change this
+	// value only if you know what you are doing. Defaults to 10 hours if unset.
+	// there will a 10 percent jitter between the SyncPeriod of all controllers
+	// so that all controllers will not send list requests simultaneously.
+	//
+	// This applies to all controllers.
+	//
+	// A period sync happens for two reasons:
+	// 1. To insure against a bug in the controller that causes an object to not
+	// be requeued, when it otherwise should be requeued.
+	// 2. To insure against an unknown bug in controller-runtime, or its dependencies,
+	// that causes an object to not be requeued, when it otherwise should be
+	// requeued, or to be removed from the queue, when it otherwise should not
+	// be removed.
+	//
+	// If you want
+	// 1. to insure against missed watch events, or
+	// 2. to poll services that cannot be watched,
+	// then we recommend that, instead of changing the default period, the
+	// controller requeue, with a constant duration `t`, whenever the controller
+	// is "done" with an object, and would otherwise not requeue it, i.e., we
+	// recommend the `Reconcile` function return `reconcile.Result{RequeueAfter: t}`,
+	// instead of `reconcile.Result{}`.
+	SyncPeriod *time.Duration
+
+	// Logger is the logger that should be used by this manager.
+	// If none is set, it defaults to log.Log global logger.
+	Logger logr.Logger
+
+	// LeaderElection determines whether or not to use leader election when
+	// starting the manager.
+	LeaderElection bool
+
+	// LeaderElectionResourceLock determines which resource lock to use for leader election,
+	// defaults to "configmapsleases". Change this value only if you know what you are doing.
+	// Otherwise, users of your controller might end up with multiple running instances that
+	// each acquired leadership through different resource locks during upgrades and thus
+	// act on the same resources concurrently.
+	// If you want to migrate to the "leases" resource lock, you might do so by migrating to the
+	// respective multilock first ("configmapsleases" or "endpointsleases"), which will acquire a
+	// leader lock on both resources. After all your users have migrated to the multilock, you can
+	// go ahead and migrate to "leases". Please also keep in mind, that users might skip versions
+	// of your controller.
+	//
+	// Note: before controller-runtime version v0.7, the resource lock was set to "configmaps".
+	// Please keep this in mind, when planning a proper migration path for your controller.
+	LeaderElectionResourceLock string
+
+	// LeaderElectionNamespace determines the namespace in which the leader
+	// election resource will be created.
+	LeaderElectionNamespace string
+
+	// LeaderElectionID determines the name of the resource that leader election
+	// will use for holding the leader lock.
+	LeaderElectionID string
+
+	// LeaderElectionConfig can be specified to override the default configuration
+	// that is used to build the leader election client.
+	LeaderElectionConfig *rest.Config
+
+	// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
+	// when the Manager ends. This requires the binary to immediately end when the
+	// Manager is stopped, otherwise this setting is unsafe. Setting this significantly
+	// speeds up voluntary leader transitions as the new leader doesn't have to wait
+	// LeaseDuration time first.
+	LeaderElectionReleaseOnCancel bool
+
+	// LeaseDuration is the duration that non-leader candidates will
+	// wait to force acquire leadership. This is measured against time of
+	// last observed ack. Default is 15 seconds.
+	LeaseDuration *time.Duration
+	// RenewDeadline is the duration that the acting controlplane will retry
+	// refreshing leadership before giving up. Default is 10 seconds.
+	RenewDeadline *time.Duration
+	// RetryPeriod is the duration the LeaderElector clients should wait
+	// between tries of actions. Default is 2 seconds.
+	RetryPeriod *time.Duration
+
+	// Namespace, if specified, restricts the manager's cache to watch objects in
+	// the desired namespace. Defaults to all namespaces.
+	//
+	// Note: If a namespace is specified, controllers can still Watch for a
+	// cluster-scoped resource (e.g Node). For namespaced resources, the cache
+	// will only hold objects from the desired namespace.
+	Namespace string
+
+	// MetricsBindAddress is the TCP address that the controller should bind to
+	// for serving prometheus metrics.
+	// It can be set to "0" to disable the metrics serving.
+	MetricsBindAddress string
+
+	// HealthProbeBindAddress is the TCP address that the controller should bind to
+	// for serving health probes
+	HealthProbeBindAddress string
+
+	// Readiness probe endpoint name, defaults to "readyz"
+	ReadinessEndpointName string
+
+	// Liveness probe endpoint name, defaults to "healthz"
+	LivenessEndpointName string
+
+	// Port is the port that the webhook server serves at.
+	// It is used to set webhook.Server.Port if WebhookServer is not set.
+	Port int
+	// Host is the hostname that the webhook server binds to.
+	// It is used to set webhook.Server.Host if WebhookServer is not set.
+	Host string
+
+	// CertDir is the directory that contains the server key and certificate.
+	// If not set, webhook server would look up the server key and certificate in
+	// {TempDir}/k8s-webhook-server/serving-certs. The server key and certificate
+	// must be named tls.key and tls.crt, respectively.
+	// It is used to set webhook.Server.CertDir if WebhookServer is not set.
+	CertDir string
+
+	// WebhookServer is an externally configured webhook.Server. By default,
+	// a Manager will create a default server using Port, Host, and CertDir;
+	// if this is set, the Manager will use this server instead.
+	WebhookServer *webhook.Server
+
+	// Functions to allow for a user to customize values that will be injected.
+
+	// NewCache is the function that will create the cache to be used
+	// by the manager. If not set this will use the default new cache function.
+	NewCache cache.NewCacheFunc
+
+	// NewClient is the func that creates the client to be used by the manager.
+	// If not set this will create the default DelegatingClient that will
+	// use the cache for reads and the client for writes.
+	NewClient cluster.NewClientFunc
+
+	// BaseContext is the function that provides Context values to Runnables
+	// managed by the Manager. If a BaseContext function isn't provided, Runnables
+	// will receive a new Background Context instead.
+	BaseContext BaseContextFunc
+
+	// ClientDisableCacheFor tells the client that, if any cache is used, to bypass it
+	// for the given objects.
+	ClientDisableCacheFor []client.Object
+
+	// DryRunClient specifies whether the client should be configured to enforce
+	// dryRun mode.
+	DryRunClient bool
+
+	// EventBroadcaster records Events emitted by the manager and sends them to the Kubernetes API
+	// Use this to customize the event correlator and spam filter
+	//
+	// Deprecated: using this may cause goroutine leaks if the lifetime of your manager or controllers
+	// is shorter than the lifetime of your process.
+	EventBroadcaster record.EventBroadcaster
+
+	// GracefulShutdownTimeout is the duration given to runnable to stop before the manager actually returns on stop.
+	// To disable graceful shutdown, set to time.Duration(0)
+	// To use graceful shutdown without timeout, set to a negative duration, e.G. time.Duration(-1)
+	// The graceful shutdown is skipped for safety reasons in case the leader election lease is lost.
+	GracefulShutdownTimeout *time.Duration
+
+	// Controller contains global configuration options for controllers
+	// registered within this manager.
+	// +optional
+	Controller v1alpha1.ControllerConfigurationSpec
+
+	// makeBroadcaster allows deferring the creation of the broadcaster to
+	// avoid leaking goroutines if we never call Start on this manager.  It also
+	// returns whether or not this is a "owned" broadcaster, and as such should be
+	// stopped with the manager.
+	makeBroadcaster intrec.EventBroadcasterProducer
+
+	// Dependency injection for testing
+	newRecorderProvider    func(config *rest.Config, scheme *runtime.Scheme, logger logr.Logger, makeBroadcaster intrec.EventBroadcasterProducer) (*intrec.Provider, error)
+	newResourceLock        func(config *rest.Config, recorderProvider recorder.Provider, options leaderelection.Options) (resourcelock.Interface, error)
+	newMetricsListener     func(addr string) (net.Listener, error)
+	newHealthProbeListener func(addr string) (net.Listener, error)
+}
+
+// BaseContextFunc is a function used to provide a base Context to Runnables
+// managed by a Manager.
+type BaseContextFunc func() context.Context
+
+// Runnable allows a component to be started.
+// It's very important that Start blocks until
+// it's done running.
+type Runnable interface {
+	// Start starts running the component.  The component will stop running
+	// when the context is closed. Start blocks until the context is closed or
+	// an error occurs.
+	Start(context.Context) error
+}
+
+// RunnableFunc implements Runnable using a function.
+// It's very important that the given function block
+// until it's done running.
+type RunnableFunc func(context.Context) error
+
+// Start implements Runnable.
+func (r RunnableFunc) Start(ctx context.Context) error {
+	return r(ctx)
+}
+
+// LeaderElectionRunnable knows if a Runnable needs to be run in the leader election mode.
+type LeaderElectionRunnable interface {
+	// NeedLeaderElection returns true if the Runnable needs to be run in the leader election mode.
+	// e.g. controllers need to be run in leader election mode, while webhook server doesn't.
+	NeedLeaderElection() bool
+}
+
+// New returns a new Manager for creating Controllers.
+func New(config *rest.Config, options Options) (Manager, error) {
+	// Set default values for options fields
+	options = setOptionsDefaults(options)
+
+	cluster, err := cluster.New(config, func(clusterOptions *cluster.Options) {
+		clusterOptions.Scheme = options.Scheme
+		clusterOptions.MapperProvider = options.MapperProvider
+		clusterOptions.Logger = options.Logger
+		clusterOptions.SyncPeriod = options.SyncPeriod
+		clusterOptions.Namespace = options.Namespace
+		clusterOptions.NewCache = options.NewCache
+		clusterOptions.NewClient = options.NewClient
+		clusterOptions.ClientDisableCacheFor = options.ClientDisableCacheFor
+		clusterOptions.DryRunClient = options.DryRunClient
+		clusterOptions.EventBroadcaster = options.EventBroadcaster //nolint:staticcheck
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the recorder provider to inject event recorders for the components.
+	// TODO(directxman12): the log for the event provider should have a context (name, tags, etc) specific
+	// to the particular controller that it's being injected into, rather than a generic one like is here.
+	recorderProvider, err := options.newRecorderProvider(config, cluster.GetScheme(), options.Logger.WithName("events"), options.makeBroadcaster)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the resource lock to enable leader election)
+	var leaderConfig *rest.Config
+	var leaderRecorderProvider *intrec.Provider
+
+	if options.LeaderElectionConfig == nil {
+		leaderConfig = rest.CopyConfig(config)
+		leaderRecorderProvider = recorderProvider
+	} else {
+		leaderConfig = rest.CopyConfig(options.LeaderElectionConfig)
+		leaderRecorderProvider, err = options.newRecorderProvider(leaderConfig, cluster.GetScheme(), options.Logger.WithName("events"), options.makeBroadcaster)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	resourceLock, err := options.newResourceLock(leaderConfig, leaderRecorderProvider, leaderelection.Options{
+		LeaderElection:             options.LeaderElection,
+		LeaderElectionResourceLock: options.LeaderElectionResourceLock,
+		LeaderElectionID:           options.LeaderElectionID,
+		LeaderElectionNamespace:    options.LeaderElectionNamespace,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the metrics listener. This will throw an error if the metrics bind
+	// address is invalid or already in use.
+	metricsListener, err := options.newMetricsListener(options.MetricsBindAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	// By default we have no extra endpoints to expose on metrics http server.
+	metricsExtraHandlers := make(map[string]http.Handler)
+
+	// Create health probes listener. This will throw an error if the bind
+	// address is invalid or already in use.
+	healthProbeListener, err := options.newHealthProbeListener(options.HealthProbeBindAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	errChan := make(chan error)
+	runnables := newRunnables(options.BaseContext, errChan)
+
+	return &controllerManager{
+		stopProcedureEngaged:          pointer.Int64(0),
+		cluster:                       cluster,
+		runnables:                     runnables,
+		errChan:                       errChan,
+		recorderProvider:              recorderProvider,
+		resourceLock:                  resourceLock,
+		metricsListener:               metricsListener,
+		metricsExtraHandlers:          metricsExtraHandlers,
+		controllerOptions:             options.Controller,
+		logger:                        options.Logger,
+		elected:                       make(chan struct{}),
+		port:                          options.Port,
+		host:                          options.Host,
+		certDir:                       options.CertDir,
+		webhookServer:                 options.WebhookServer,
+		leaseDuration:                 *options.LeaseDuration,
+		renewDeadline:                 *options.RenewDeadline,
+		retryPeriod:                   *options.RetryPeriod,
+		healthProbeListener:           healthProbeListener,
+		readinessEndpointName:         options.ReadinessEndpointName,
+		livenessEndpointName:          options.LivenessEndpointName,
+		gracefulShutdownTimeout:       *options.GracefulShutdownTimeout,
+		internalProceduresStop:        make(chan struct{}),
+		leaderElectionStopped:         make(chan struct{}),
+		leaderElectionReleaseOnCancel: options.LeaderElectionReleaseOnCancel,
+	}, nil
+}
+
+// AndFrom will use a supplied type and convert to Options
+// any options already set on Options will be ignored, this is used to allow
+// cli flags to override anything specified in the config file.
+func (o Options) AndFrom(loader config.ControllerManagerConfiguration) (Options, error) {
+	if inj, wantsScheme := loader.(inject.Scheme); wantsScheme {
+		err := inj.InjectScheme(o.Scheme)
+		if err != nil {
+			return o, err
+		}
+	}
+
+	newObj, err := loader.Complete()
+	if err != nil {
+		return o, err
+	}
+
+	o = o.setLeaderElectionConfig(newObj)
+
+	if o.SyncPeriod == nil && newObj.SyncPeriod != nil {
+		o.SyncPeriod = &newObj.SyncPeriod.Duration
+	}
+
+	if o.Namespace == "" && newObj.CacheNamespace != "" {
+		o.Namespace = newObj.CacheNamespace
+	}
+
+	if o.MetricsBindAddress == "" && newObj.Metrics.BindAddress != "" {
+		o.MetricsBindAddress = newObj.Metrics.BindAddress
+	}
+
+	if o.HealthProbeBindAddress == "" && newObj.Health.HealthProbeBindAddress != "" {
+		o.HealthProbeBindAddress = newObj.Health.HealthProbeBindAddress
+	}
+
+	if o.ReadinessEndpointName == "" && newObj.Health.ReadinessEndpointName != "" {
+		o.ReadinessEndpointName = newObj.Health.ReadinessEndpointName
+	}
+
+	if o.LivenessEndpointName == "" && newObj.Health.LivenessEndpointName != "" {
+		o.LivenessEndpointName = newObj.Health.LivenessEndpointName
+	}
+
+	if o.Port == 0 && newObj.Webhook.Port != nil {
+		o.Port = *newObj.Webhook.Port
+	}
+
+	if o.Host == "" && newObj.Webhook.Host != "" {
+		o.Host = newObj.Webhook.Host
+	}
+
+	if o.CertDir == "" && newObj.Webhook.CertDir != "" {
+		o.CertDir = newObj.Webhook.CertDir
+	}
+
+	if newObj.Controller != nil {
+		if o.Controller.CacheSyncTimeout == nil && newObj.Controller.CacheSyncTimeout != nil {
+			o.Controller.CacheSyncTimeout = newObj.Controller.CacheSyncTimeout
+		}
+
+		if len(o.Controller.GroupKindConcurrency) == 0 && len(newObj.Controller.GroupKindConcurrency) > 0 {
+			o.Controller.GroupKindConcurrency = newObj.Controller.GroupKindConcurrency
+		}
+	}
+
+	return o, nil
+}
+
+// AndFromOrDie will use options.AndFrom() and will panic if there are errors.
+func (o Options) AndFromOrDie(loader config.ControllerManagerConfiguration) Options {
+	o, err := o.AndFrom(loader)
+	if err != nil {
+		panic(fmt.Sprintf("could not parse config file: %v", err))
+	}
+	return o
+}
+
+func (o Options) setLeaderElectionConfig(obj v1alpha1.ControllerManagerConfigurationSpec) Options {
+	if obj.LeaderElection == nil {
+		// The source does not have any configuration; noop
+		return o
+	}
+
+	if !o.LeaderElection && obj.LeaderElection.LeaderElect != nil {
+		o.LeaderElection = *obj.LeaderElection.LeaderElect
+	}
+
+	if o.LeaderElectionResourceLock == "" && obj.LeaderElection.ResourceLock != "" {
+		o.LeaderElectionResourceLock = obj.LeaderElection.ResourceLock
+	}
+
+	if o.LeaderElectionNamespace == "" && obj.LeaderElection.ResourceNamespace != "" {
+		o.LeaderElectionNamespace = obj.LeaderElection.ResourceNamespace
+	}
+
+	if o.LeaderElectionID == "" && obj.LeaderElection.ResourceName != "" {
+		o.LeaderElectionID = obj.LeaderElection.ResourceName
+	}
+
+	if o.LeaseDuration == nil && !reflect.DeepEqual(obj.LeaderElection.LeaseDuration, metav1.Duration{}) {
+		o.LeaseDuration = &obj.LeaderElection.LeaseDuration.Duration
+	}
+
+	if o.RenewDeadline == nil && !reflect.DeepEqual(obj.LeaderElection.RenewDeadline, metav1.Duration{}) {
+		o.RenewDeadline = &obj.LeaderElection.RenewDeadline.Duration
+	}
+
+	if o.RetryPeriod == nil && !reflect.DeepEqual(obj.LeaderElection.RetryPeriod, metav1.Duration{}) {
+		o.RetryPeriod = &obj.LeaderElection.RetryPeriod.Duration
+	}
+
+	return o
+}
+
+// defaultHealthProbeListener creates the default health probes listener bound to the given address.
+func defaultHealthProbeListener(addr string) (net.Listener, error) {
+	if addr == "" || addr == "0" {
+		return nil, nil
+	}
+
+	ln, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, fmt.Errorf("error listening on %s: %w", addr, err)
+	}
+	return ln, nil
+}
+
+// defaultBaseContext is used as the BaseContext value in Options if one
+// has not already been set.
+func defaultBaseContext() context.Context {
+	return context.Background()
+}
+
+// setOptionsDefaults set default values for Options fields.
+func setOptionsDefaults(options Options) Options {
+	// Allow newResourceLock to be mocked
+	if options.newResourceLock == nil {
+		options.newResourceLock = leaderelection.NewResourceLock
+	}
+
+	// Allow newRecorderProvider to be mocked
+	if options.newRecorderProvider == nil {
+		options.newRecorderProvider = intrec.NewProvider
+	}
+
+	// This is duplicated with pkg/cluster, we need it here
+	// for the leader election and there to provide the user with
+	// an EventBroadcaster
+	if options.EventBroadcaster == nil {
+		// defer initialization to avoid leaking by default
+		options.makeBroadcaster = func() (record.EventBroadcaster, bool) {
+			return record.NewBroadcaster(), true
+		}
+	} else {
+		options.makeBroadcaster = func() (record.EventBroadcaster, bool) {
+			return options.EventBroadcaster, false
+		}
+	}
+
+	if options.newMetricsListener == nil {
+		options.newMetricsListener = metrics.NewListener
+	}
+	leaseDuration, renewDeadline, retryPeriod := defaultLeaseDuration, defaultRenewDeadline, defaultRetryPeriod
+	if options.LeaseDuration == nil {
+		options.LeaseDuration = &leaseDuration
+	}
+
+	if options.RenewDeadline == nil {
+		options.RenewDeadline = &renewDeadline
+	}
+
+	if options.RetryPeriod == nil {
+		options.RetryPeriod = &retryPeriod
+	}
+
+	if options.ReadinessEndpointName == "" {
+		options.ReadinessEndpointName = defaultReadinessEndpoint
+	}
+
+	if options.LivenessEndpointName == "" {
+		options.LivenessEndpointName = defaultLivenessEndpoint
+	}
+
+	if options.newHealthProbeListener == nil {
+		options.newHealthProbeListener = defaultHealthProbeListener
+	}
+
+	if options.GracefulShutdownTimeout == nil {
+		gracefulShutdownTimeout := defaultGracefulShutdownPeriod
+		options.GracefulShutdownTimeout = &gracefulShutdownTimeout
+	}
+
+	if options.Logger.GetSink() == nil {
+		options.Logger = log.Log
+	}
+
+	if options.BaseContext == nil {
+		options.BaseContext = defaultBaseContext
+	}
+
+	return options
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/manager/runnable_group.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/manager/runnable_group.go
@@ -1,0 +1,297 @@
+package manager
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+var (
+	errRunnableGroupStopped = errors.New("can't accept new runnable as stop procedure is already engaged")
+)
+
+// readyRunnable encapsulates a runnable with
+// a ready check.
+type readyRunnable struct {
+	Runnable
+	Check       runnableCheck
+	signalReady bool
+}
+
+// runnableCheck can be passed to Add() to let the runnable group determine that a
+// runnable is ready. A runnable check should block until a runnable is ready,
+// if the returned result is false, the runnable is considered not ready and failed.
+type runnableCheck func(ctx context.Context) bool
+
+// runnables handles all the runnables for a manager by grouping them accordingly to their
+// type (webhooks, caches etc.).
+type runnables struct {
+	Webhooks       *runnableGroup
+	Caches         *runnableGroup
+	LeaderElection *runnableGroup
+	Others         *runnableGroup
+}
+
+// newRunnables creates a new runnables object.
+func newRunnables(baseContext BaseContextFunc, errChan chan error) *runnables {
+	return &runnables{
+		Webhooks:       newRunnableGroup(baseContext, errChan),
+		Caches:         newRunnableGroup(baseContext, errChan),
+		LeaderElection: newRunnableGroup(baseContext, errChan),
+		Others:         newRunnableGroup(baseContext, errChan),
+	}
+}
+
+// Add adds a runnable to closest group of runnable that they belong to.
+//
+// Add should be able to be called before and after Start, but not after StopAndWait.
+// Add should return an error when called during StopAndWait.
+// The runnables added before Start are started when Start is called.
+// The runnables added after Start are started directly.
+func (r *runnables) Add(fn Runnable) error {
+	switch runnable := fn.(type) {
+	case hasCache:
+		return r.Caches.Add(fn, func(ctx context.Context) bool {
+			return runnable.GetCache().WaitForCacheSync(ctx)
+		})
+	case *webhook.Server:
+		return r.Webhooks.Add(fn, nil)
+	case LeaderElectionRunnable:
+		if !runnable.NeedLeaderElection() {
+			return r.Others.Add(fn, nil)
+		}
+		return r.LeaderElection.Add(fn, nil)
+	default:
+		return r.LeaderElection.Add(fn, nil)
+	}
+}
+
+// runnableGroup manages a group of runnables that are
+// meant to be running together until StopAndWait is called.
+//
+// Runnables can be added to a group after the group has started
+// but not after it's stopped or while shutting down.
+type runnableGroup struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	start        sync.Mutex
+	startOnce    sync.Once
+	started      bool
+	startQueue   []*readyRunnable
+	startReadyCh chan *readyRunnable
+
+	stop     sync.RWMutex
+	stopOnce sync.Once
+	stopped  bool
+
+	// errChan is the error channel passed by the caller
+	// when the group is created.
+	// All errors are forwarded to this channel once they occur.
+	errChan chan error
+
+	// ch is the internal channel where the runnables are read off from.
+	ch chan *readyRunnable
+
+	// wg is an internal sync.WaitGroup that allows us to properly stop
+	// and wait for all the runnables to finish before returning.
+	wg *sync.WaitGroup
+}
+
+func newRunnableGroup(baseContext BaseContextFunc, errChan chan error) *runnableGroup {
+	r := &runnableGroup{
+		startReadyCh: make(chan *readyRunnable),
+		errChan:      errChan,
+		ch:           make(chan *readyRunnable),
+		wg:           new(sync.WaitGroup),
+	}
+
+	r.ctx, r.cancel = context.WithCancel(baseContext())
+	return r
+}
+
+// Started returns true if the group has started.
+func (r *runnableGroup) Started() bool {
+	r.start.Lock()
+	defer r.start.Unlock()
+	return r.started
+}
+
+// Start starts the group and waits for all
+// initially registered runnables to start.
+// It can only be called once, subsequent calls have no effect.
+func (r *runnableGroup) Start(ctx context.Context) error {
+	var retErr error
+
+	r.startOnce.Do(func() {
+		defer close(r.startReadyCh)
+
+		// Start the internal reconciler.
+		go r.reconcile()
+
+		// Start the group and queue up all
+		// the runnables that were added prior.
+		r.start.Lock()
+		r.started = true
+		for _, rn := range r.startQueue {
+			rn.signalReady = true
+			r.ch <- rn
+		}
+		r.start.Unlock()
+
+		// If we don't have any queue, return.
+		if len(r.startQueue) == 0 {
+			return
+		}
+
+		// Wait for all runnables to signal.
+		for {
+			select {
+			case <-ctx.Done():
+				if err := ctx.Err(); !errors.Is(err, context.Canceled) {
+					retErr = err
+				}
+			case rn := <-r.startReadyCh:
+				for i, existing := range r.startQueue {
+					if existing == rn {
+						// Remove the item from the start queue.
+						r.startQueue = append(r.startQueue[:i], r.startQueue[i+1:]...)
+						break
+					}
+				}
+				// We're done waiting if the queue is empty, return.
+				if len(r.startQueue) == 0 {
+					return
+				}
+			}
+		}
+	})
+
+	return retErr
+}
+
+// reconcile is our main entrypoint for every runnable added
+// to this group. Its primary job is to read off the internal channel
+// and schedule runnables while tracking their state.
+func (r *runnableGroup) reconcile() {
+	for runnable := range r.ch {
+		// Handle stop.
+		// If the shutdown has been called we want to avoid
+		// adding new goroutines to the WaitGroup because Wait()
+		// panics if Add() is called after it.
+		{
+			r.stop.RLock()
+			if r.stopped {
+				// Drop any runnables if we're stopped.
+				r.errChan <- errRunnableGroupStopped
+				r.stop.RUnlock()
+				continue
+			}
+
+			// Why is this here?
+			// When StopAndWait is called, if a runnable is in the process
+			// of being added, we could end up in a situation where
+			// the WaitGroup is incremented while StopAndWait has called Wait(),
+			// which would result in a panic.
+			r.wg.Add(1)
+			r.stop.RUnlock()
+		}
+
+		// Start the runnable.
+		go func(rn *readyRunnable) {
+			go func() {
+				if rn.Check(r.ctx) {
+					if rn.signalReady {
+						r.startReadyCh <- rn
+					}
+				}
+			}()
+
+			// If we return, the runnable ended cleanly
+			// or returned an error to the channel.
+			//
+			// We should always decrement the WaitGroup here.
+			defer r.wg.Done()
+
+			// Start the runnable.
+			if err := rn.Start(r.ctx); err != nil {
+				r.errChan <- err
+			}
+		}(runnable)
+	}
+}
+
+// Add should be able to be called before and after Start, but not after StopAndWait.
+// Add should return an error when called during StopAndWait.
+func (r *runnableGroup) Add(rn Runnable, ready runnableCheck) error {
+	r.stop.RLock()
+	if r.stopped {
+		r.stop.RUnlock()
+		return errRunnableGroupStopped
+	}
+	r.stop.RUnlock()
+
+	if ready == nil {
+		ready = func(_ context.Context) bool { return true }
+	}
+
+	readyRunnable := &readyRunnable{
+		Runnable: rn,
+		Check:    ready,
+	}
+
+	// Handle start.
+	// If the overall runnable group isn't started yet
+	// we want to buffer the runnables and let Start()
+	// queue them up again later.
+	{
+		r.start.Lock()
+
+		// Check if we're already started.
+		if !r.started {
+			// Store the runnable in the internal if not.
+			r.startQueue = append(r.startQueue, readyRunnable)
+			r.start.Unlock()
+			return nil
+		}
+		r.start.Unlock()
+	}
+
+	// Enqueue the runnable.
+	r.ch <- readyRunnable
+	return nil
+}
+
+// StopAndWait waits for all the runnables to finish before returning.
+func (r *runnableGroup) StopAndWait(ctx context.Context) {
+	r.stopOnce.Do(func() {
+		// Close the reconciler channel once we're done.
+		defer close(r.ch)
+
+		_ = r.Start(ctx)
+		r.stop.Lock()
+		// Store the stopped variable so we don't accept any new
+		// runnables for the time being.
+		r.stopped = true
+		r.stop.Unlock()
+
+		// Cancel the internal channel.
+		r.cancel()
+
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			// Wait for all the runnables to finish.
+			r.wg.Wait()
+		}()
+
+		select {
+		case <-done:
+			// We're done, exit.
+		case <-ctx.Done():
+			// Calling context has expired, exit.
+		}
+	})
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/manager/signals/doc.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/manager/signals/doc.go
@@ -1,0 +1,20 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package signals contains libraries for handling signals to gracefully
+// shutdown the manager in combination with Kubernetes pod graceful termination
+// policy.
+package signals

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/manager/signals/signal.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/manager/signals/signal.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signals
+
+import (
+	"context"
+	"os"
+	"os/signal"
+)
+
+var onlyOneSignalHandler = make(chan struct{})
+
+// SetupSignalHandler registers for SIGTERM and SIGINT. A context is returned
+// which is canceled on one of these signals. If a second signal is caught, the program
+// is terminated with exit code 1.
+func SetupSignalHandler() context.Context {
+	close(onlyOneSignalHandler) // panics when called twice
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	c := make(chan os.Signal, 2)
+	signal.Notify(c, shutdownSignals...)
+	go func() {
+		<-c
+		cancel()
+		<-c
+		os.Exit(1) // second signal. Exit directly.
+	}()
+
+	return ctx
+}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/manager/signals/signal_posix.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/manager/signals/signal_posix.go
@@ -1,0 +1,27 @@
+//go:build !windows
+// +build !windows
+
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signals
+
+import (
+	"os"
+	"syscall"
+)
+
+var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}

--- a/vendor/sigs.k8s.io/controller-runtime/pkg/manager/signals/signal_windows.go
+++ b/vendor/sigs.k8s.io/controller-runtime/pkg/manager/signals/signal_windows.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signals
+
+import (
+	"os"
+)
+
+var shutdownSignals = []os.Signal{os.Interrupt}


### PR DESCRIPTION
`.gitignore` contained `manager`, which made git ignore any directory named `manager` in the repository, including a `controller-runtime` package.