### PR TITLE
centralise the name of the image to build in the controller (#88)

### DIFF
--- a/controllers/module_reconciler_test.go
+++ b/controllers/module_reconciler_test.go
@@ -745,7 +745,7 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 			mockSU,
 		)
 
-		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion)
+		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion, km.ContainerImage)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res).To(BeFalse())
 	})
@@ -796,7 +796,7 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 			mockSU,
 		)
 
-		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion)
+		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion, km.ContainerImage)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res).To(BeFalse())
 	})
@@ -840,7 +840,7 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 			mockSU,
 		)
 
-		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion)
+		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion, km.ContainerImage)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res).To(BeFalse())
 	})
@@ -865,7 +865,7 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 				NewRegistryAuthGetterFrom(mod).
 				Return(authGetter),
 			mockRegistry.EXPECT().ImageExists(context.Background(), imageName, nil, authGetter).Return(false, nil),
-			mockBM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), true).Return(buildRes, nil),
+			mockBM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), km.ContainerImage, true).Return(buildRes, nil),
 			mockMetrics.EXPECT().SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.BuildStage, false),
 		)
 
@@ -882,7 +882,7 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 			mockSU,
 		)
 
-		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion)
+		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion, km.ContainerImage)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res).To(BeTrue())
 	})
@@ -907,7 +907,7 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 				NewRegistryAuthGetterFrom(mod).
 				Return(authGetter),
 			mockRegistry.EXPECT().ImageExists(context.Background(), imageName, nil, authGetter).Return(false, nil),
-			mockBM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), true).Return(buildRes, nil),
+			mockBM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), km.ContainerImage, true).Return(buildRes, nil),
 			mockMetrics.EXPECT().SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.BuildStage, false),
 		)
 
@@ -924,7 +924,7 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 			mockSU,
 		)
 
-		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion)
+		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion, km.ContainerImage)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res).To(BeTrue())
 	})
@@ -949,7 +949,7 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 				NewRegistryAuthGetterFrom(mod).
 				Return(authGetter),
 			mockRegistry.EXPECT().ImageExists(context.Background(), imageName, nil, authGetter).Return(false, nil),
-			mockBM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), true).Return(buildRes, nil),
+			mockBM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), km.ContainerImage, true).Return(buildRes, nil),
 			mockMetrics.EXPECT().SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.BuildStage, true),
 		)
 
@@ -966,7 +966,7 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 			mockSU,
 		)
 
-		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion)
+		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion, km.ContainerImage)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res).To(BeFalse())
 	})

--- a/internal/build/buildconfig/manager.go
+++ b/internal/build/buildconfig/manager.go
@@ -34,10 +34,10 @@ func NewManager(client client.Client, maker Maker, ocpBuildsHelper OpenShiftBuil
 	}
 }
 
-func (bcm *buildConfigManager) Sync(ctx context.Context, mod kmmv1beta1.Module, m kmmv1beta1.KernelMapping, targetKernel string, pushImage bool) (build.Result, error) {
+func (bcm *buildConfigManager) Sync(ctx context.Context, mod kmmv1beta1.Module, m kmmv1beta1.KernelMapping, targetKernel, targetImage string, pushImage bool) (build.Result, error) {
 	logger := log.FromContext(ctx)
 
-	buildConfigTemplate, err := bcm.maker.MakeBuildConfigTemplate(mod, m, targetKernel, m.ContainerImage, pushImage)
+	buildConfigTemplate, err := bcm.maker.MakeBuildConfigTemplate(mod, m, targetKernel, targetImage, pushImage)
 	if err != nil {
 		return build.Result{}, fmt.Errorf("could not make BuildConfig template: %v", err)
 	}

--- a/internal/build/buildconfig/manager_test.go
+++ b/internal/build/buildconfig/manager_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Manager_Sync", func() {
 			mockKubeClient.EXPECT().Create(ctx, &buildConfig),
 		)
 
-		res, err := m.Sync(ctx, mod, mapping, targetKernel, true)
+		res, err := m.Sync(ctx, mod, mapping, targetKernel, mapping.ContainerImage, true)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Status).To(BeEquivalentTo(build.StatusCreated))
 		Expect(res.Requeue).To(BeTrue())
@@ -131,7 +131,7 @@ var _ = Describe("Manager_Sync", func() {
 				mockOpenShiftBuildsHelper.EXPECT().GetLatestBuild(ctx, namespace, buildConfigName).Return(&b, nil),
 			)
 
-			res, err := m.Sync(ctx, mod, mapping, targetKernel, true)
+			res, err := m.Sync(ctx, mod, mapping, targetKernel, mapping.ContainerImage, true)
 
 			if expectError {
 				Expect(err).To(HaveOccurred())

--- a/internal/build/manager.go
+++ b/internal/build/manager.go
@@ -22,5 +22,5 @@ type Result struct {
 //go:generate mockgen -source=manager.go -package=build -destination=mock_manager.go
 
 type Manager interface {
-	Sync(ctx context.Context, mod kmmv1beta1.Module, m kmmv1beta1.KernelMapping, targetKernel string, pushImage bool) (Result, error)
+	Sync(ctx context.Context, mod kmmv1beta1.Module, m kmmv1beta1.KernelMapping, targetKernel string, targetImage string, pushImage bool) (Result, error)
 }

--- a/internal/build/mock_manager.go
+++ b/internal/build/mock_manager.go
@@ -36,16 +36,16 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 }
 
 // Sync mocks base method.
-func (m_2 *MockManager) Sync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping, targetKernel string, pushImage bool) (Result, error) {
+func (m_2 *MockManager) Sync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping, targetKernel, targetImage string, pushImage bool) (Result, error) {
 	m_2.ctrl.T.Helper()
-	ret := m_2.ctrl.Call(m_2, "Sync", ctx, mod, m, targetKernel, pushImage)
+	ret := m_2.ctrl.Call(m_2, "Sync", ctx, mod, m, targetKernel, targetImage, pushImage)
 	ret0, _ := ret[0].(Result)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Sync indicates an expected call of Sync.
-func (mr *MockManagerMockRecorder) Sync(ctx, mod, m, targetKernel, pushImage interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) Sync(ctx, mod, m, targetKernel, targetImage, pushImage interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockManager)(nil).Sync), ctx, mod, m, targetKernel, pushImage)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockManager)(nil).Sync), ctx, mod, m, targetKernel, targetImage, pushImage)
 }


### PR DESCRIPTION
The name of the image to build is assumed to be km.ContainerImage in several places in the code, this commit centralises that assumption into a single point in Reconcile(). In the future this will allow us to determine the image the stage produces once E.g if we add signing (or other) intermediate stages to the image build process.