### PR TITLE
 Garbage collection for successfull build jobs 

### DIFF
--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -173,14 +173,10 @@ func (r *ModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return res, fmt.Errorf("could handle device plugin: %w", err)
 	}
 
-	logger.Info("Garbage-collecting DaemonSets")
-
-	// Garbage collect old DaemonSets for which there are no nodes.
-	validKernels := sets.StringKeySet(mappings)
-
-	deleted, err := r.daemonAPI.GarbageCollect(ctx, dsByKernelVersion, validKernels)
+	logger.Info("Run garbage collection")
+	err = r.garbageCollect(ctx, mod, mappings, dsByKernelVersion)
 	if err != nil {
-		return res, fmt.Errorf("could not garbage collect DaemonSets: %v", err)
+		return res, fmt.Errorf("failed to run garbage collection: %v", err)
 	}
 
 	err = r.statusUpdaterAPI.ModuleUpdateStatus(ctx, mod, nodesWithMapping, targetedNodes, dsByKernelVersion)
@@ -188,7 +184,7 @@ func (r *ModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return res, fmt.Errorf("failed to update status of the module: %w", err)
 	}
 
-	logger.Info("Garbage-collected DaemonSets", "names", deleted)
+	logger.Info("Reconcile loop finished successfully")
 
 	return res, nil
 }
@@ -370,6 +366,32 @@ func (r *ModuleReconciler) handleDevicePlugin(ctx context.Context, mod *kmmv1bet
 	}
 
 	return err
+}
+
+func (r *ModuleReconciler) garbageCollect(ctx context.Context,
+	mod *kmmv1beta1.Module,
+	mappings map[string]*kmmv1beta1.KernelMapping,
+	existingDS map[string]*appsv1.DaemonSet) error {
+	logger := log.FromContext(ctx)
+	// Garbage collect old DaemonSets for which there are no nodes.
+	validKernels := sets.StringKeySet(mappings)
+
+	deleted, err := r.daemonAPI.GarbageCollect(ctx, existingDS, validKernels)
+	if err != nil {
+		return fmt.Errorf("could not garbage collect DaemonSets: %v", err)
+	}
+
+	logger.Info("Garbage-collected DaemonSets", "names", deleted)
+
+	// Garbage collect for successfully finished build jobs
+	deleted, err = r.buildAPI.GarbageCollect(ctx, *mod)
+	if err != nil {
+		return fmt.Errorf("could not garbage collect build objects: %v", err)
+	}
+
+	logger.Info("Garbage-collected Build objects", "names", deleted)
+
+	return nil
 }
 
 func (r *ModuleReconciler) setKMMOMetrics(ctx context.Context) {

--- a/controllers/module_reconciler_test.go
+++ b/controllers/module_reconciler_test.go
@@ -167,6 +167,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		gomock.InOrder(
 			mockDC.EXPECT().ModuleDaemonSetsByKernelVersion(ctx, moduleName, namespace).Return(dsByKernelVersion, nil),
 			mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString()),
+			mockBM.EXPECT().GarbageCollect(ctx, mod),
 			mockSU.EXPECT().ModuleUpdateStatus(ctx, &mod, []v1.Node{}, []v1.Node{}, dsByKernelVersion).Return(nil),
 		)
 
@@ -233,6 +234,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		gomock.InOrder(
 			mockDC.EXPECT().ModuleDaemonSetsByKernelVersion(ctx, moduleName, namespace).Return(dsByKernelVersion, nil),
 			mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString()),
+			mockBM.EXPECT().GarbageCollect(ctx, mod),
 			mockSU.EXPECT().ModuleUpdateStatus(ctx, &mod, []v1.Node{}, []v1.Node{}, dsByKernelVersion).Return(nil),
 		)
 
@@ -299,6 +301,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		gomock.InOrder(
 			mockDC.EXPECT().ModuleDaemonSetsByKernelVersion(ctx, moduleName, namespace).Return(dsByKernelVersion, nil),
 			mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString()),
