### PR TITLE
Preflight should use PullOptions in image verification (#52)

### DIFF
--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -67,8 +67,9 @@ func (p *preflight) verifyImage(ctx context.Context, mapping *kmmv1beta1.KernelM
 	moduleName := mod.Spec.ModuleLoader.Container.Modprobe.ModuleName
 	baseDir := mod.Spec.ModuleLoader.Container.Modprobe.DirName
 
+	pullOptions := module.GetRelevantPullOptions(mod, mapping)
 	registryAuthGetter := p.authFactory.NewRegistryAuthGetterFrom(mod)
-	digests, repoConfig, err := p.registryAPI.GetLayersDigests(ctx, image, registryAuthGetter)
+	digests, repoConfig, err := p.registryAPI.GetLayersDigests(ctx, image, pullOptions, registryAuthGetter)
 	if err != nil {
 		log.Info("image layers inaccessible, image probably does not exists", "module name", mod.Name, "image", image)
 		return false, fmt.Sprintf("image %s inaccessible or does not exists", image)

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -104,7 +104,7 @@ var _ = Describe("verifyImage", func() {
 		repoConfig := &registry.RepoPullConfig{}
 		digestLayer := v1stream.Layer{}
 		mockAuthFactory.EXPECT().NewRegistryAuthGetterFrom(mod)
-		mockRegistryAPI.EXPECT().GetLayersDigests(context.Background(), containerImage, gomock.Any()).Return(digests, repoConfig, nil)
+		mockRegistryAPI.EXPECT().GetLayersDigests(context.Background(), containerImage, nil, gomock.Any()).Return(digests, repoConfig, nil)
 		mockRegistryAPI.EXPECT().GetLayerByDigest(digests[1], repoConfig).Return(&digestLayer, nil)
 		mockRegistryAPI.EXPECT().VerifyModuleExists(&digestLayer, "/opt", kernelVersion, "simple-kmod.ko").Return(true)
 
@@ -117,7 +117,7 @@ var _ = Describe("verifyImage", func() {
 	It("get layers digest failed", func() {
 		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
 		mockAuthFactory.EXPECT().NewRegistryAuthGetterFrom(mod)
-		mockRegistryAPI.EXPECT().GetLayersDigests(context.Background(), containerImage, gomock.Any()).Return(nil, nil, fmt.Errorf("some error"))
+		mockRegistryAPI.EXPECT().GetLayersDigests(context.Background(), containerImage, nil, gomock.Any()).Return(nil, nil, fmt.Errorf("some error"))
 
 		res, message := p.verifyImage(context.Background(), &mapping, mod, kernelVersion)
 
@@ -130,7 +130,7 @@ var _ = Describe("verifyImage", func() {
 		digests := []string{"digest0", "digest1"}
 		repoConfig := &registry.RepoPullConfig{}
 		mockAuthFactory.EXPECT().NewRegistryAuthGetterFrom(mod)
-		mockRegistryAPI.EXPECT().GetLayersDigests(context.Background(), containerImage, gomock.Any()).Return(digests, repoConfig, nil)
+		mockRegistryAPI.EXPECT().GetLayersDigests(context.Background(), containerImage, nil, gomock.Any()).Return(digests, repoConfig, nil)
 		mockRegistryAPI.EXPECT().GetLayerByDigest(digests[1], repoConfig).Return(nil, fmt.Errorf("some error"))
 
 		res, message := p.verifyImage(context.Background(), &mapping, mod, kernelVersion)
@@ -145,7 +145,7 @@ var _ = Describe("verifyImage", func() {
 		repoConfig := &registry.RepoPullConfig{}
 		digestLayer := v1stream.Layer{}
 		mockAuthFactory.EXPECT().NewRegistryAuthGetterFrom(mod)
-		mockRegistryAPI.EXPECT().GetLayersDigests(context.Background(), containerImage, gomock.Any()).Return(digests, repoConfig, nil)
+		mockRegistryAPI.EXPECT().GetLayersDigests(context.Background(), containerImage, nil, gomock.Any()).Return(digests, repoConfig, nil)
 		mockRegistryAPI.EXPECT().GetLayerByDigest(digests[0], repoConfig).Return(&digestLayer, nil)
 		mockRegistryAPI.EXPECT().VerifyModuleExists(&digestLayer, "/opt", kernelVersion, "simple-kmod.ko").Return(false)
 

--- a/internal/registry/mock_registry_api.go
+++ b/internal/registry/mock_registry_api.go
@@ -53,9 +53,9 @@ func (mr *MockRegistryMockRecorder) GetLayerByDigest(digest, pullConfig interfac
 }
 
 // GetLayersDigests mocks base method.
-func (m *MockRegistry) GetLayersDigests(ctx context.Context, image string, registryAuthGetter auth.RegistryAuthGetter) ([]string, *RepoPullConfig, error) {
+func (m *MockRegistry) GetLayersDigests(ctx context.Context, image string, po *v1beta1.PullOptions, registryAuthGetter auth.RegistryAuthGetter) ([]string, *RepoPullConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLayersDigests", ctx, image, registryAuthGetter)
+	ret := m.ctrl.Call(m, "GetLayersDigests", ctx, image, po, registryAuthGetter)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(*RepoPullConfig)
 	ret2, _ := ret[2].(error)
@@ -63,9 +63,9 @@ func (m *MockRegistry) GetLayersDigests(ctx context.Context, image string, regis
 }
 
 // GetLayersDigests indicates an expected call of GetLayersDigests.
-func (mr *MockRegistryMockRecorder) GetLayersDigests(ctx, image, registryAuthGetter interface{}) *gomock.Call {
+func (mr *MockRegistryMockRecorder) GetLayersDigests(ctx, image, po, registryAuthGetter interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLayersDigests", reflect.TypeOf((*MockRegistry)(nil).GetLayersDigests), ctx, image, registryAuthGetter)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLayersDigests", reflect.TypeOf((*MockRegistry)(nil).GetLayersDigests), ctx, image, po, registryAuthGetter)
 }
 
 // ImageExists mocks base method.

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -42,7 +42,7 @@ type RepoPullConfig struct {
 type Registry interface {
 	ImageExists(ctx context.Context, image string, po *kmmv1beta1.PullOptions, registryAuthGetter auth.RegistryAuthGetter) (bool, error)
 	VerifyModuleExists(layer v1.Layer, pathPrefix, kernelVersion, moduleFileName string) bool
-	GetLayersDigests(ctx context.Context, image string, registryAuthGetter auth.RegistryAuthGetter) ([]string, *RepoPullConfig, error)
+	GetLayersDigests(ctx context.Context, image string, po *kmmv1beta1.PullOptions, registryAuthGetter auth.RegistryAuthGetter) ([]string, *RepoPullConfig, error)
 	GetLayerByDigest(digest string, pullConfig *RepoPullConfig) (v1.Layer, error)
 }
 
@@ -65,8 +65,8 @@ func (r *registry) ImageExists(ctx context.Context, image string, po *kmmv1beta1
 	return true, nil
 }
 
-func (r *registry) GetLayersDigests(ctx context.Context, image string, registryAuthGetter auth.RegistryAuthGetter) ([]string, *RepoPullConfig, error) {
-	manifest, pullConfig, err := r.getImageManifest(ctx, image, nil, registryAuthGetter)
+func (r *registry) GetLayersDigests(ctx context.Context, image string, po *kmmv1beta1.PullOptions, registryAuthGetter auth.RegistryAuthGetter) ([]string, *RepoPullConfig, error) {
+	manifest, pullConfig, err := r.getImageManifest(ctx, image, po, registryAuthGetter)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get manifest from image %s: %w", image, err)
 	}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -258,7 +258,7 @@ var _ = Describe("GetLayersDigests", func() {
 			u := mustParseURL(server.URL)
 
 			image := fmt.Sprintf("%s/%s/%s:%s", u.Host, validImageOrg, validImageName, validImageTag)
-			_, _, err = reg.GetLayersDigests(ctx, image, nil)
+			_, _, err = reg.GetLayersDigests(ctx, image, &kmmv1beta1.PullOptions{}, nil)
 
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to get crane manifest from image"))
@@ -273,7 +273,7 @@ var _ = Describe("GetLayersDigests", func() {
 			u := mustParseURL(server.URL)
 
 			image := fmt.Sprintf("%s/%s/%s:%s", u.Host, validImageOrg, validImageName, validImageTag)
-			_, _, err = reg.GetLayersDigests(ctx, image, nil)
+			_, _, err = reg.GetLayersDigests(ctx, image, &kmmv1beta1.PullOptions{}, nil)
 
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to unmarshal crane manifest"))
@@ -299,7 +299,7 @@ var _ = Describe("GetLayersDigests", func() {
 			u := mustParseURL(server.URL)
 
 			image := fmt.Sprintf("%s/%s/%s:%s", u.Host, validImageOrg, validImageName, validImageTag)
-			_, _, err = reg.GetLayersDigests(ctx, image, nil)
+			_, _, err = reg.GetLayersDigests(ctx, image, &kmmv1beta1.PullOptions{}, nil)
 
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("mediaType is missing from the image"))
@@ -324,9 +324,9 @@ var _ = Describe("GetLayersDigests", func() {
 		var err error
 		image := fmt.Sprintf("%s/%s/%s:%s", u.Host, validImageOrg, validImageName, validImageTag)
 		if withRegistryAuthGetter {
-			_, _, err = reg.GetLayersDigests(ctx, image, mockRegistryAuthGetter)
+			_, _, err = reg.GetLayersDigests(ctx, image, &kmmv1beta1.PullOptions{}, mockRegistryAuthGetter)
 		} else {
-			_, _, err = reg.GetLayersDigests(ctx, image, nil)
+			_, _, err = reg.GetLayersDigests(ctx, image, &kmmv1beta1.PullOptions{}, nil)
 		}
 		Expect(err).ToNot(HaveOccurred())
 	},


### PR DESCRIPTION
Since now we have pull options also in kernel mapping and in Spec, those parameters should now be used in the preflight image verification