### PR TITLE
Expand registry package API (#133)

### DIFF
--- a/internal/registry/mock_registry_api.go
+++ b/internal/registry/mock_registry_api.go
@@ -37,21 +37,6 @@ func (m *MockRegistry) EXPECT() *MockRegistryMockRecorder {
 	return m.recorder
 }
 
-// ExtractToolkitRelease mocks base method.
-func (m *MockRegistry) ExtractToolkitRelease(arg0 v1.Layer) (*DriverToolkitEntry, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ExtractToolkitRelease", arg0)
-	ret0, _ := ret[0].(*DriverToolkitEntry)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ExtractToolkitRelease indicates an expected call of ExtractToolkitRelease.
-func (mr *MockRegistryMockRecorder) ExtractToolkitRelease(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExtractToolkitRelease", reflect.TypeOf((*MockRegistry)(nil).ExtractToolkitRelease), arg0)
-}
-
 // GetLayerByDigest mocks base method.
 func (m *MockRegistry) GetLayerByDigest(digest string, pullConfig *RepoPullConfig) (v1.Layer, error) {
 	m.ctrl.T.Helper()
@@ -96,4 +81,18 @@ func (m *MockRegistry) ImageExists(ctx context.Context, image string, po *v1beta
 func (mr *MockRegistryMockRecorder) ImageExists(ctx, image, po, registryAuthGetter interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ImageExists", reflect.TypeOf((*MockRegistry)(nil).ImageExists), ctx, image, po, registryAuthGetter)
+}
+
+// VerifyModuleExists mocks base method.
+func (m *MockRegistry) VerifyModuleExists(layer v1.Layer, pathPrefix, kernelVersion, moduleFileName string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VerifyModuleExists", layer, pathPrefix, kernelVersion, moduleFileName)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// VerifyModuleExists indicates an expected call of VerifyModuleExists.
+func (mr *MockRegistryMockRecorder) VerifyModuleExists(layer, pathPrefix, kernelVersion, moduleFileName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VerifyModuleExists", reflect.TypeOf((*MockRegistry)(nil).VerifyModuleExists), layer, pathPrefix, kernelVersion, moduleFileName)
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -21,7 +22,7 @@ import (
 )
 
 const (
-	driverToolkitJSONFile = "etc/driver-toolkit-release.json"
+	modulesLocationPath = "lib/modules"
 )
 
 type DriverToolkitEntry struct {
@@ -40,7 +41,7 @@ type RepoPullConfig struct {
 
 type Registry interface {
 	ImageExists(ctx context.Context, image string, po *kmmv1beta1.PullOptions, registryAuthGetter auth.RegistryAuthGetter) (bool, error)
-	ExtractToolkitRelease(v1.Layer) (*DriverToolkitEntry, error)
+	VerifyModuleExists(layer v1.Layer, pathPrefix, kernelVersion, moduleFileName string) bool
 	GetLayersDigests(ctx context.Context, image string, registryAuthGetter auth.RegistryAuthGetter) ([]string, *RepoPullConfig, error)
 	GetLayerByDigest(digest string, pullConfig *RepoPullConfig) (v1.Layer, error)
 }
@@ -89,29 +90,10 @@ func (r *registry) GetLayerByDigest(digest string, pullConfig *RepoPullConfig) (
 	return crane.PullLayer(pullConfig.repo+"@"+digest, pullConfig.authOptions...)
 }
 
-func (r *registry) ExtractToolkitRelease(layer v1.Layer) (*DriverToolkitEntry, error) {
-	var found bool
-	dtk := &DriverToolkitEntry{}
-	obj, err := r.getHeaderFromLayer(layer, driverToolkitJSONFile)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find file %s in image layer: %w", driverToolkitJSONFile, err)
-	}
-
-	dtk.KernelFullVersion, found, err = unstructured.NestedString(obj.Object, "KERNEL_VERSION")
-	if !found || err != nil {
-		return nil, fmt.Errorf("failed to get KERNEL_VERSION from %s, found %t: %w", driverToolkitJSONFile, found, err)
-	}
-
-	dtk.RTKernelFullVersion, found, err = unstructured.NestedString(obj.Object, "RT_KERNEL_VERSION")
-	if !found || err != nil {
-		return nil, fmt.Errorf("failed to get RT_KERNEL_VERSION from %s, found %t: %w", driverToolkitJSONFile, found, err)
-	}
-
-	dtk.OSVersion, found, err = unstructured.NestedString(obj.Object, "RHEL_VERSION")
-	if !found || err != nil {
-		return nil, fmt.Errorf("failed to get RHEL_VERSION from %s, found %t: %w", driverToolkitJSONFile, found, err)
-	}
-	return dtk, nil
+func (r *registry) VerifyModuleExists(layer v1.Layer, pathPrefix, kernelVersion, moduleFileName string) bool {
+	fullPath := filepath.Join(pathPrefix, modulesLocationPath, kernelVersion, moduleFileName)
+	_, err := r.getHeaderStreamFromLayer(layer, fullPath)
+	return err == nil
 }
 
 func (r *registry) getPullOptions(ctx context.Context, image string, po *kmmv1beta1.PullOptions, registryAuthGetter auth.RegistryAuthGetter) (*RepoPullConfig, error) {
@@ -216,7 +198,7 @@ func (r *registry) getLayersDigestsFromManifestStream(manifestStream []byte) ([]
 	return digests, nil
 }
 
-func (r *registry) getHeaderFromLayer(layer v1.Layer, headerName string) (*unstructured.Unstructured, error) {
+func (r *registry) getHeaderStreamFromLayer(layer v1.Layer, headerName string) (io.Reader, error) {
 
 	targz, err := layer.Compressed()
 	if err != nil {
@@ -244,17 +226,7 @@ func (r *registry) getHeaderFromLayer(layer v1.Layer, headerName string) (*unstr
 			return nil, fmt.Errorf("failed to get next entry from targz: %w", err)
 		}
 		if header.Name == headerName {
-			buff, err := io.ReadAll(tr)
-			if err != nil {
-				return nil, fmt.Errorf("failed to read tar entry: %w", err)
-			}
-
-			obj := unstructured.Unstructured{}
-
-			if err = json.Unmarshal(buff, &obj.Object); err != nil {
-				return nil, fmt.Errorf("failed to unmarshal tar entry: %w", err)
-			}
-			return &obj, nil
+			return tr, nil
 		}
 	}
 

--- a/internal/registry/registry_helper_test.go
+++ b/internal/registry/registry_helper_test.go
@@ -1,0 +1,66 @@
+package registry
+
+import (
+	"archive/tar"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"io/ioutil"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/partial"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+type uncompressedLayer struct {
+	diffID    v1.Hash
+	mediaType types.MediaType
+	content   []byte
+}
+
+func (ul *uncompressedLayer) DiffID() (v1.Hash, error) {
+	return ul.diffID, nil
+}
+
+func (ul *uncompressedLayer) Uncompressed() (io.ReadCloser, error) {
+	return ioutil.NopCloser(bytes.NewBuffer(ul.content)), nil
+}
+
+func (ul *uncompressedLayer) MediaType() (types.MediaType, error) {
+	return ul.mediaType, nil
+}
+
+func prepareLayer(fileName string, data []byte) (v1.Layer, error) {
+	// Hash the contents as we write it out to the buffer.
+	var b bytes.Buffer
+	hasher := sha256.New()
+	mw := io.MultiWriter(&b, hasher)
+
+	// Write a single file with a random name and random contents.
+	tw := tar.NewWriter(mw)
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     fileName,
+		Size:     int64(len(data)),
+		Typeflag: tar.TypeRegA,
+	}); err != nil {
+		return nil, err
+	}
+	if _, err := io.Copy(tw, bytes.NewReader(data)); err != nil {
+		return nil, err
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+
+	h := v1.Hash{
+		Algorithm: "sha256",
+		Hex:       hex.EncodeToString(hasher.Sum(make([]byte, 0, hasher.Size()))),
+	}
+
+	return partial.UncompressedToLayer(&uncompressedLayer{
+		diffID:    h,
+		mediaType: types.DockerLayer,
+		content:   b.Bytes(),
+	})
+}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -335,8 +335,26 @@ var _ = Describe("GetLayersDigests", func() {
 	)
 })
 
-var _ = Describe("ExtractToolkitRelease", func() {
-	//TODO: implement when the preflight feature starst using that method
+var _ = Describe("VerifyModuleExists", func() {
+	reg := NewRegistry()
+
+	It("file is not present", func() {
+		const fileName = "/etc/fileName"
+		layer, err := prepareLayer(fileName, []byte("some data"))
+		Expect(err).ToNot(HaveOccurred())
+
+		res := reg.VerifyModuleExists(layer, "", "somekernel", "module_name.ko")
+		Expect(res).To(BeFalse())
+	})
+
+	It("file is present", func() {
+		const fileName = "/opt/lib/modules/somekernel/module_name.ko"
+		layer, err := prepareLayer(fileName, []byte("some data"))
+		Expect(err).ToNot(HaveOccurred())
+
+		res := reg.VerifyModuleExists(layer, "/opt", "somekernel", "module_name.ko")
+		Expect(res).To(BeTrue())
+	})
 })
 
 func mustParseURL(rawURL string) *url.URL {


### PR DESCRIPTION
This PR includes:
1) adding VerifyModuleExistsForKernel function, that verifies
   presence of a file (full path) in a v1.Layer (layer of container image)
2) removing ExtractToolkitRelease funtion: no longer used
   by the preflight code, replaced by the VerifyModuleExistsForKernel
3) add unit-test
4) add test infrastructure to create a dummy v1.Layer