### PR TITLE
Restrict manager capabilities and privileges

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ the kernel modules for new incoming kernel versions attached to upgrades.
 ## Getting started
 Install the bleeding edge KMMO in one command:
 ```shell
-kubectl apply -k https://github.com/rh-ecosystem-edge/kernel-module-management/config/default
+oc apply -k https://github.com/rh-ecosystem-edge/kernel-module-management/config/default
 ```

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -27,6 +27,10 @@ spec:
           requests:
             cpu: 5m
             memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
       - name: manager
         args:
         - "--health-probe-bind-address=:8081"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -28,6 +28,8 @@ spec:
         node-role.kubernetes.io/master: ''
       securityContext:
         runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - command:
         - /manager
@@ -38,6 +40,8 @@ spec:
         imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
This removes all warnings when installing KMMO with `oc apply -k ...`.

/cc @ybettan @yevgeny-shnaidman @enriquebelarte