+			mockBM.EXPECT().GarbageCollect(ctx, mod),
 			mockSU.EXPECT().ModuleUpdateStatus(ctx, &mod, []v1.Node{}, []v1.Node{}, dsByKernelVersion).Return(nil),
 		)
 
@@ -375,6 +378,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		gomock.InOrder(
 			mockDC.EXPECT().ModuleDaemonSetsByKernelVersion(ctx, moduleName, namespace).Return(dsByKernelVersion, nil),
 			mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString()),
+			mockBM.EXPECT().GarbageCollect(ctx, mod),
 			mockSU.EXPECT().ModuleUpdateStatus(ctx, &mod, []v1.Node{}, []v1.Node{}, dsByKernelVersion).Return(nil),
 		)
 
@@ -481,6 +485,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			clnt.EXPECT().Create(ctx, gomock.Any()).Return(nil),
 			mockMetrics.EXPECT().SetCompletedStage(moduleName, namespace, kernelVersion, metrics.ModuleLoaderStage, false),
 			mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString(kernelVersion)),
+			mockBM.EXPECT().GarbageCollect(ctx, mod),
 			mockSU.EXPECT().ModuleUpdateStatus(ctx, &mod, nodeList.Items, nodeList.Items, dsByKernelVersion).Return(nil),
 		)
 
@@ -600,6 +605,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 					d.SetLabels(map[string]string{"test": "test"})
 				}),
 			mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString(kernelVersion)),
+			mockBM.EXPECT().GarbageCollect(ctx, mod),
 			mockSU.EXPECT().ModuleUpdateStatus(ctx, &mod, nodeList.Items, nodeList.Items, dsByKernelVersion).Return(nil),
 		)
 
@@ -691,6 +697,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			clnt.EXPECT().Create(ctx, gomock.Any()).Return(nil),
 			mockMetrics.EXPECT().SetCompletedStage(moduleName, namespace, "", metrics.DevicePluginStage, false),
 			mockDC.EXPECT().GarbageCollect(ctx, nil, sets.NewString()),
+			mockBM.EXPECT().GarbageCollect(ctx, mod),
 			mockSU.EXPECT().ModuleUpdateStatus(ctx, &mod, []v1.Node{}, []v1.Node{}, nil).Return(nil),
 		)
 

--- a/internal/build/buildconfig/manager.go
+++ b/internal/build/buildconfig/manager.go
@@ -35,6 +35,12 @@ func NewManager(client client.Client, maker Maker, ocpBuildsHelper OpenShiftBuil
 	}
 }
 
