### PR TITLE
Add required variables for the lint CI job

### DIFF
--- a/ci/prow/lint
+++ b/ci/prow/lint
@@ -2,4 +2,7 @@
 
 set -euxo pipefail
 
-make lint
+export GOCACHE=/tmp
+export GOLANGCI_LINT_CACHE=/tmp
+
+make lint GOLANGCI_LINT=/usr/bin/golangci-lint


### PR DESCRIPTION
These variables are necessary for `golangci-lint` to run correctly.

/cc @ybettan 