### PR TITLE
Automate module loader and device plugin SAs bindings to privileged SCC

### DIFF
--- a/bundle/manifests/kmm-operator-device-plugin_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/kmm-operator-device-plugin_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: kmm-operator-device-plugin
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/bundle/manifests/kmm-operator-module-loader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/kmm-operator-module-loader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: kmm-operator-module-loader
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/bundle/manifests/kmm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kmm-operator.clusterserviceversion.yaml
@@ -153,6 +153,34 @@ spec:
           - patch
           - update
         - apiGroups:
+          - rbac.authorization.k8s.io
+          resourceNames:
+          - kmm-operator-device-plugin
+          - kmm-operator-module-loader
+          resources:
+          - clusterroles
+          verbs:
+          - bind
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        - apiGroups:
           - authentication.k8s.io
           resources:
           - tokenreviews

--- a/config/rbac/device_plugin_cluster_role.yaml
+++ b/config/rbac/device_plugin_cluster_role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: device-plugin
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -9,6 +9,8 @@ resources:
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml
+- module_loader_cluster_role.yaml
+- device_plugin_cluster_role.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.
@@ -16,3 +18,6 @@ resources:
 - auth_proxy_role.yaml
 - auth_proxy_role_binding.yaml
 - auth_proxy_client_clusterrole.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/rbac/kustomizeconfig.yaml
+++ b/config/rbac/kustomizeconfig.yaml
@@ -1,0 +1,5 @@
+namereference:
+- kind: ClusterRole
+  fieldSpecs:
+  - path: rules/resourceNames
+    kind: ClusterRole

--- a/config/rbac/module_loader_cluster_role.yaml
+++ b/config/rbac/module_loader_cluster_role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: module-loader
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -118,3 +118,31 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resourceNames:
+  - device-plugin
+  - module-loader
+  resources:
+  - clusterroles
+  verbs:
+  - bind
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use

