### PR TITLE
Add code to the reconcile loop for signing of kmods for secureboot

### DIFF
--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	buildv1 "github.com/openshift/api/build/v1"
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
@@ -30,8 +31,10 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/module"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/rbac"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/registry"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/sign"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/statusupdater"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/syncronizedmap"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -54,6 +57,7 @@ type ModuleReconciler struct {
 
 	authFactory        auth.RegistryAuthGetterFactory
 	buildAPI           build.Manager
+	signAPI            sign.SignManager
 	rbacAPI            rbac.RBACCreator
 	daemonAPI          daemonset.DaemonSetCreator
 	kernelAPI          module.KernelMapper
@@ -67,6 +71,7 @@ type ModuleReconciler struct {
 func NewModuleReconciler(
 	client client.Client,
 	buildAPI build.Manager,
+	signAPI sign.SignManager,
 	rbacAPI rbac.RBACCreator,
 	daemonAPI daemonset.DaemonSetCreator,
 	kernelAPI module.KernelMapper,
@@ -80,6 +85,7 @@ func NewModuleReconciler(
 		Client:             client,
 		authFactory:        authFactory,
 		buildAPI:           buildAPI,
+		signAPI:            signAPI,
 		rbacAPI:            rbacAPI,
 		daemonAPI:          daemonAPI,
 		kernelAPI:          kernelAPI,
@@ -157,6 +163,16 @@ func (r *ModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		}
 		if requeue {
 			logger.Info("Build requires a requeue; skipping handling driver container for now", "kernelVersion", kernelVersion, "image", m)
+			res.Requeue = true
+			continue
+		}
+
+		signrequeue, err := r.handleSigning(ctx, mod, m, kernelVersion, m.ContainerImage)
+		if err != nil {
+			return res, fmt.Errorf("failed to handle signing for kernel version %s: %v", kernelVersion, err)
+		}
+		if signrequeue {
+			logger.Info("Signing requires a requeue; skipping handling driver container for now", "kernelVersion", kernelVersion, "image", m)
 			res.Requeue = true
 			continue
 		}
@@ -262,13 +278,22 @@ func (r *ModuleReconciler) handleBuild(ctx context.Context,
 	km *kmmv1beta1.KernelMapping,
 	kernelVersion string,
 	containerImage string) (bool, error) {
-	if mod.Spec.ModuleLoader.Container.Build == nil && km.Build == nil {
+
+	//if theres no build specified skip this section
+	if !r.willBuild(mod, km) {
 		return false, nil
+	}
+	//if build is specified AND sign is specified then we want to build an intermediate image
+	// and let sign produce the one specified in containerImage
+	if r.willSign(mod, km) {
+		containerImage = r.appendToTag(containerImage, mod.Namespace+"_"+mod.Name+"_kmm_unsigned")
 	}
 
 	logger := log.FromContext(ctx, "kernel version", kernelVersion, "image", containerImage)
 	logger.Info("Trying to pull the output image")
 
+	// build is specified and containerImage is either the final image, or the intermediate image tag depending on if sign is defined
+	// either way if containerImage exists we can skip building it
 	exists, err := r.checkImageExists(ctx, mod, km, containerImage)
 	if err != nil {
 		return false, fmt.Errorf("failed to check existence of image %s for kernel %s: %w", containerImage, kernelVersion, err)
@@ -294,6 +319,79 @@ func (r *ModuleReconciler) handleBuild(ctx context.Context,
 	}
 
 	return buildRes.Requeue, nil
+}
+
+// is sign defined in the CR
+func (r *ModuleReconciler) willSign(mod *kmmv1beta1.Module, km *kmmv1beta1.KernelMapping) bool {
+	if mod.Spec.ModuleLoader.Container.Sign == nil && km.Sign == nil {
+		return false
+	}
+	return true
+}
+
+// is build defined in the CR
+func (r *ModuleReconciler) willBuild(mod *kmmv1beta1.Module, km *kmmv1beta1.KernelMapping) bool {
+	if mod.Spec.ModuleLoader.Container.Build == nil && km.Build == nil {
+		return false
+	}
+	return true
+}
+
+// append tag to the image name cleanly, avoiding messing up the name or getting "name:-tag"
+func (r *ModuleReconciler) appendToTag(name string, tag string) string {
+	if strings.Contains(name, ":") {
+		return name + "_" + tag
+	} else {
+		return name + ":" + tag
+	}
+
+}
+
+func (r *ModuleReconciler) handleSigning(ctx context.Context,
+	mod *kmmv1beta1.Module,
+	km *kmmv1beta1.KernelMapping,
+	kernelVersion string,
+	containerImage string) (bool, error) {
+
+	// if sign is not specified skip
+	if !r.willSign(mod, km) {
+		return false, nil
+	}
+
+	// if its already built, skip
+	exists, err := r.checkImageExists(ctx, mod, km, containerImage)
+	if err != nil {
+		return false, fmt.Errorf("failed to check existence of image %s for kernel %s: %w", containerImage, kernelVersion, err)
+	}
+	if exists {
+		return false, nil
+	}
+
+	// if we need to sign AND we've built, then we must have built the intermediate image so must figure out its name
+	previousImage := ""
+	if r.willBuild(mod, km) {
+		previousImage = r.appendToTag(containerImage, mod.Namespace+"_"+mod.Name+"_kmm_unsigned")
+		if err != nil {
+			return false, err
+		}
+	}
+
+	logger := log.FromContext(ctx).WithValues("kernel version", kernelVersion, "image", containerImage)
+	signCtx := log.IntoContext(ctx, logger)
+
+	signRes, err := r.signAPI.Sync(signCtx, *mod, *km, kernelVersion, previousImage, containerImage, true)
+	if err != nil {
+		return false, fmt.Errorf("could not synchronize the signing: %w", err)
+	}
+
+	switch signRes.Status {
+	case utils.StatusCreated:
+		r.metricsAPI.SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.SignStage, false)
+	case utils.StatusCompleted:
+		r.metricsAPI.SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.SignStage, true)
+	}
+
+	return signRes.Requeue, nil
 }
 
 func (r *ModuleReconciler) checkImageExists(ctx context.Context, mod *kmmv1beta1.Module, km *kmmv1beta1.KernelMapping, imageName string) (bool, error) {

--- a/controllers/module_reconciler_test.go
+++ b/controllers/module_reconciler_test.go
@@ -15,7 +15,9 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/module"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/rbac"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/registry"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/sign"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/statusupdater"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -35,6 +37,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		ctrl         *gomock.Controller
 		clnt         *client.MockClient
 		mockBM       *build.MockManager
+		mockSM       *sign.MockSignManager
 		mockRC       *rbac.MockRBACCreator
 		mockDC       *daemonset.MockDaemonSetCreator
 		mockKM       *module.MockKernelMapper
@@ -47,6 +50,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
 		mockBM = build.NewMockManager(ctrl)
+		mockSM = sign.NewMockSignManager(ctrl)
 		mockRC = rbac.NewMockRBACCreator(ctrl)
 		mockDC = daemonset.NewMockDaemonSetCreator(ctrl)
 		mockKM = module.NewMockKernelMapper(ctrl)
@@ -77,6 +81,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		mr := NewModuleReconciler(
 			clnt,
 			mockBM,
+			mockSM,
 			mockRC,
 			mockDC,
 			mockKM,
@@ -151,6 +156,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		mr := NewModuleReconciler(
 			clnt,
 			mockBM,
+			mockSM,
 			mockRC,
 			mockDC,
 			mockKM,
@@ -218,6 +224,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		mr := NewModuleReconciler(
 			clnt,
 			mockBM,
+			mockSM,
 			mockRC,
 			mockDC,
 			mockKM,
@@ -285,6 +292,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		mr := NewModuleReconciler(
 			clnt,
 			mockBM,
+			mockSM,
 			mockRC,
 			mockDC,
 			mockKM,
@@ -362,6 +370,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		mr := NewModuleReconciler(
 			clnt,
 			mockBM,
+			mockSM,
 			mockRC,
 			mockDC,
 			mockKM,
@@ -438,6 +447,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		mr := NewModuleReconciler(
 			clnt,
 			mockBM,
+			mockSM,
 			mockRC,
 			mockDC,
 			mockKM,
@@ -582,6 +592,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		mr := NewModuleReconciler(
 			clnt,
 			mockBM,
+			mockSM,
 			mockRC,
 			mockDC,
 			mockKM,
@@ -652,6 +663,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		mr := NewModuleReconciler(
 			clnt,
 			mockBM,
+			mockSM,
 			mockRC,
 			mockDC,
 			mockKM,
@@ -714,6 +726,7 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 		clnt            *client.MockClient
 		mockAuthFactory *auth.MockRegistryAuthGetterFactory
 		mockBM          *build.MockManager
+		mockSM          *sign.MockSignManager
 		mockRC          *rbac.MockRBACCreator
 		mockDC          *daemonset.MockDaemonSetCreator
 		mockKM          *module.MockKernelMapper
@@ -727,6 +740,7 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 		clnt = client.NewMockClient(ctrl)
 		mockAuthFactory = auth.NewMockRegistryAuthGetterFactory(ctrl)
 		mockBM = build.NewMockManager(ctrl)
+		mockSM = sign.NewMockSignManager(ctrl)
 		mockRC = rbac.NewMockRBACCreator(ctrl)
 		mockDC = daemonset.NewMockDaemonSetCreator(ctrl)
 		mockKM = module.NewMockKernelMapper(ctrl)
@@ -752,6 +766,7 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 		mr := NewModuleReconciler(
 			clnt,
 			mockBM,
+			mockSM,
 			mockRC,
 			mockDC,
 			mockKM,
@@ -804,6 +819,7 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 		mr := NewModuleReconciler(
 			clnt,
 			mockBM,
+			mockSM,
 			mockRC,
 			mockDC,
 			mockKM,
@@ -849,6 +865,7 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 		mr := NewModuleReconciler(
 			clnt,
 			mockBM,
+			mockSM,
 			mockRC,
 			mockDC,
 			mockKM,
@@ -892,6 +909,7 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 		mr := NewModuleReconciler(
 			clnt,
 			mockBM,
+			mockSM,
 			mockRC,
 			mockDC,
 			mockKM,
@@ -935,6 +953,7 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 		mr := NewModuleReconciler(
 			clnt,
 			mockBM,
+			mockSM,
 			mockRC,
 			mockDC,
 			mockKM,
@@ -978,6 +997,7 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 		mr := NewModuleReconciler(
 			clnt,
 			mockBM,
+			mockSM,
 			mockRC,
 			mockDC,
 			mockKM,
@@ -996,6 +1016,322 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 
 })
 
+/***************** signing ***********************/
+var _ = Describe("ModuleReconciler_handleSigning", func() {
+	var (
+		ctrl            *gomock.Controller
+		clnt            *client.MockClient
+		mockBM          *build.MockManager
+		mockSM          *sign.MockSignManager
+		mockRC          *rbac.MockRBACCreator
+		mockDC          *daemonset.MockDaemonSetCreator
+		mockKM          *module.MockKernelMapper
+		mockMetrics     *metrics.MockMetrics
+		mockSU          *statusupdater.MockModuleStatusUpdater
+		mockRegistry    *registry.MockRegistry
+		mockAuthFactory *auth.MockRegistryAuthGetterFactory
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		mockAuthFactory = auth.NewMockRegistryAuthGetterFactory(ctrl)
+		mockBM = build.NewMockManager(ctrl)
+		mockSM = sign.NewMockSignManager(ctrl)
+		mockRC = rbac.NewMockRBACCreator(ctrl)
+		mockDC = daemonset.NewMockDaemonSetCreator(ctrl)
+		mockKM = module.NewMockKernelMapper(ctrl)
+		mockMetrics = metrics.NewMockMetrics(ctrl)
+		mockSU = statusupdater.NewMockModuleStatusUpdater(ctrl)
+		mockRegistry = registry.NewMockRegistry(ctrl)
+	})
+
+	const (
+		moduleName    = "test-module"
+		kernelVersion = "1.2.3"
+		imageName     = "test-image"
+	)
+
+	It("Sign missing in module and in kernel mapping", func() {
+		km := &kmmv1beta1.KernelMapping{
+			ContainerImage: imageName,
+			Literal:        kernelVersion,
+		}
+
+		mod := &kmmv1beta1.Module{}
+		mr := NewModuleReconciler(
+			clnt,
+			mockBM,
+			mockSM,
+			mockRC,
+			mockDC,
+			mockKM,
+			mockMetrics,
+			nil,
+			mockRegistry,
+			mockAuthFactory,
+			mockSU,
+			nil,
+		)
+
+		res, err := mr.handleSigning(context.Background(), mod, km, kernelVersion, km.ContainerImage)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(BeFalse())
+	})
+
+	It("Sign present, image exists", func() {
+		km := &kmmv1beta1.KernelMapping{
+			ContainerImage: imageName,
+			Literal:        kernelVersion,
+			Sign:           &kmmv1beta1.Sign{},
+		}
+		mod := &kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      moduleName,
+				Namespace: namespace,
+			},
+			Spec: kmmv1beta1.ModuleSpec{
+				ImageRepoSecret: &v1.LocalObjectReference{Name: "pull-push-secret"},
+			},
+		}
+
+		authGetter := &auth.MockRegistryAuthGetter{}
+		mockAuthFactory.EXPECT().NewRegistryAuthGetterFrom(mod).Return(authGetter)
+		mockRegistry.EXPECT().ImageExists(context.Background(), imageName, nil, gomock.Any()).DoAndReturn(
+			func(_ interface{}, _ interface{}, _ interface{}, registryAuthGetter auth.RegistryAuthGetter) (bool, error) {
+				Expect(registryAuthGetter).ToNot(BeNil())
+				return true, nil
+			},
+		)
+
+		mr := NewModuleReconciler(
+			clnt,
+			mockBM,
+			mockSM,
+			mockRC,
+			mockDC,
+			mockKM,
+			mockMetrics,
+			nil,
+			mockRegistry,
+			mockAuthFactory,
+			mockSU,
+			nil,
+		)
+
+		res, err := mr.handleSigning(context.Background(), mod, km, kernelVersion, km.ContainerImage)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(BeFalse())
+	})
+
+	It("Sign present, image does not exist, job created", func() {
+		km := &kmmv1beta1.KernelMapping{
+			ContainerImage: imageName,
+			Literal:        kernelVersion,
+			Sign:           &kmmv1beta1.Sign{},
+		}
+		mod := &kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      moduleName,
+				Namespace: namespace,
+			},
+			Spec: kmmv1beta1.ModuleSpec{},
+		}
+		signRes := utils.Result{Requeue: true, Status: utils.StatusCreated}
+		authGetter := &auth.MockRegistryAuthGetter{}
+		gomock.InOrder(
+			mockAuthFactory.EXPECT().NewRegistryAuthGetterFrom(mod).Return(authGetter),
+			mockRegistry.EXPECT().ImageExists(context.Background(), imageName, nil, gomock.Any()).Return(false, nil),
+			mockSM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), "", km.ContainerImage, true).Return(signRes, nil),
+			mockMetrics.EXPECT().SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.SignStage, false),
+		)
+		mr := NewModuleReconciler(
+			clnt,
+			mockBM,
+			mockSM,
+			mockRC,
+			mockDC,
+			mockKM,
+			mockMetrics,
+			nil,
+			mockRegistry,
+			mockAuthFactory,
+			mockSU,
+			nil,
+		)
+
+		res, err := mr.handleSigning(context.Background(), mod, km, kernelVersion, km.ContainerImage)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(BeTrue())
+	})
+
+	It("Sign present, image does not exist, job created", func() {
+		km := &kmmv1beta1.KernelMapping{
+			ContainerImage: imageName,
+			Literal:        kernelVersion,
+			Sign:           &kmmv1beta1.Sign{},
+		}
+		mod := &kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      moduleName,
+				Namespace: namespace,
+			},
+			Spec: kmmv1beta1.ModuleSpec{},
+		}
+		buildRes := utils.Result{Requeue: true, Status: utils.StatusCreated}
+		authGetter := &auth.MockRegistryAuthGetter{}
+		gomock.InOrder(
+			mockAuthFactory.EXPECT().NewRegistryAuthGetterFrom(mod).Return(authGetter),
+			mockRegistry.EXPECT().ImageExists(context.Background(), imageName, nil, gomock.Any()).Return(false, nil),
+			mockSM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), "", km.ContainerImage, true).Return(buildRes, nil),
+			mockMetrics.EXPECT().SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.SignStage, false),
+		)
+
+		mr := NewModuleReconciler(
+			clnt,
+			mockBM,
+			mockSM,
+			mockRC,
+			mockDC,
+			mockKM,
+			mockMetrics,
+			nil,
+			mockRegistry,
+			mockAuthFactory,
+			mockSU,
+			nil,
+		)
+		res, err := mr.handleSigning(context.Background(), mod, km, kernelVersion, km.ContainerImage)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(BeTrue())
+	})
+
+	It("Sign present, image does not exist, job completed", func() {
+		km := &kmmv1beta1.KernelMapping{
+			ContainerImage: imageName,
+			Literal:        kernelVersion,
+			Sign:           &kmmv1beta1.Sign{},
+		}
+		mod := &kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      moduleName,
+				Namespace: namespace,
+			},
+			Spec: kmmv1beta1.ModuleSpec{},
+		}
+		signRes := utils.Result{Requeue: false, Status: build.StatusCompleted}
+		authGetter := &auth.MockRegistryAuthGetter{}
+		gomock.InOrder(
+			mockAuthFactory.EXPECT().NewRegistryAuthGetterFrom(mod).Return(authGetter),
+			mockRegistry.EXPECT().ImageExists(context.Background(), imageName, nil, gomock.Any()).Return(false, nil),
+			mockSM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), "", km.ContainerImage, true).Return(signRes, nil),
+			mockMetrics.EXPECT().SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.SignStage, true),
+		)
+
+		mr := NewModuleReconciler(
+			clnt,
+			mockBM,
+			mockSM,
+			mockRC,
+			mockDC,
+			mockKM,
+			mockMetrics,
+			nil,
+			mockRegistry,
+			mockAuthFactory,
+			mockSU,
+			nil,
+		)
+		res, err := mr.handleSigning(context.Background(), mod, km, kernelVersion, km.ContainerImage)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(BeFalse())
+	})
+	It("Sign present, Build present, image does not exist, job completed", func() {
+		km := &kmmv1beta1.KernelMapping{
+			ContainerImage: imageName,
+			Literal:        kernelVersion,
+			Sign:           &kmmv1beta1.Sign{},
+			Build:          &kmmv1beta1.Build{},
+		}
+		mod := &kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      moduleName,
+				Namespace: namespace,
+			},
+			Spec: kmmv1beta1.ModuleSpec{},
+		}
+		signRes := utils.Result{Requeue: false, Status: build.StatusCompleted}
+		authGetter := &auth.MockRegistryAuthGetter{}
+		gomock.InOrder(
+			mockAuthFactory.EXPECT().NewRegistryAuthGetterFrom(mod).Return(authGetter),
+			mockRegistry.EXPECT().ImageExists(context.Background(), imageName, nil, gomock.Any()).Return(false, nil),
+			mockSM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), imageName+":"+namespace+"_"+moduleName+"_kmm_unsigned", km.ContainerImage, true).Return(signRes, nil),
+			mockMetrics.EXPECT().SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.SignStage, true),
+		)
+
+		mr := NewModuleReconciler(
+			clnt,
+			mockBM,
+			mockSM,
+			mockRC,
+			mockDC,
+			mockKM,
+			mockMetrics,
+			nil,
+			mockRegistry,
+			mockAuthFactory,
+			mockSU,
+			nil,
+		)
+		res, err := mr.handleSigning(context.Background(), mod, km, kernelVersion, km.ContainerImage)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(BeFalse())
+	})
+	It("Sign present, Build present, image does not exist, job completed", func() {
+		km := &kmmv1beta1.KernelMapping{
+			ContainerImage: imageName + ":test",
+			Literal:        kernelVersion,
+			Sign:           &kmmv1beta1.Sign{},
+			Build:          &kmmv1beta1.Build{},
+		}
+		mod := &kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      moduleName,
+				Namespace: namespace,
+			},
+			Spec: kmmv1beta1.ModuleSpec{},
+		}
+		signRes := utils.Result{Requeue: false, Status: build.StatusCompleted}
+		authGetter := &auth.MockRegistryAuthGetter{}
+		gomock.InOrder(
+			mockAuthFactory.EXPECT().NewRegistryAuthGetterFrom(mod).Return(authGetter),
+			mockRegistry.EXPECT().ImageExists(context.Background(), imageName+":test", nil, gomock.Any()).Return(false, nil),
+			mockSM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), imageName+":test_"+namespace+"_"+moduleName+"_kmm_unsigned", km.ContainerImage, true).Return(signRes, nil),
+			mockMetrics.EXPECT().SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.SignStage, true),
+		)
+
+		mr := NewModuleReconciler(
+			clnt,
+			mockBM,
+			mockSM,
+			mockRC,
+			mockDC,
+			mockKM,
+			mockMetrics,
+			nil,
+			mockRegistry,
+			mockAuthFactory,
+			mockSU,
+			nil,
+		)
+		res, err := mr.handleSigning(context.Background(), mod, km, kernelVersion, km.ContainerImage)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).To(BeFalse())
+	})
+})
+
+/***************** end signing ***********************/
+
 var _ = Describe("ModuleReconciler_getNodesListBySelector", func() {
 	var (
 		ctrl *gomock.Controller
@@ -1006,7 +1342,7 @@ var _ = Describe("ModuleReconciler_getNodesListBySelector", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
-		mr = NewModuleReconciler(clnt, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		mr = NewModuleReconciler(clnt, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	})
 
 	ctx := context.Background()
@@ -1023,6 +1359,7 @@ var _ = Describe("ModuleReconciler_getNodesListBySelector", func() {
 				return nil
 			},
 		)
+		//mr := NewModuleReconciler(clnt, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		nodeList, err := mr.getNodesListBySelector(context.Background(), &mod)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(nodeList)).To(Equal(0))
@@ -1035,6 +1372,7 @@ var _ = Describe("ModuleReconciler_getNodesListBySelector", func() {
 				return nil
 			},
 		)
+		//mr := NewModuleReconciler(clnt, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		nodeList, err := mr.getNodesListBySelector(context.Background(), &mod)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(nodeList)).To(Equal(2))
@@ -1056,6 +1394,7 @@ var _ = Describe("ModuleReconciler_getNodesListBySelector", func() {
 				return nil
 			},
 		)
+		//mr := NewModuleReconciler(clnt, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		nodeList, err := mr.getNodesListBySelector(context.Background(), &mod)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(nodeList)).To(Equal(1))

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -10,6 +10,7 @@ const (
 	existingKMMOModulesQuery = "kmmo_module_total"
 	completedKMMOStageQuery  = "kmmo_completed_stage"
 	BuildStage               = "build"
+	SignStage                = "sign"
 	ModuleLoaderStage        = "module-loader"
 	DevicePluginStage        = "device-plugin"
 )

--- a/internal/sign/job/manager.go
+++ b/internal/sign/job/manager.go
@@ -2,6 +2,7 @@ package signjob
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
@@ -38,16 +39,15 @@ func (jbm *signJobManager) Sync(ctx context.Context, mod kmmv1beta1.Module, m km
 	}
 
 	job, err := jbm.jobHelper.GetModuleJobByKernel(ctx, mod, targetKernel, utils.JobTypeSign)
-	// if theres an error getting jobs explode
 	if err != nil {
-		return utils.Result{}, fmt.Errorf("error getting the signing job: %v", err)
-	}
-	// if there are no errors getting jobs, but there are no jobs either, we need to create it
-	if job == nil {
-		logger.Info("Creating job")
+		if !errors.Is(err, utils.ErrNoMatchingJob) {
+			return utils.Result{}, fmt.Errorf("error getting the signing job: %v", err)
+		}
 
-		if err = jbm.jobHelper.CreateJob(ctx, jobTemplate); err != nil {
-			return utils.Result{}, fmt.Errorf("could not create Job: %v", err)
+		logger.Info("Creating job")
+		err = jbm.jobHelper.CreateJob(ctx, jobTemplate)
+		if err != nil {
+			return utils.Result{}, fmt.Errorf("could not create Signing Job: %v", err)
 		}
 
 		return utils.Result{Status: utils.StatusCreated, Requeue: true}, nil

--- a/internal/sign/job/manager_test.go
+++ b/internal/sign/job/manager_test.go
@@ -179,7 +179,7 @@ var _ = Describe("JobManager", func() {
 				helper.EXPECT().GetRelevantSign(mod, km).Return(km.Sign),
 				jobhelper.EXPECT().JobLabels(mod, kernelVersion, "sign").Return(labels),
 				maker.EXPECT().MakeJobTemplate(mod, km.Sign, kernelVersion, previousImageName, km.ContainerImage, labels, true).Return(&j, nil),
-				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod, kernelVersion, utils.JobTypeSign).Return(nil, nil),
+				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod, kernelVersion, utils.JobTypeSign).Return(nil, utils.ErrNoMatchingJob),
 				jobhelper.EXPECT().CreateJob(ctx, &j).Return(errors.New("unable to create job")),
 			)
 
@@ -210,7 +210,7 @@ var _ = Describe("JobManager", func() {
 				helper.EXPECT().GetRelevantSign(mod, km).Return(km.Sign),
 				jobhelper.EXPECT().JobLabels(mod, kernelVersion, "sign").Return(labels),
 				maker.EXPECT().MakeJobTemplate(mod, km.Sign, kernelVersion, previousImageName, km.ContainerImage, labels, true).Return(&j, nil),
-				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod, kernelVersion, utils.JobTypeSign).Return(nil, nil),
+				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod, kernelVersion, utils.JobTypeSign).Return(nil, utils.ErrNoMatchingJob),
 				jobhelper.EXPECT().CreateJob(ctx, &j).Return(nil),
 			)
 


### PR DESCRIPTION
This is the last part of the secureboot signing code and provides the required code in the reconcile loop to detect if the CR contains a Sign stanza, and if so makes the required calls into the internal/sign library to instantiate and manage the signing job.
    
    - It changes the handleBuild() function to check if a Sign stanza is defined, if so it outputs an intermediate image named spec.containerImage+"-unsigned"
    - It then adds a handleSigning() function that will consume this intermediate image, run the signing job and produce the final spec.containerImage image
    
It is this final image that is then loaded by the daemonset.
    
 It also makes sure is Sign is not defined handleBuild() still does the right thing and handleSigning() consumes sign.UnsignedImage if a Build stanza is not defined.