### PR TITLE
Add check-commits-count

### DIFF
--- a/ci/prow/check-commits-count
+++ b/ci/prow/check-commits-count
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+git remote add main https://github.com/rh-ecosystem-edge/kernel-module-management.git
+git fetch main
+
+commits_count=$(git rev-list --count HEAD ^main)
+# When Prow is testing a PR, it is creating a branch for it but then merges it
+# into the "main" branch for testing, therefore, we also get the "merge commit"
+# in addition to the original commit.
+if [[ ${commits_count} != 2 ]]; then
+    echo '
+    All PRs must contain a single commit.
+    Please refer to https://github.com/rh-ecosystem-edge/kernel-module-management/blob/main/CONTRIBUTING.md
+    '
+    exit 1
+fi


### PR DESCRIPTION
Add script to check that each PR consists of one single commit.