### PR TITLE
Add permissions to module loader pod (#151)

### DIFF
--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -142,8 +142,13 @@ func (dc *daemonSetGenerator) SetDriverContainerAsDesired(ctx context.Context, d
 							},
 						},
 						SecurityContext: &v1.SecurityContext{
+							AllowPrivilegeEscalation: pointer.Bool(false),
 							Capabilities: &v1.Capabilities{
 								Add: []v1.Capability{"SYS_MODULE"},
+							},
+							RunAsUser: pointer.Int64(0),
+							SELinuxOptions: &v1.SELinuxOptions{
+								Type: "spc_t",
 							},
 						},
 						VolumeMounts: []v1.VolumeMount{

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -179,8 +179,13 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 									},
 								},
 								SecurityContext: &v1.SecurityContext{
+									AllowPrivilegeEscalation: pointer.Bool(false),
 									Capabilities: &v1.Capabilities{
 										Add: []v1.Capability{"SYS_MODULE"},
+									},
+									RunAsUser: pointer.Int64(0),
+									SELinuxOptions: &v1.SELinuxOptions{
+										Type: "spc_t",
 									},
 								},
 							},


### PR DESCRIPTION
To be able to load a module, more privileges are required. This change sets the SELinux type of the pod to `spc_t` and the user to `root`. It also explicitely disable privilege escalation.

This has been tested with a pod ServiceAccount that can use the `privileged` SCC.

Reference: [Introducing a Super Privileged Container Concept](https://developers.redhat.com/blog/2014/11/06/introducing-a-super-privileged-container-concept)

Signed-off-by: Fabien Dupont <fdupont@redhat.com>