### PR TITLE
Update bundle manifests to reflect latest changes

### DIFF
--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=kmm-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.17.0+git
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.21.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/kmm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kmm-operator.clusterserviceversion.yaml
@@ -14,7 +14,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    operators.operatorframework.io/builder: operator-sdk-v1.17.0+git
+    operators.operatorframework.io/builder: operator-sdk-v1.21.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: kmm-operator.v0.0.1
   namespace: placeholder
@@ -26,6 +26,9 @@ spec:
       displayName: Module
       kind: Module
       name: modules.kmm.sigs.k8s.io
+      version: v1beta1
+    - kind: PreflightValidation
+      name: preflightvalidations.kmm.sigs.k8s.io
       version: v1beta1
   description: Kubernetes operator managing out of tree kernel modules
   displayName: OOT Operator
@@ -48,11 +51,22 @@ spec:
           - patch
           - watch
         - apiGroups:
-          - batch
+          - build.openshift.io
           resources:
-          - jobs
+          - buildconfigs
           verbs:
           - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - build.openshift.io
+          resources:
+          - builds
+          verbs:
+          - get
           - list
           - watch
         - apiGroups:
@@ -82,6 +96,17 @@ spec:
           - list
           - watch
         - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
           - kmm.sigs.k8s.io
           resources:
           - modules
@@ -108,6 +133,26 @@ spec:
           - patch
           - update
         - apiGroups:
+          - kmm.sigs.k8s.io
+          resources:
+          - preflightvalidations
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - kmm.sigs.k8s.io
+          resources:
+          - preflightvalidations/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
           - authentication.k8s.io
           resources:
           - tokenreviews
@@ -121,7 +166,9 @@ spec:
           - create
         serviceAccountName: kmm-operator-controller-manager
       deployments:
-      - name: kmm-operator-controller-manager
+      - label:
+          control-plane: controller-manager
+        name: kmm-operator-controller-manager
         spec:
           replicas: 1
           selector:

--- a/bundle/manifests/kmm.sigs.k8s.io_modules.yaml
+++ b/bundle/manifests/kmm.sigs.k8s.io_modules.yaml
@@ -1871,7 +1871,7 @@ spec:
                             type: string
                           pull:
                             description: Pull contains settings determining how to
-                              check if the DriverContainer image already exists.
+                              pull the base images of the build process.
                             properties:
                               insecure:
                                 description: If Insecure is true, images can be pulled
@@ -1959,8 +1959,7 @@ spec:
                                   type: string
                                 pull:
                                   description: Pull contains settings determining
-                                    how to check if the DriverContainer image already
-                                    exists.
+                                    how to pull the base images of the build process.
                                   properties:
                                     insecure:
                                       description: If Insecure is true, images can
@@ -2017,6 +2016,20 @@ spec:
                               description: Literal defines a literal target kernel
                                 version to be matched exactly against node kernels.
                               type: string
+                            pull:
+                              description: Pull contains settings determining how
+                                to check if the ModuleLoader image already exists
+                                and allows overriding of the ModuleLoader's pull options
+                              properties:
+                                insecure:
+                                  description: If Insecure is true, images can be
+                                    pulled from an insecure (plain HTTP) registry.
+                                  type: boolean
+                                insecureSkipTLSVerify:
+                                  description: If InsecureSkipTLSVerify, the operator
+                                    will accept any certificate provided by the registry.
+                                  type: boolean
+                              type: object
                             regexp:
                               description: Regexp is a regular expression to be match
                                 against node kernels.
@@ -2056,6 +2069,11 @@ spec:
                             description: DirName is the root directory for modules.
                               It adds `-d ${DirName}` to the modprobe command-line.
                             type: string
+                          firmwarePath:
+                            description: FirmwarePath is the path of the firmware(s).
+                              The firmware(s) will be copied to the host for the kernel
+                              to find them.
+                            type: string
                           moduleName:
                             description: ModuleName is the name of the Module to be
                               loaded.
@@ -2092,6 +2110,19 @@ spec:
                             type: object
                         required:
                         - moduleName
+                        type: object
+                      pull:
+                        description: Pull contains settings determining how to check
+                          if the ModuleLoader image already exists.
+                        properties:
+                          insecure:
+                            description: If Insecure is true, images can be pulled
+                              from an insecure (plain HTTP) registry.
+                            type: boolean
+                          insecureSkipTLSVerify:
+                            description: If InsecureSkipTLSVerify, the operator will
+                              accept any certificate provided by the registry.
+                            type: boolean
                         type: object
                     required:
                     - kernelMappings

--- a/bundle/manifests/kmm.sigs.k8s.io_preflightvalidations.yaml
+++ b/bundle/manifests/kmm.sigs.k8s.io_preflightvalidations.yaml
@@ -1,0 +1,103 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: unapproved, testing-only
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: preflightvalidations.kmm.sigs.k8s.io
+spec:
+  group: kmm.sigs.k8s.io
+  names:
+    kind: PreflightValidation
+    listKind: PreflightValidationList
+    plural: preflightvalidations
+    shortNames:
+    - pv
+    singular: preflightvalidation
+  scope: Cluster
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: PreflightValidation initiates a preflight validations for all
+          SpecialResources on the current Kuberentes cluster.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'PreflightValidationSpec describes the desired state of the
+              resource, such as the kernel version that Module CRs need to be verified
+              against as well as the debug configuration of the logs More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              kernelVersion:
+                description: KernelImage describes the kernel image that all Modules
+                  need to be checked against.
+                type: string
+            required:
+            - kernelVersion
+            type: object
+          status:
+            description: 'PreflightValidationStatus is the most recently observed
+              status of the PreflightValidation. It is populated by the system and
+              is read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+            properties:
+              crStatuses:
+                additionalProperties:
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the CR status
+                        transitioned from one status to another. This should be when
+                        the underlying status changed.  If that is not known, then
+                        using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    statusReason:
+                      description: StatusReason contains a string describing the status
+                        source.
+                      type: string
+                    verificationStage:
+                      description: 'Current stage of the verification process: image
+                        (image existence verification), build(build process verification)'
+                      enum:
+                      - Image
+                      - Build
+                      type: string
+                    verificationStatus:
+                      description: 'Status of Module CR verification: true (verified),
+                        false (verification failed), error (error during verification
+                        process), unknown (verification has not started yet)'
+                      enum:
+                      - "True"
+                      - "False"
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - verificationStage
+                  - verificationStatus
+                  type: object
+                description: CRStatuses contain observations about each SpecialResource's
+                  preflight upgradability validation
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: kmm-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.17.0+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.21.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 


### PR DESCRIPTION
This PR updates the OLM bundle manifests to reflect the latest changes to the latter.

Specifically, it brings the changes of the following PRs:

- https://github.com/rh-ecosystem-edge/kernel-module-management/pull/23/
-  https://github.com/rh-ecosystem-edge/kernel-module-management/pull/39
- https://github.com/rh-ecosystem-edge/kernel-module-management/pull/47
- https://github.com/rh-ecosystem-edge/kernel-module-management/pull/52/
- https://github.com/rh-ecosystem-edge/kernel-module-management/pull/56
- https://github.com/rh-ecosystem-edge/kernel-module-management/pull/60

Signed-off-by: Michail Resvanis <mresvani@redhat.com>