### PR TITLE
Download golangci-lint instead of installing it in a vendored environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ unit-test: vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test $(TEST) -coverprofile cover.out
 
 .PHONY: lint
-lint: golangci-lint ## Run golangci-lint against code.
+lint: $(GOLANGCI_LINT) ## Run golangci-lint against code.
 	@if [ `gofmt -l . | wc -l` -ne 0 ]; then \
 		echo There are some malformed files, please make sure to run \'make fmt\'; \
 		exit 1; \
@@ -181,9 +181,8 @@ controller-gen: ## Download controller-gen locally if necessary.
 	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.8.0)
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-.PHONY: golangci-lint
-golangci-lint: ## Download golangci-lint locally if necessary.
-	$(call go-get-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.46.2)
+$(GOLANGCI_LINT): ## Download golangci-lint locally if necessary.
+	BINDIR=bin ./scripts/download-golangci-lint
 
 .PHONY: mockgen
 mockgen: ## Install mockgen locally.

--- a/scripts/download-golangci-lint
+++ b/scripts/download-golangci-lint
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -euxo pipefail
+
+: "${BINDIR}"
+
+TMPDIR=$(mktemp -d)
+OS=$(go env GOOS)
+ARCH=$(go env GOARCH)
+
+curl -L https://github.com/golangci/golangci-lint/releases/download/v1.48.0/golangci-lint-1.48.0-${OS}-${ARCH}.tar.gz | tar xvz -C "${TMPDIR}"
+
+mv "${TMPDIR}/golangci-lint-1.48.0-${OS}-${ARCH}/golangci-lint" "${BINDIR}"
+
+rm -fr "${TMPDIR}"


### PR DESCRIPTION
Among the consequences of vendoring dependencies is the fact that we cannot `go install` any package from the internet.
We have to either:
- list the code of the package as a dependency and vendor it, even though the operator does not use it, or;
- install the binary we need through other means.

This PR installs `golangci-lint` by downloading it from the GitHub release.