--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -94,6 +94,9 @@ func NewModuleReconciler(
 //+kubebuilder:rbac:groups="core",resources=nodes,verbs=get;list;watch
 //+kubebuilder:rbac:groups="core",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups="core",resources=serviceaccounts,verbs=create;delete;get;list;patch;watch
+//+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=use,resourceNames=privileged
+//+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=create;delete;get;list;patch;watch
+//+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=clusterroles,verbs=bind,resourceNames=module-loader;device-plugin
 //+kubebuilder:rbac:groups="build.openshift.io",resources=buildconfigs,verbs=create;delete;get;list;patch;watch
 //+kubebuilder:rbac:groups="build.openshift.io",resources=builds,verbs=get;list;watch
 
@@ -118,13 +121,13 @@ func (r *ModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	r.setKMMOMetrics(ctx)
 
 	if mod.Spec.ModuleLoader.ServiceAccountName == "" {
-		if err := r.rbacAPI.CreateModuleLoaderServiceAccount(ctx, *mod); err != nil {
-			return res, fmt.Errorf("could not create module-loader's ServiceAccount: %w", err)
+		if err := r.rbacAPI.CreateModuleLoaderRBAC(ctx, *mod); err != nil {
+			return res, fmt.Errorf("could not create module-loader's RBAC: %w", err)
 		}
 	}
 	if mod.Spec.DevicePlugin != nil && mod.Spec.DevicePlugin.ServiceAccountName == "" {
-		if err := r.rbacAPI.CreateDevicePluginServiceAccount(ctx, *mod); err != nil {
-			return res, fmt.Errorf("could not create device-plugin's ServiceAccount: %w", err)
+		if err := r.rbacAPI.CreateDevicePluginRBAC(ctx, *mod); err != nil {
+			return res, fmt.Errorf("could not create device-plugin's RBAC: %w", err)
 		}
 	}
 

--- a/internal/rbac/mock_rbac.go
+++ b/internal/rbac/mock_rbac.go
@@ -35,30 +35,30 @@ func (m *MockRBACCreator) EXPECT() *MockRBACCreatorMockRecorder {
 	return m.recorder
 }
 
-// CreateDevicePluginServiceAccount mocks base method.
-func (m *MockRBACCreator) CreateDevicePluginServiceAccount(ctx context.Context, mod v1beta1.Module) error {
+// CreateDevicePluginRBAC mocks base method.
+func (m *MockRBACCreator) CreateDevicePluginRBAC(ctx context.Context, mod v1beta1.Module) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateDevicePluginServiceAccount", ctx, mod)
+	ret := m.ctrl.Call(m, "CreateDevicePluginRBAC", ctx, mod)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// CreateDevicePluginServiceAccount indicates an expected call of CreateDevicePluginServiceAccount.
-func (mr *MockRBACCreatorMockRecorder) CreateDevicePluginServiceAccount(ctx, mod interface{}) *gomock.Call {
+// CreateDevicePluginRBAC indicates an expected call of CreateDevicePluginRBAC.
+func (mr *MockRBACCreatorMockRecorder) CreateDevicePluginRBAC(ctx, mod interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDevicePluginServiceAccount", reflect.TypeOf((*MockRBACCreator)(nil).CreateDevicePluginServiceAccount), ctx, mod)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateDevicePluginRBAC", reflect.TypeOf((*MockRBACCreator)(nil).CreateDevicePluginRBAC), ctx, mod)
 }
 
-// CreateModuleLoaderServiceAccount mocks base method.
-func (m *MockRBACCreator) CreateModuleLoaderServiceAccount(ctx context.Context, mod v1beta1.Module) error {
+// CreateModuleLoaderRBAC mocks base method.
+func (m *MockRBACCreator) CreateModuleLoaderRBAC(ctx context.Context, mod v1beta1.Module) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateModuleLoaderServiceAccount", ctx, mod)
+	ret := m.ctrl.Call(m, "CreateModuleLoaderRBAC", ctx, mod)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// CreateModuleLoaderServiceAccount indicates an expected call of CreateModuleLoaderServiceAccount.
-func (mr *MockRBACCreatorMockRecorder) CreateModuleLoaderServiceAccount(ctx, mod interface{}) *gomock.Call {
+// CreateModuleLoaderRBAC indicates an expected call of CreateModuleLoaderRBAC.
+func (mr *MockRBACCreatorMockRecorder) CreateModuleLoaderRBAC(ctx, mod interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateModuleLoaderServiceAccount", reflect.TypeOf((*MockRBACCreator)(nil).CreateModuleLoaderServiceAccount), ctx, mod)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateModuleLoaderRBAC", reflect.TypeOf((*MockRBACCreator)(nil).CreateModuleLoaderRBAC), ctx, mod)
 }

--- a/internal/rbac/rbac.go
+++ b/internal/rbac/rbac.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,8 +18,8 @@ import (
 //go:generate mockgen -source=rbac.go -package=rbac -destination=mock_rbac.go
 
 type RBACCreator interface {
-	CreateModuleLoaderServiceAccount(ctx context.Context, mod kmmv1beta1.Module) error
-	CreateDevicePluginServiceAccount(ctx context.Context, mod kmmv1beta1.Module) error
+	CreateModuleLoaderRBAC(ctx context.Context, mod kmmv1beta1.Module) error
+	CreateDevicePluginRBAC(ctx context.Context, mod kmmv1beta1.Module) error
 }
 
 type rbacCreator struct {
@@ -33,52 +34,122 @@ func NewCreator(client client.Client, scheme *runtime.Scheme) RBACCreator {
 	}
 }
 
-func (rc *rbacCreator) CreateModuleLoaderServiceAccount(ctx context.Context, mod kmmv1beta1.Module) error {
-	logger := log.FromContext(ctx)
-
-	sa := &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      GenerateModuleLoaderServiceAccountName(mod),
-			Namespace: mod.Namespace,
-		},
-	}
-
-	opRes, err := controllerutil.CreateOrPatch(ctx, rc.client, sa, func() error {
-		return controllerutil.SetControllerReference(&mod, sa, rc.scheme)
-	})
-	if err != nil {
-		return fmt.Errorf("cound not create/patch ServiceAccount: %w", err)
-	}
-	logger.Info("Created module-loader's ServiceAccount", "name", sa.Name, "result", opRes)
-
-	return nil
-}
-
-func (rc *rbacCreator) CreateDevicePluginServiceAccount(ctx context.Context, mod kmmv1beta1.Module) error {
-	logger := log.FromContext(ctx)
-
-	sa := &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      GenerateDevicePluginServiceAccountName(mod),
-			Namespace: mod.Namespace,
-		},
-	}
-
-	opRes, err := controllerutil.CreateOrPatch(ctx, rc.client, sa, func() error {
-		return controllerutil.SetControllerReference(&mod, sa, rc.scheme)
-	})
-	if err != nil {
-		return fmt.Errorf("cound not create/patch ServiceAccount: %w", err)
-	}
-	logger.Info("Created device-plugin's ServiceAccount", "name", sa.Name, "result", opRes)
-
-	return nil
-}
-
 func GenerateModuleLoaderServiceAccountName(mod kmmv1beta1.Module) string {
-	return mod.Name + "-module-loader"
+	return generateModuleLoaderRBACName(mod)
 }
 
 func GenerateDevicePluginServiceAccountName(mod kmmv1beta1.Module) string {
+	return generateDevicePluginRBACName(mod)
+}
+
+func (rc *rbacCreator) CreateModuleLoaderRBAC(ctx context.Context, mod kmmv1beta1.Module) error {
+	logger := log.FromContext(ctx)
+
+	serviceAccountName := GenerateModuleLoaderServiceAccountName(mod)
+
+	opRes, err := rc.createServiceAccount(ctx, mod, serviceAccountName)
+	if err != nil {
+		return fmt.Errorf("cound not create module-loader's ServiceAccount: %w", err)
+	}
+	logger.Info("Created module-loader's ServiceAccount", "name", serviceAccountName, "result", opRes)
+
+	roleBindingName := generateModuleLoaderRoleBindingName(mod)
+	clusterRoleName := "kmm-operator-module-loader"
+
+	opRes, err = rc.createRoleBinding(ctx, mod, roleBindingName, serviceAccountName, clusterRoleName)
+	if err != nil {
+		return fmt.Errorf("cound not create module-loader's RoleBinding: %w", err)
+	}
+	logger.Info("Created module-loader's RoleBinding", "name", roleBindingName, "result", opRes)
+
+	return nil
+}
+
+func (rc *rbacCreator) CreateDevicePluginRBAC(ctx context.Context, mod kmmv1beta1.Module) error {
+	logger := log.FromContext(ctx)
+
+	serviceAccountName := GenerateDevicePluginServiceAccountName(mod)
+
+	opRes, err := rc.createServiceAccount(ctx, mod, serviceAccountName)
+	if err != nil {
+		return fmt.Errorf("cound not create device-plugin's ServiceAccount: %w", err)
+	}
+	logger.Info("Created device-plugin's ServiceAccount", "name", serviceAccountName, "result", opRes)
+
+	roleBindingName := generateDevicePluginRoleBindingName(mod)
+	clusterRoleName := "kmm-operator-device-plugin"
+
+	opRes, err = rc.createRoleBinding(ctx, mod, roleBindingName, serviceAccountName, clusterRoleName)
+	if err != nil {
+		return fmt.Errorf("cound not create device-plugin's RoleBinding: %w", err)
+	}
+	logger.Info("Created device-plugin's RoleBinding", "name", roleBindingName, "result", opRes)
+
+	return nil
+}
+
+func (rc *rbacCreator) createServiceAccount(
+	ctx context.Context,
+	mod kmmv1beta1.Module,
+	name string) (controllerutil.OperationResult, error) {
+
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: mod.Namespace,
+		},
+	}
+
+	return controllerutil.CreateOrPatch(ctx, rc.client, sa, func() error {
+		return controllerutil.SetControllerReference(&mod, sa, rc.scheme)
+	})
+}
+
+func (rc *rbacCreator) createRoleBinding(
+	ctx context.Context,
+	mod kmmv1beta1.Module,
+	name,
+	serviceAccountName,
+	clusterRoleName string) (controllerutil.OperationResult, error) {
+
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: mod.Namespace,
+		},
+	}
+
+	return controllerutil.CreateOrPatch(ctx, rc.client, rb, func() error {
+		rb.Subjects = []rbacv1.Subject{
+			{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      serviceAccountName,
+				Namespace: mod.Namespace,
+			},
+		}
+
+		rb.RoleRef = rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     clusterRoleName,
+		}
+
+		return controllerutil.SetControllerReference(&mod, rb, rc.scheme)
+	})
+}
+
+func generateModuleLoaderRoleBindingName(mod kmmv1beta1.Module) string {
+	return generateModuleLoaderRBACName(mod)
+}
+
+func generateModuleLoaderRBACName(mod kmmv1beta1.Module) string {
+	return mod.Name + "-module-loader"
+}
+
+func generateDevicePluginRoleBindingName(mod kmmv1beta1.Module) string {
+	return generateDevicePluginRBACName(mod)
+}
+
+func generateDevicePluginRBACName(mod kmmv1beta1.Module) string {
 	return mod.Name + "-device-plugin"
 }

