### PR TITLE
Fix duplicate namespace inspects for DSs in must-gather

### DIFF
--- a/must-gather/gather
+++ b/must-gather/gather
@@ -28,7 +28,9 @@ oc adm inspect -A crd/modules.kmm.sigs.k8s.io  --dest-dir="$OUTPUT_DIR/inspect"
 echo "Inspecting all Modules in all namespaces"
 oc adm inspect -A modules.kmm.sigs.k8s.io --dest-dir="$OUTPUT_DIR/inspect"
 
-for ns in $(oc get daemonset -A -l kmm.node.kubernetes.io/module.name --no-headers -o custom-columns="NS:.metadata.namespace"); do
+namespaces=$(oc get daemonset -A -l kmm.node.kubernetes.io/module.name --no-headers -o custom-columns="NS:.metadata.namespace")
+IFS=" " read -r -a namespaces <<< "$(echo "${namespaces[@]}" | tr ' ' '\n' | sort -u | tr '\n' ' ')"
+for ns in "${namespaces[@]}"; do
   echo "Inspecting DaemonSet in '${ns}' namespace"
   oc adm inspect -n "$ns" daemonset.apps --dest-dir="$OUTPUT_DIR/inspect"
 done


### PR DESCRIPTION
This change removes duplicate execution of `oc adm inspect daemonsets` statements, when fetching the namespaces to loop for by getting the DaemonSets of all namespaces labelled as KMM DSs. There could be 2 KMM DaemonSets per namespace, i.e. the module-loader and the device-plugin one. As a result, the namespaces array for which to loop included duplicates.

Signed-off-by: Michail Resvanis <mresvani@redhat.com>