### PR TITLE
Add the GitStream GitHub Action

### DIFF
--- a/.github/gitstream.yml
+++ b/.github/gitstream.yml
@@ -1,0 +1,22 @@
+commit_markup: Upstream-Commit
+
+downstream:
+  create_draft_prs: true
+  github_repo_name: rh-ecosystem-edge/kernel-module-management
+  local_repo_path: _gitstream_downstream
+  max_open_items: 3
+
+log_level: 1000
+
+diff:
+  commits_since: 2022-08-31T00:00:00.00Z
+
+sync:
+  before_commit:
+    - [go, mod, tidy]
+    - [go, mod, vendor]
+
+upstream:
+  ref: main
+  url: https://github.com/kubernetes-sigs/kernel-module-management
+

--- a/.github/workflows/gitstream.yml
+++ b/.github/workflows/gitstream.yml
@@ -1,0 +1,41 @@
+name: GitStream
+
+on:
+  schedule:
+    - cron: '*/20 * * * *'
+
+jobs:
+  gitstream:
+    name: Install and run GitStream
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Checkout the downstream repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: main
+          path: _gitstream_downstream
+
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+
+      - name: Install GitStream
+        run: go install github.com/qbarrand/gitstream@main
+        env:
+          GOPROXY: direct
+
+      - name: Bring upstream commits
+        run: ${HOME}/go/bin/gitstream sync
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Make the oldest draft PR ready for review
+        run: ${HOME}/go/bin/gitstream make-oldest-draft-pr-ready
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Only process commits created after the split between upstream and midstream repos.
Run go mod {tidy,vendor} after each cherry-pick.
Limit the number of simultaneous open issues to 3. Create draft PRs and make the oldest one ready for review.

/cc @ybettan @yevgeny-shnaidman @enriquebelarte @mresvanis