### PR TITLE
Fix kustomize and bundle CRD manifests YAML errors

### DIFF
--- a/bundle/manifests/kmm.sigs.k8s.io_preflightvalidations.yaml
+++ b/bundle/manifests/kmm.sigs.k8s.io_preflightvalidations.yaml
@@ -21,7 +21,7 @@ spec:
     schema:
       openAPIV3Schema:
         description: PreflightValidation initiates a preflight validations for all
-        Module objects on the current Kubernetes cluster.
+          Modules on the current Kubernetes cluster.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -86,8 +86,8 @@ spec:
                   - verificationStage
                   - verificationStatus
                   type: object
-                description: CRStatuses contain observations about each Module's
-                  preflight upgradability validation
+                description: CRStatuses contain observations about each Module's preflight
+                  upgradability validation
                 type: object
             type: object
         type: object

--- a/config/crd/bases/kmm.sigs.k8s.io_modules.yaml
+++ b/config/crd/bases/kmm.sigs.k8s.io_modules.yaml
@@ -2034,48 +2034,6 @@ spec:
                               description: Regexp is a regular expression to be match
                                 against node kernels.
                               type: string
-                            sign:
-                              description: Sign enables in-cluster signing for this
-                                mapping
-                              properties:
-                                certSecret:
-                                  description: a secret containing the public key
-                                    used to sign kernel modules for secureboot
-                                  properties:
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                filesToSign:
-                                  description: paths inside the image for the kernel
-                                    modules to sign (if ommited all kmods are signed)
-                                  items:
-                                    type: string
-                                  type: array
-                                keySecret:
-                                  description: a secret containing the private key
-                                    used to sign kernel modules for secureboot
-                                  properties:
-                                    name:
-                                      description: 'Name of the referent. More info:
-                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                        TODO: Add other useful fields. apiVersion,
-                                        kind, uid?'
-                                      type: string
-                                  type: object
-                                  x-kubernetes-map-type: atomic
-                                unsignedImage:
-                                  description: Image to sign, ignored if a Build is
-                                    present, required otherwise
-                                  type: string
-                              required:
-                              - certSecret
-                              - keySecret
-                              type: object
                           required:
                           - containerImage
                           type: object
@@ -2165,45 +2123,6 @@ spec:
                             description: If InsecureSkipTLSVerify, the operator will
                               accept any certificate provided by the registry.
                             type: boolean
-                        type: object
-                      sign:
-                        description: Sign provides default kmod signing settings
-                        properties:
-                          certSecret:
-                            description: a secret containing the public key used to
-                              sign kernel modules for secureboot
-                            properties:
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
-                                type: string
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          filesToSign:
-                            description: paths inside the image for the kernel modules
-                              to sign (if ommited all kmods are signed)
-                            items:
-                              type: string
-                            type: array
-                          keySecret:
-                            description: a secret containing the private key used
-                              to sign kernel modules for secureboot
-                            properties:
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
-                                type: string
-                            type: object
-                            x-kubernetes-map-type: atomic
-                          unsignedImage:
-                            description: Image to sign, ignored if a Build is present,
-                              required otherwise
-                            type: string
-                        required:
-                        - certSecret
-                        - keySecret
                         type: object
                     required:
                     - kernelMappings

--- a/config/crd/bases/kmm.sigs.k8s.io_preflightvalidations.yaml
+++ b/config/crd/bases/kmm.sigs.k8s.io_preflightvalidations.yaml
@@ -21,7 +21,7 @@ spec:
     schema:
       openAPIV3Schema:
         description: PreflightValidation initiates a preflight validations for all
-        Module obects on the current Kubernetes cluster.
+          Modules on the current Kubernetes cluster.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation


### PR DESCRIPTION
This PR fixes `kustomize` and `bundle` CRD manifests YAML errors leading to failed `kustomize` deployment. Specifically, it resolves the following issue:

```shell
$ oc apply -k https://github.com/rh-ecosystem-edge/kernel-module-management/config/default
error: accumulating resources: accumulation err='accumulating resources from '../crd': '/tmp/kustomize-2948061914/config/crd' must resolve to a file': recursed accumulation of path '/tmp/kustomize-2948061914/config/crd': accumulating resources: accumulating resources from 'bases/kmm.sigs.k8s.io_preflightvalidations.yaml': MalformedYAMLError: yaml: line 24: could not find expected ':' in File: bases/kmm.sigs.k8s.io_preflightvalidations.yaml
```

Signed-off-by: Michail Resvanis <mresvani@redhat.com>