### PR TITLE
Allow the operator to get ServiceAccounts.

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -62,6 +62,12 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+- apiGroups:
   - kmm.sigs.k8s.io
   resources:
   - modules

--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -94,7 +94,7 @@ func NewModuleReconciler(
 //+kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=create;delete;get;list;patch;watch
 //+kubebuilder:rbac:groups="core",resources=nodes,verbs=get;list;watch
 //+kubebuilder:rbac:groups="core",resources=secrets,verbs=get;list;watch
-//+kubebuilder:rbac:groups="core",resources=secrets,verbs=get;list;watch
+//+kubebuilder:rbac:groups="core",resources=serviceaccounts,verbs=get
 //+kubebuilder:rbac:groups="build.openshift.io",resources=buildconfigs,verbs=create;delete;get;list;patch;watch
 //+kubebuilder:rbac:groups="build.openshift.io",resources=builds,verbs=get;list;watch
 


### PR DESCRIPTION
Getting ServiceAccounts is required by the go-containerregistry library to get all pull secrets linked to the builder ServiceAccount.