--- a/internal/rbac/rbac_test.go
+++ b/internal/rbac/rbac_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -22,180 +23,6 @@ var (
 	ctrl *gomock.Controller
 	clnt *client.MockClient
 )
-
-var _ = Describe("CreateModuleLoaderServiceAccount", func() {
-	const (
-		moduleName = "test-module"
-		namespace  = "namespace"
-	)
-
-	var (
-		rc RBACCreator
-
-		mod kmmv1beta1.Module
-
-		requestedServiceAccount *corev1.ServiceAccount
-
-		expectedServiceAccount *corev1.ServiceAccount
-	)
-
-	ctx := context.Background()
-
-	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		clnt = client.NewMockClient(ctrl)
-		rc = NewCreator(clnt, scheme)
-
-		mod = kmmv1beta1.Module{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: kmmv1beta1.GroupVersion.String(),
-				Kind:       "Module",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      moduleName,
-				Namespace: namespace,
-			},
-		}
-		requestedServiceAccount = &corev1.ServiceAccount{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      moduleName + "-module-loader",
-				Namespace: namespace,
-			},
-		}
-		expectedServiceAccount = &corev1.ServiceAccount{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      moduleName + "-module-loader",
-				Namespace: namespace,
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion:         mod.APIVersion,
-						BlockOwnerDeletion: pointer.Bool(true),
-						Controller:         pointer.Bool(true),
-						Kind:               mod.Kind,
-						Name:               moduleName,
-						UID:                mod.UID,
-					},
-				},
-			},
-		}
-	})
-
-	It("should add the default module loader ServiceAccount", func() {
-		gomock.InOrder(
-			clnt.EXPECT().Get(ctx, gomock.Any(), requestedServiceAccount).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
-			clnt.EXPECT().Create(ctx, expectedServiceAccount).Return(nil),
-		)
-
-		err := rc.CreateModuleLoaderServiceAccount(context.Background(), mod)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("should return an error when the ServiceAccount fetch fails", func() {
-		gomock.InOrder(
-			clnt.EXPECT().Get(ctx, gomock.Any(), requestedServiceAccount).Return(errors.New("some-error")),
-		)
-
-		err := rc.CreateModuleLoaderServiceAccount(context.Background(), mod)
-		Expect(err).To(HaveOccurred())
-	})
-
-	It("should return an error when the ServiceAccount creation fails", func() {
-		gomock.InOrder(
-			clnt.EXPECT().Get(ctx, gomock.Any(), requestedServiceAccount).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
-			clnt.EXPECT().Create(ctx, expectedServiceAccount).Return(errors.New("some-error")),
-		)
-
-		err := rc.CreateModuleLoaderServiceAccount(context.Background(), mod)
-		Expect(err).To(HaveOccurred())
-	})
-})
-
-var _ = Describe("CreateDevicePluginServiceAccount", func() {
-	const (
-		moduleName = "test-module"
-		namespace  = "namespace"
-	)
-
-	var (
-		rc RBACCreator
-
-		mod kmmv1beta1.Module
-
-		requestedServiceAccount *corev1.ServiceAccount
-
-		expectedServiceAccount *corev1.ServiceAccount
-	)
-
-	ctx := context.Background()
-
-	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		clnt = client.NewMockClient(ctrl)
-		rc = NewCreator(clnt, scheme)
-
-		mod = kmmv1beta1.Module{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: kmmv1beta1.GroupVersion.String(),
-				Kind:       "Module",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      moduleName,
-				Namespace: namespace,
-			},
-		}
-		requestedServiceAccount = &corev1.ServiceAccount{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      moduleName + "-device-plugin",
-				Namespace: namespace,
-			},
-		}
-		expectedServiceAccount = &corev1.ServiceAccount{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      moduleName + "-device-plugin",
-				Namespace: namespace,
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion:         mod.APIVersion,
-						BlockOwnerDeletion: pointer.Bool(true),
-						Controller:         pointer.Bool(true),
-						Kind:               mod.Kind,
-						Name:               moduleName,
-						UID:                mod.UID,
-					},
-				},
-			},
-		}
-	})
-
-	It("should add the default device plugin ServiceAccount", func() {
-		gomock.InOrder(
-			clnt.EXPECT().Get(ctx, gomock.Any(), requestedServiceAccount).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
-			clnt.EXPECT().Create(ctx, expectedServiceAccount).Return(nil),
-		)
-
-		err := rc.CreateDevicePluginServiceAccount(context.Background(), mod)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("should return an error when the ServiceAccount fetch fails", func() {
-		gomock.InOrder(
-			clnt.EXPECT().Get(ctx, gomock.Any(), requestedServiceAccount).Return(errors.New("some-error")),
-		)
-
-		err := rc.CreateDevicePluginServiceAccount(context.Background(), mod)
-		Expect(err).To(HaveOccurred())
-	})
-
-	It("should return an error when the ServiceAccount creation fails", func() {
-		gomock.InOrder(
-			clnt.EXPECT().Get(ctx, gomock.Any(), requestedServiceAccount).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
-			clnt.EXPECT().Create(ctx, expectedServiceAccount).Return(errors.New("some-error")),
-		)
-
-		err := rc.CreateDevicePluginServiceAccount(context.Background(), mod)
-		Expect(err).To(HaveOccurred())
-	})
-})
 
 var _ = Describe("GenerateModuleLoaderServiceAccountName", func() {
 	mod := kmmv1beta1.Module{
@@ -214,5 +41,305 @@ var _ = Describe("GenerateDevicePluginServiceAccountName", func() {
 
 	It("should return the default device plugin ServiceAccount name", func() {
 		Expect(GenerateDevicePluginServiceAccountName(mod)).To(Equal("test-module-device-plugin"))
+	})
+})
+
+var _ = Describe("CreateModuleLoaderRBAC", func() {
+	const (
+		moduleName = "test-module"
+		namespace  = "namespace"
+	)
+
+	var (
+		rc RBACCreator
+
+		mod kmmv1beta1.Module
+
+		requestedServiceAccount *corev1.ServiceAccount
+
+		requestedRoleBinding *rbacv1.RoleBinding
+
+		expectedServiceAccount *corev1.ServiceAccount
+
+		expectedRoleBinding *rbacv1.RoleBinding
+	)
+
+	ctx := context.Background()
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		rc = NewCreator(clnt, scheme)
+
+		mod = kmmv1beta1.Module{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: kmmv1beta1.GroupVersion.String(),
+				Kind:       "Module",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      moduleName,
+				Namespace: namespace,
+			},
+		}
+		requestedServiceAccount = &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      moduleName + "-module-loader",
+				Namespace: namespace,
+			},
+		}
+		requestedRoleBinding = &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      moduleName + "-module-loader",
+				Namespace: namespace,
+			},
+		}
+		expectedServiceAccount = &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      moduleName + "-module-loader",
+				Namespace: namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         mod.APIVersion,
+						BlockOwnerDeletion: pointer.Bool(true),
+						Controller:         pointer.Bool(true),
+						Kind:               mod.Kind,
+						Name:               moduleName,
+						UID:                mod.UID,
+					},
+				},
+			},
+		}
+		expectedRoleBinding = &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      moduleName + "-module-loader",
+				Namespace: namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         mod.APIVersion,
+						BlockOwnerDeletion: pointer.Bool(true),
+						Controller:         pointer.Bool(true),
+						Kind:               mod.Kind,
+						Name:               moduleName,
+						UID:                mod.UID,
+					},
+				},
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      rbacv1.ServiceAccountKind,
+					Name:      expectedServiceAccount.Name,
+					Namespace: mod.Namespace,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     "kmm-operator-module-loader",
+			},
+		}
+	})
+
+	It("should add the default module loader ServiceAccount and RoleBinding", func() {
+		gomock.InOrder(
+			clnt.EXPECT().Get(ctx, gomock.Any(), requestedServiceAccount).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
+			clnt.EXPECT().Create(ctx, expectedServiceAccount).Return(nil),
+			clnt.EXPECT().Get(ctx, gomock.Any(), requestedRoleBinding).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
+			clnt.EXPECT().Create(ctx, expectedRoleBinding).Return(nil),
+		)
+
+		err := rc.CreateModuleLoaderRBAC(context.Background(), mod)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should return an error when the ServiceAccount fetch fails", func() {
+		gomock.InOrder(
+			clnt.EXPECT().Get(ctx, gomock.Any(), requestedServiceAccount).Return(errors.New("some-error")),
+		)
+
+		err := rc.CreateModuleLoaderRBAC(context.Background(), mod)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should return an error when the ServiceAccount creation fails", func() {
+		gomock.InOrder(
+			clnt.EXPECT().Get(ctx, gomock.Any(), requestedServiceAccount).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
+			clnt.EXPECT().Create(ctx, expectedServiceAccount).Return(errors.New("some-error")),
+		)
+
+		err := rc.CreateModuleLoaderRBAC(context.Background(), mod)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should return an error when the RoleBinding fetch fails", func() {
+		gomock.InOrder(
+			clnt.EXPECT().Get(ctx, gomock.Any(), requestedServiceAccount).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
+			clnt.EXPECT().Create(ctx, expectedServiceAccount).Return(nil),
+			clnt.EXPECT().Get(ctx, gomock.Any(), requestedRoleBinding).Return(errors.New("some-error")),
+		)
+
+		err := rc.CreateModuleLoaderRBAC(context.Background(), mod)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should return an error when the RoleBinding creation fails", func() {
+		gomock.InOrder(
+			clnt.EXPECT().Get(ctx, gomock.Any(), requestedServiceAccount).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
+			clnt.EXPECT().Create(ctx, expectedServiceAccount).Return(nil),
+			clnt.EXPECT().Get(ctx, gomock.Any(), requestedRoleBinding).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
+			clnt.EXPECT().Create(ctx, expectedRoleBinding).Return(errors.New("some-error")),
+		)
+
+		err := rc.CreateModuleLoaderRBAC(context.Background(), mod)
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("CreateDevicePluginServiceRBAC", func() {
+	const (
+		moduleName = "test-module"
+		namespace  = "namespace"
+	)
+
+	var (
+		rc RBACCreator
+
+		mod kmmv1beta1.Module
+
+		requestedServiceAccount *corev1.ServiceAccount
+
+		requestedRoleBinding *rbacv1.RoleBinding
+
+		expectedServiceAccount *corev1.ServiceAccount
+
+		expectedRoleBinding *rbacv1.RoleBinding
+	)
+
+	ctx := context.Background()
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		rc = NewCreator(clnt, scheme)
+
+		mod = kmmv1beta1.Module{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: kmmv1beta1.GroupVersion.String(),
+				Kind:       "Module",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      moduleName,
+				Namespace: namespace,
+			},
+		}
+		requestedServiceAccount = &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      moduleName + "-device-plugin",
+				Namespace: namespace,
+			},
+		}
+		requestedRoleBinding = &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      moduleName + "-device-plugin",
+				Namespace: namespace,
+			},
+		}
+		expectedServiceAccount = &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      moduleName + "-device-plugin",
+				Namespace: namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         mod.APIVersion,
+						BlockOwnerDeletion: pointer.Bool(true),
+						Controller:         pointer.Bool(true),
+						Kind:               mod.Kind,
+						Name:               moduleName,
+						UID:                mod.UID,
+					},
+				},
+			},
+		}
+		expectedRoleBinding = &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      moduleName + "-device-plugin",
+				Namespace: namespace,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         mod.APIVersion,
+						BlockOwnerDeletion: pointer.Bool(true),
+						Controller:         pointer.Bool(true),
+						Kind:               mod.Kind,
+						Name:               moduleName,
+						UID:                mod.UID,
+					},
+				},
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      rbacv1.ServiceAccountKind,
+					Name:      expectedServiceAccount.Name,
+					Namespace: mod.Namespace,
+				},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     "kmm-operator-device-plugin",
+			},
+		}
+	})
+
+	It("should add the default device plugin ServiceAccount and RoleBinding", func() {
+		gomock.InOrder(
+			clnt.EXPECT().Get(ctx, gomock.Any(), requestedServiceAccount).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
+			clnt.EXPECT().Create(ctx, expectedServiceAccount).Return(nil),
+			clnt.EXPECT().Get(ctx, gomock.Any(), requestedRoleBinding).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
+			clnt.EXPECT().Create(ctx, expectedRoleBinding).Return(nil),
+		)
+
+		err := rc.CreateDevicePluginRBAC(context.Background(), mod)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should return an error when the ServiceAccount fetch fails", func() {
+		gomock.InOrder(
+			clnt.EXPECT().Get(ctx, gomock.Any(), requestedServiceAccount).Return(errors.New("some-error")),
+		)
+
+		err := rc.CreateDevicePluginRBAC(context.Background(), mod)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should return an error when the ServiceAccount creation fails", func() {
+		gomock.InOrder(
+			clnt.EXPECT().Get(ctx, gomock.Any(), requestedServiceAccount).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
+			clnt.EXPECT().Create(ctx, expectedServiceAccount).Return(errors.New("some-error")),
+		)
+
+		err := rc.CreateDevicePluginRBAC(context.Background(), mod)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should return an error when the RoleBinding fetch fails", func() {
+		gomock.InOrder(
+			clnt.EXPECT().Get(ctx, gomock.Any(), requestedServiceAccount).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
+			clnt.EXPECT().Create(ctx, expectedServiceAccount).Return(nil),
+			clnt.EXPECT().Get(ctx, gomock.Any(), requestedRoleBinding).Return(errors.New("some-error")),
+		)
+
+		err := rc.CreateDevicePluginRBAC(context.Background(), mod)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should return an error when the RoleBinding creation fails", func() {
+		gomock.InOrder(
+			clnt.EXPECT().Get(ctx, gomock.Any(), requestedServiceAccount).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
+			clnt.EXPECT().Create(ctx, expectedServiceAccount).Return(nil),
+			clnt.EXPECT().Get(ctx, gomock.Any(), requestedRoleBinding).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
+			clnt.EXPECT().Create(ctx, expectedRoleBinding).Return(errors.New("some-error")),
+		)
+
+		err := rc.CreateDevicePluginRBAC(context.Background(), mod)
+		Expect(err).To(HaveOccurred())
 	})
 })

