### PR TITLE
Fix failing firmware requests

### DIFF
--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -184,13 +184,11 @@ func (dc *daemonSetGenerator) SetDriverContainerAsDesired(ctx context.Context, d
 	}
 
 	if fw := mod.Spec.ModuleLoader.Container.Modprobe.FirmwarePath; fw != "" {
-		moduleFirmwarePath := fmt.Sprintf("%s/%s", nodeVarLibFirmwarePath, mod.Name)
-
 		firmwareVolume := v1.Volume{
 			Name: nodeVarLibFirmwareVolumeName,
 			VolumeSource: v1.VolumeSource{
 				HostPath: &v1.HostPathVolumeSource{
-					Path: moduleFirmwarePath,
+					Path: nodeVarLibFirmwarePath,
 					Type: &hostPathDirectoryOrCreate,
 				},
 			},
@@ -199,7 +197,7 @@ func (dc *daemonSetGenerator) SetDriverContainerAsDesired(ctx context.Context, d
 
 		firmwareVolumeMount := v1.VolumeMount{
 			Name:      nodeVarLibFirmwareVolumeName,
-			MountPath: moduleFirmwarePath,
+			MountPath: nodeVarLibFirmwarePath,
 		}
 
 		container.VolumeMounts = append(container.VolumeMounts, firmwareVolumeMount)
@@ -383,7 +381,7 @@ func MakeLoadCommand(spec kmmv1beta1.ModprobeSpec, modName string) []string {
 	var loadCommand strings.Builder
 
 	if fw := spec.FirmwarePath; fw != "" {
-		fmt.Fprintf(&loadCommand, "cp -r %s %s/%s && ", fw, nodeVarLibFirmwarePath, modName)
+		fmt.Fprintf(&loadCommand, "cp -r %s %s && ", fw, nodeVarLibFirmwarePath)
 	}
 
 	loadCommand.WriteString("modprobe")
@@ -432,7 +430,7 @@ func MakeUnloadCommand(spec kmmv1beta1.ModprobeSpec, modName string) []string {
 
 	fwUnloadCommand := ""
 	if fw := spec.FirmwarePath; fw != "" {
-		fwUnloadCommand = fmt.Sprintf(" && rm -rf %s/%s", nodeVarLibFirmwarePath, modName)
+		fwUnloadCommand = fmt.Sprintf(" && cd %s && find |sort -r |xargs -I{} rm -d %s/$(basename %s)/{}", fw, nodeVarLibFirmwarePath, fw)
 	}
 
 	if rawArgs := spec.RawArgs; rawArgs != nil && len(rawArgs.Unload) > 0 {

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -86,7 +86,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 			Name: "node-var-lib-firmware",
 			VolumeSource: v1.VolumeSource{
 				HostPath: &v1.HostPathVolumeSource{
-					Path: "/var/lib/firmware/module-name",
+					Path: "/var/lib/firmware",
 					Type: &hostPathDirectoryOrCreate,
 				},
 			},
@@ -94,7 +94,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 		volm := v1.VolumeMount{
 			Name:      "node-var-lib-firmware",
-			MountPath: "/var/lib/firmware/module-name",
+			MountPath: "/var/lib/firmware",
 		}
 
 		mod := kmmv1beta1.Module{
@@ -936,7 +936,7 @@ var _ = Describe("MakeLoadCommand", func() {
 			Equal([]string{
 				"/bin/sh",
 				"-c",
-				fmt.Sprintf("cp -r /kmm/firmware/mymodule /var/lib/firmware/module-name && modprobe -v %s", kernelModuleName),
+				fmt.Sprintf("cp -r /kmm/firmware/mymodule /var/lib/firmware && modprobe -v %s", kernelModuleName),
 			}),
 		)
 	})
@@ -1017,7 +1017,7 @@ var _ = Describe("MakeUnloadCommand", func() {
 			Equal([]string{
 				"/bin/sh",
 				"-c",
-				fmt.Sprintf("modprobe -rv %s && rm -rf /var/lib/firmware/module-name", kernelModuleName),
+				fmt.Sprintf("modprobe -rv %s && cd /kmm/firmware/mymodule && find |sort -r |xargs -I{} rm -d /var/lib/firmware/$(basename /kmm/firmware/mymodule)/{}", kernelModuleName),
 			}),
 		)
 	})


### PR DESCRIPTION
This change fixes failing firmware requests, which are caused by the additional firmware path directory, named after the Module CR, which is created by KMM when copying the firmware files from the module-loader container to the host directory and default firmware search path `/var/lib/firmware`.

Modules request firmware files using a relative path, e.g. `vendor/device/firmware.bin`, which is appended to the default firmware search path. The additional firmware path directory makes the firmware requests unresolvable.

Specifically, this change:

- removes the additional firmware path directory, named after the Module CR
- ensures that only the copied firmware files are removed after the module is unloaded and non-empty firmware directories are skipped (this was not needed before, because each Module had its own firmware subpath under `/var/lib/firmware`)

Signed-off-by: Michail Resvanis <mresvani@redhat.com>

Upstream-Commit: 5a772aa3496468ba9eaf1de4f28772d6902cdded