+func (bcm *buildConfigManager) GarbageCollect(ctx context.Context, mod kmmv1beta1.Module) ([]string, error) {
+
+	//Garbage Collection noti (yet) implemented for BuildConfig
+	return nil, nil
+}
+
 func (bcm *buildConfigManager) Sync(ctx context.Context, mod kmmv1beta1.Module, m kmmv1beta1.KernelMapping,
 	targetKernel, targetImage string, pushImage bool, kernelOsDtkMapping syncronizedmap.KernelOsDtkMapping) (build.Result, error) {
 

--- a/internal/build/manager.go
+++ b/internal/build/manager.go
@@ -25,4 +25,5 @@ type Result struct {
 type Manager interface {
 	Sync(ctx context.Context, mod kmmv1beta1.Module, m kmmv1beta1.KernelMapping, targetKernel string, targetImage string,
 		pushImage bool, kernelOsDtkMapping syncronizedmap.KernelOsDtkMapping) (Result, error)
+	GarbageCollect(ctx context.Context, mod kmmv1beta1.Module) ([]string, error)
 }

--- a/internal/build/mock_manager.go
+++ b/internal/build/mock_manager.go
@@ -36,6 +36,21 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 	return m.recorder
 }
 
+// GarbageCollect mocks base method.
+func (m *MockManager) GarbageCollect(ctx context.Context, mod v1beta1.Module) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GarbageCollect", ctx, mod)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GarbageCollect indicates an expected call of GarbageCollect.
+func (mr *MockManagerMockRecorder) GarbageCollect(ctx, mod interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockManager)(nil).GarbageCollect), ctx, mod)
+}
+
 // Sync mocks base method.
 func (m_2 *MockManager) Sync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping, targetKernel, targetImage string, pushImage bool, kernelOsDtkMapping syncronizedmap.KernelOsDtkMapping) (Result, error) {
 	m_2.ctrl.T.Helper()

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -6,4 +6,5 @@ const (
 	NodeLabelerFinalizer         = "kmm.node.kubernetes.io/node-labeler"
 	TargetKernelTarget           = "kmm.node.kubernetes.io/target-kernel"
 	JobType                      = "kmm.node.kubernetes.io/job-type"
+	JobHashAnnotation            = "kmm.node.kubernetes.io/last-hash"
 )

--- a/internal/sign/job/manager.go
+++ b/internal/sign/job/manager.go
@@ -37,7 +37,7 @@ func (jbm *signJobManager) Sync(ctx context.Context, mod kmmv1beta1.Module, m km
 		return utils.Result{}, fmt.Errorf("could not make Job template: %v", err)
 	}
 
-	job, err := jbm.jobHelper.GetJob(ctx, mod.Namespace, "sign", jobLabels)
+	job, err := jbm.jobHelper.GetModuleJobByKernel(ctx, mod, targetKernel, utils.JobTypeSign)
 	// if theres an error getting jobs explode
 	if err != nil {
 		return utils.Result{}, fmt.Errorf("error getting the signing job: %v", err)

--- a/internal/sign/job/manager_test.go
+++ b/internal/sign/job/manager_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/sign"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	batchv1 "k8s.io/api/batch/v1"
@@ -29,10 +30,9 @@ var _ = Describe("JobManager", func() {
 			previousImageName = "previous-image"
 			namespace         = "some-namespace"
 
-			moduleName        = "module-name"
-			kernelVersion     = "1.2.3"
-			jobName           = "some-job"
-			jobHashAnnotation = "kmm.node.kubernetes.io/last-hash"
+			moduleName    = "module-name"
+			kernelVersion = "1.2.3"
+			jobName       = "some-job"
 		)
 
 		BeforeEach(func() {
@@ -66,7 +66,7 @@ var _ = Describe("JobManager", func() {
 							"kmm.node.kubernetes.io/target-kernel": kernelVersion,
 						},
 						Namespace:   namespace,
-						Annotations: map[string]string{jobHashAnnotation: "some hash"},
+						Annotations: map[string]string{constants.JobHashAnnotation: "some hash"},
 					},
 					Status: s,
 				}
@@ -77,7 +77,7 @@ var _ = Describe("JobManager", func() {
 							"kmm.node.kubernetes.io/target-kernel": kernelVersion,
 						},
 						Namespace:   namespace,
-						Annotations: map[string]string{jobHashAnnotation: "some hash"},
+						Annotations: map[string]string{constants.JobHashAnnotation: "some hash"},
 					},
 					Status: s,
 				}
@@ -93,7 +93,7 @@ var _ = Describe("JobManager", func() {
 
 					jobhelper.EXPECT().JobLabels(mod, kernelVersion, "sign").Return(labels),
 					maker.EXPECT().MakeJobTemplate(mod, km.Sign, kernelVersion, previousImageName, km.ContainerImage, labels, true).Return(&j, nil),
-					jobhelper.EXPECT().GetJob(ctx, "", "sign", labels).Return(&newJob, nil),
+					jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod, kernelVersion, utils.JobTypeSign).Return(&newJob, nil),
 					jobhelper.EXPECT().IsJobChanged(&j, &newJob).Return(false, nil),
 					jobhelper.EXPECT().GetJobStatus(&newJob).Return(r.Status, r.Requeue, joberr),
 				)
@@ -150,7 +150,7 @@ var _ = Describe("JobManager", func() {
 				helper.EXPECT().GetRelevantSign(mod, km).Return(km.Sign),
 				jobhelper.EXPECT().JobLabels(mod, kernelVersion, "sign").Return(labels),
 				maker.EXPECT().MakeJobTemplate(mod, km.Sign, kernelVersion, previousImageName, km.ContainerImage, labels, true).Return(&j, nil),
-				jobhelper.EXPECT().GetJob(ctx, "", "sign", labels).Return(nil, errors.New("random error")),
+				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod, kernelVersion, utils.JobTypeSign).Return(nil, errors.New("random error")),
 			)
 
 			mgr := NewSignJobManager(maker, helper, jobhelper)
@@ -179,7 +179,7 @@ var _ = Describe("JobManager", func() {
 				helper.EXPECT().GetRelevantSign(mod, km).Return(km.Sign),
 				jobhelper.EXPECT().JobLabels(mod, kernelVersion, "sign").Return(labels),
 				maker.EXPECT().MakeJobTemplate(mod, km.Sign, kernelVersion, previousImageName, km.ContainerImage, labels, true).Return(&j, nil),
-				jobhelper.EXPECT().GetJob(ctx, "", "sign", labels).Return(nil, nil),
+				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod, kernelVersion, utils.JobTypeSign).Return(nil, nil),
 				jobhelper.EXPECT().CreateJob(ctx, &j).Return(errors.New("unable to create job")),
 			)
 
@@ -210,7 +210,7 @@ var _ = Describe("JobManager", func() {
 				helper.EXPECT().GetRelevantSign(mod, km).Return(km.Sign),
 				jobhelper.EXPECT().JobLabels(mod, kernelVersion, "sign").Return(labels),
 				maker.EXPECT().MakeJobTemplate(mod, km.Sign, kernelVersion, previousImageName, km.ContainerImage, labels, true).Return(&j, nil),
-				jobhelper.EXPECT().GetJob(ctx, "", "sign", labels).Return(nil, nil),
+				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod, kernelVersion, utils.JobTypeSign).Return(nil, nil),
 				jobhelper.EXPECT().CreateJob(ctx, &j).Return(nil),
 			)
 
@@ -234,7 +234,7 @@ var _ = Describe("JobManager", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        jobName,
 					Namespace:   namespace,
-					Annotations: map[string]string{jobHashAnnotation: "new hash"},
+					Annotations: map[string]string{constants.JobHashAnnotation: "new hash"},
 				},
 			}
 
@@ -242,7 +242,7 @@ var _ = Describe("JobManager", func() {
 				helper.EXPECT().GetRelevantSign(mod, km).Return(km.Sign),
 				jobhelper.EXPECT().JobLabels(mod, kernelVersion, "sign").Return(labels),
 				maker.EXPECT().MakeJobTemplate(mod, km.Sign, kernelVersion, previousImageName, km.ContainerImage, labels, true).Return(&newJob, nil),
-				jobhelper.EXPECT().GetJob(ctx, "", "sign", labels).Return(&newJob, nil),
+				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod, kernelVersion, utils.JobTypeSign).Return(&newJob, nil),
 				jobhelper.EXPECT().IsJobChanged(&newJob, &newJob).Return(true, nil),
 				jobhelper.EXPECT().DeleteJob(ctx, &newJob).Return(nil),
 			)

--- a/internal/utils/jobhelper.go
+++ b/internal/utils/jobhelper.go
@@ -4,6 +4,7 @@ package utils
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
@@ -16,13 +17,16 @@ import (
 type Status string
 
 const (
-	jobHashAnnotation = "kmm.node.kubernetes.io/last-hash"
+	JobTypeBuild = "build"
+	JobTypeSign  = "sign"
 
 	StatusCompleted  = "completed"
 	StatusCreated    = "created"
 	StatusInProgress = "in progress"
-	StatusFailed     = "Failed"
+	StatusFailed     = "failed"
 )
+
+var ErrNoMatchingJob = errors.New("no matching job")
 
 type Result struct {
 	Requeue bool
@@ -32,7 +36,8 @@ type Result struct {
 type JobHelper interface {
 	IsJobChanged(existingJob *batchv1.Job, newJob *batchv1.Job) (bool, error)
 	JobLabels(mod kmmv1beta1.Module, targetKernel string, jobType string) map[string]string
-	GetJob(ctx context.Context, namespace string, jobType string, labels map[string]string) (*batchv1.Job, error)
+	GetModuleJobByKernel(ctx context.Context, mod kmmv1beta1.Module, targetKernel, jobType string) (*batchv1.Job, error)
+	GetModuleJobs(ctx context.Context, mod kmmv1beta1.Module, jobType string) ([]batchv1.Job, error)
 	DeleteJob(ctx context.Context, job *batchv1.Job) error
 	CreateJob(ctx context.Context, jobTemplate *batchv1.Job) error
 	GetJobStatus(job *batchv1.Job) (Status, bool, error)
@@ -54,39 +59,36 @@ func (jh *jobHelper) IsJobChanged(existingJob *batchv1.Job, newJob *batchv1.Job)
 	if existingAnnotations == nil {
 		return false, fmt.Errorf("annotations are not present in the existing job %s", existingJob.Name)
 	}
-	if existingAnnotations[jobHashAnnotation] == newAnnotations[jobHashAnnotation] {
+	if existingAnnotations[constants.JobHashAnnotation] == newAnnotations[constants.JobHashAnnotation] {
 		return false, nil
 	}
 	return true, nil
 }
 
 func (jh *jobHelper) JobLabels(mod kmmv1beta1.Module, targetKernel string, jobType string) map[string]string {
-	return map[string]string{
-		constants.ModuleNameLabel:    mod.Name,
-		constants.TargetKernelTarget: targetKernel,
-		constants.JobType:            jobType,
-	}
+	return moduleKernelLabels(mod.Name, targetKernel, jobType)
 }
 
-func (jh *jobHelper) GetJob(ctx context.Context, namespace string, jobType string, labels map[string]string) (*batchv1.Job, error) {
-	jobList := batchv1.JobList{}
-
-	opts := []client.ListOption{
-		client.MatchingLabels(labels),
-		client.InNamespace(namespace),
+func (jh *jobHelper) GetModuleJobByKernel(ctx context.Context, mod kmmv1beta1.Module, targetKernel, jobType string) (*batchv1.Job, error) {
+	matchLabels := moduleKernelLabels(mod.Name, targetKernel, jobType)
+	jobs, err := jh.getJobs(ctx, mod.Namespace, matchLabels)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get module %s, jobs by kernel %s: %v", mod.Name, targetKernel, err)
 	}
 
-	if err := jh.client.List(ctx, &jobList, opts...); err != nil {
-		return nil, fmt.Errorf("could not list jobs: %v", err)
+	numFoundJobs := len(jobs)
+	if numFoundJobs == 0 {
+		return nil, ErrNoMatchingJob
+	} else if numFoundJobs > 1 {
+		return nil, fmt.Errorf("expected 0 or 1 %s job, got %d", jobType, numFoundJobs)
 	}
 
-	if n := len(jobList.Items); n == 0 {
-		return nil, nil
-	} else if n > 1 {
-		return nil, fmt.Errorf("expected 0 or 1 %s job, got %d", jobType, n)
-	}
+	return &jobs[0], nil
+}
 
-	return &jobList.Items[0], nil
+func (jh *jobHelper) GetModuleJobs(ctx context.Context, mod kmmv1beta1.Module, jobType string) ([]batchv1.Job, error) {
+	matchLabels := moduleLabels(mod.Name, jobType)
+	return jh.getJobs(ctx, mod.Namespace, matchLabels)
 }
 
 func (jh *jobHelper) DeleteJob(ctx context.Context, job *batchv1.Job) error {
@@ -125,5 +127,31 @@ func (jh *jobHelper) GetJobStatus(job *batchv1.Job) (Status, bool, error) {
 		return StatusFailed, false, fmt.Errorf("job failed")
 	default:
 		return StatusFailed, false, fmt.Errorf("unknown status: %v", job.Status)
+	}
+}
+
+func (jh *jobHelper) getJobs(ctx context.Context, namespace string, labels map[string]string) ([]batchv1.Job, error) {
+	jobList := batchv1.JobList{}
+	opts := []client.ListOption{
+		client.MatchingLabels(labels),
+		client.InNamespace(namespace),
+	}
+	if err := jh.client.List(ctx, &jobList, opts...); err != nil {
+		return nil, fmt.Errorf("could not list jobs: %v", err)
+	}
+
+	return jobList.Items, nil
+}
+
+func moduleKernelLabels(moduleName, targetKernel, jobType string) map[string]string {
+	labels := moduleLabels(moduleName, jobType)
+	labels[constants.TargetKernelTarget] = targetKernel
+	return labels
+}
+
+func moduleLabels(moduleName, jobType string) map[string]string {
+	return map[string]string{
+		constants.ModuleNameLabel: moduleName,
+		constants.JobType:         jobType,
 	}
 }

--- a/internal/utils/mock_jobhelper.go
+++ b/internal/utils/mock_jobhelper.go
@@ -64,21 +64,6 @@ func (mr *MockJobHelperMockRecorder) DeleteJob(ctx, job interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteJob", reflect.TypeOf((*MockJobHelper)(nil).DeleteJob), ctx, job)
 }
 
-// GetJob mocks base method.
-func (m *MockJobHelper) GetJob(ctx context.Context, namespace, jobType string, labels map[string]string) (*v1.Job, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetJob", ctx, namespace, jobType, labels)
-	ret0, _ := ret[0].(*v1.Job)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetJob indicates an expected call of GetJob.
-func (mr *MockJobHelperMockRecorder) GetJob(ctx, namespace, jobType, labels interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetJob", reflect.TypeOf((*MockJobHelper)(nil).GetJob), ctx, namespace, jobType, labels)
-}
-
 // GetJobStatus mocks base method.
 func (m *MockJobHelper) GetJobStatus(job *v1.Job) (Status, bool, error) {
 	m.ctrl.T.Helper()
@@ -93,6 +78,36 @@ func (m *MockJobHelper) GetJobStatus(job *v1.Job) (Status, bool, error) {
 func (mr *MockJobHelperMockRecorder) GetJobStatus(job interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetJobStatus", reflect.TypeOf((*MockJobHelper)(nil).GetJobStatus), job)
+}
+
+// GetModuleJobByKernel mocks base method.
+func (m *MockJobHelper) GetModuleJobByKernel(ctx context.Context, mod v1beta1.Module, targetKernel, jobType string) (*v1.Job, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetModuleJobByKernel", ctx, mod, targetKernel, jobType)
+	ret0, _ := ret[0].(*v1.Job)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetModuleJobByKernel indicates an expected call of GetModuleJobByKernel.
+func (mr *MockJobHelperMockRecorder) GetModuleJobByKernel(ctx, mod, targetKernel, jobType interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleJobByKernel", reflect.TypeOf((*MockJobHelper)(nil).GetModuleJobByKernel), ctx, mod, targetKernel, jobType)
+}
+
+// GetModuleJobs mocks base method.
+func (m *MockJobHelper) GetModuleJobs(ctx context.Context, mod v1beta1.Module, jobType string) ([]v1.Job, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetModuleJobs", ctx, mod, jobType)
+	ret0, _ := ret[0].([]v1.Job)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetModuleJobs indicates an expected call of GetModuleJobs.
+func (mr *MockJobHelperMockRecorder) GetModuleJobs(ctx, mod, jobType interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleJobs", reflect.TypeOf((*MockJobHelper)(nil).GetModuleJobs), ctx, mod, jobType)
 }
 
 // IsJobChanged mocks base method.


### PR DESCRIPTION
This PR contains the following changes:
    1) implement garbage collection for successful build jobs and pods
    2) refactoring jobhelper package and moving build code to use it
    3) refactoring/adding unit-test
