### PR TITLE
Do not install envtest when running unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,6 @@ endif
 
 # Image URL to use all building/pushing image targets
 IMG ?= quay.io/edge-infrastructure/kernel-module-management:main
-# ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.23
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -113,8 +111,8 @@ vet: ## Run go vet against code.
 TEST ?= ./...
 
 .PHONY: test
-unit-test: vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test $(TEST) -coverprofile cover.out
+unit-test: vet ## Run tests.
+	go test $(TEST) -coverprofile cover.out
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT) ## Run golangci-lint against code.
@@ -192,11 +190,6 @@ KUSTOMIZE = $(shell pwd)/bin/kustomize
 .PHONY: kustomize
 kustomize: ## Download kustomize locally if necessary.
 	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.4)
-
-ENVTEST = $(shell pwd)/bin/setup-envtest
-.PHONY: envtest
-envtest: ## Download envtest-setup locally if necessary.
-	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))


### PR DESCRIPTION
`operator-sdk` generates a `Makefile` that downloads [EnvTest](https://book.kubebuilder.io/reference/envtest.html) by default for unit tests, although we do not use it.
Installing unvendored dependencis is a problem in CI, so remove the dependency on EnvTest altogether.