### PR TITLE
Add JobType to the available constants so it can be used to tag jobs

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -5,4 +5,5 @@ const (
 	ModuleNameLabel              = "kmm.node.kubernetes.io/module.name"
 	NodeLabelerFinalizer         = "kmm.node.kubernetes.io/node-labeler"
 	TargetKernelTarget           = "kmm.node.kubernetes.io/target-kernel"
+	JobType                      = "kmm.node.kubernetes.io/job-type"
 )


### PR DESCRIPTION
(this is used upstream to identify build and sign jobs as seperate, here it will only be used for sign jobs)

Upstream Commit message:
Add an extra tag to the build job to label the stage of the build (#97)

Currently jobs are labelled the module.name and target-kernel, and these are used to search for the job to ensure its creation, completion etc.

The manger searching for these jobs has no other way of determining which job belongs to it.

If we add multiple jobs into the build pipeline (e.g. a signing job) the build manager has no way of distiguishing between the differnet jobs so when it searches for completed jobs it will detect finished signing jobs as if they were finished build (kaniko) jobs, and vice versa. This would lead to much confusion and the pipeline not running through its stages correctly.

This commit adds a third "kmm.node.kubernetes.io/job-stage" label that is set to "build" to make it explicit that this is a build job. For signing it should be set to "sign" and for other jobs set to their respective package name or similar. The build job manager then searches for all 3 labels (and future job managers should also search for their own build-stage label)