### PR TITLE
Run pods with the system-node-critical priority

### DIFF
--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -162,6 +162,7 @@ func (dc *daemonSetGenerator) SetDriverContainerAsDesired(ctx context.Context, d
 				},
 				ImagePullSecrets:   GetPodPullSecrets(mod.Spec.ImageRepoSecret),
 				NodeSelector:       nodeSelector,
+				PriorityClassName:  "system-node-critical",
 				ServiceAccountName: mod.Spec.DriverContainer.ServiceAccountName,
 				Volumes: []v1.Volume{
 					{
@@ -241,6 +242,7 @@ func (dc *daemonSetGenerator) SetDevicePluginAsDesired(ctx context.Context, ds *
 						VolumeMounts:    append(mod.Spec.DevicePlugin.Container.VolumeMounts, containerVolumeMounts...),
 					},
 				},
+				PriorityClassName:  "system-node-critical",
 				ImagePullSecrets:   GetPodPullSecrets(mod.Spec.ImageRepoSecret),
 				NodeSelector:       map[string]string{getDriverContainerNodeLabel(mod.Name): ""},
 				ServiceAccountName: mod.Spec.DevicePlugin.ServiceAccountName,

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -191,6 +191,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 							"has-feature-x": "true",
 							kernelLabel:     kernelVersion,
 						},
+						PriorityClassName:  "system-node-critical",
 						ServiceAccountName: serviceAccountName,
 						Volumes: []v1.Volume{
 							{
@@ -448,6 +449,7 @@ var _ = Describe("SetDevicePluginAsDesired", func() {
 						NodeSelector: map[string]string{
 							getDriverContainerNodeLabel(mod.Name): "",
 						},
+						PriorityClassName:  "system-node-critical",
 						ServiceAccountName: serviceAccountName,
 						Volumes: []v1.Volume{
 							{


### PR DESCRIPTION
Use the highest standard priority class.

Cherry-pick from upstream https://github.com/qbarrand/oot-operator/commit/10bb1a6cb094a60cbdf66a0b50920e02be09433d.

/cc @fabiendupont @yevgeny-shnaidman @ybettan 