--- a/internal/rbac/suite_test.go
+++ b/internal/rbac/suite_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/test"
 	"k8s.io/apimachinery/pkg/runtime"
 	//+kubebuilder:scaffold:imports


### PR DESCRIPTION
This PR adds the changes required to automate the binding of the default module loader and device plugin SAs to the `privileged` [SecurityContextConstraints](https://docs.openshift.com/container-platform/4.11/authentication/managing-security-context-constraints.html), in order for users to seamlessly have their `Module`'s pods [admitted](https://connect.redhat.com/en/blog/important-openshift-changes-pod-security-standards) on OCP 4.12+ (due to the enforced K8S [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/)).

> This takes place only when the `Module` CR does not define the respective `ServiceAccountName` fields of the `Module.Spec.ModuleLoader` and/or the `Module.Spec.DevicePlugin` specs.

Specifically, it adds:
- a module loader `ClusterRole`, which allows the use of the `privileged` SCC, to the OLM manifests
- a device plugin `ClusterRole`, which allows the use of the `privileged` SCC, to the OLM manifests
- controller permissions to use the privileged SCC
- controller permissions to bind the afore-mentioned `ClusterRole`s with the privileged SCC to SAs
- a `RoleBinding` of the module loader `ClusterRole` to the module loader SA
- a `RoleBinding` of the device plugin `ClusterRole` to the device plugin SA

[MGMT-11574](https://issues.redhat.com//browse/MGMT-11574)
  
Signed-off-by: Michail Resvanis <mresvani@redhat.com>