### PR TITLE
Moving build implementation from BuildConfig to Build

### DIFF
--- a/Dockerfile.kmm-operator-build
+++ b/Dockerfile.kmm-operator-build
@@ -8,7 +8,7 @@ ENV GOARCH=amd64
 
 RUN yum install -y which
 RUN yum install -y podman docker
-RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.1
+RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2
 RUN curl -L --retry 5 "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.3.0/kustomize_v4.3.0_linux_amd64.tar.gz" | \
     tar -zx -C /usr/bin
 RUN go install github.com/golang/mock/mockgen@v1.5.0

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen
 .PHONY: controller-gen
 controller-gen: ## Download controller-gen locally if necessary.
-	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.8.0)
+	$(call go-get-tool,$(CONTROLLER_GEN),sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2)
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 .PHONY: golangci-lint

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -19,21 +19,13 @@ rules:
 - apiGroups:
   - build.openshift.io
   resources:
-  - buildconfigs
+  - builds
   verbs:
   - create
   - delete
   - get
   - list
   - patch
-  - watch
-- apiGroups:
-  - build.openshift.io
-  resources:
-  - builds
-  verbs:
-  - get
-  - list
   - watch
 - apiGroups:
   - ""

--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -107,8 +107,7 @@ func NewModuleReconciler(
 //+kubebuilder:rbac:groups=security.openshift.io,resources=securitycontextconstraints,verbs=use,resourceNames=privileged
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=create;delete;get;list;patch;watch
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=clusterroles,verbs=bind,resourceNames=module-loader;device-plugin
-//+kubebuilder:rbac:groups="build.openshift.io",resources=buildconfigs,verbs=create;delete;get;list;patch;watch
-//+kubebuilder:rbac:groups="build.openshift.io",resources=builds,verbs=get;list;watch
+//+kubebuilder:rbac:groups="build.openshift.io",resources=builds,verbs=get;list;create;delete;watch;patch
 
 // Reconcile lists all nodes and looks for kernels that match its mappings.
 // For each mapping that matches at least one node in the cluster, it creates a DaemonSet running the container image
@@ -518,7 +517,7 @@ func (r *ModuleReconciler) SetupWithManager(mgr ctrl.Manager, kernelLabel string
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kmmv1beta1.Module{}).
 		Owns(&appsv1.DaemonSet{}).
-		Owns(&buildv1.BuildConfig{}).
+		Owns(&buildv1.Build{}).
 		Owns(&v1.ServiceAccount{}).
 		Watches(
 			&source.Kind{Type: &v1.Node{}},

--- a/internal/build/buildconfig/maker_test.go
+++ b/internal/build/buildconfig/maker_test.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-var _ = Describe("Maker_MakeBuildConfigTemplate", func() {
+var _ = Describe("Maker_MakeBuildTemplate", func() {
 
 	It("should work as expected", func() {
 
@@ -76,7 +76,7 @@ var _ = Describe("Maker_MakeBuildConfigTemplate", func() {
 			},
 		}
 
-		expected := buildv1.BuildConfig{
+		expected := buildv1.Build{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: moduleName + "-",
 				Namespace:    namespace,
@@ -94,11 +94,7 @@ var _ = Describe("Maker_MakeBuildConfigTemplate", func() {
 					},
 				},
 			},
-			Spec: buildv1.BuildConfigSpec{
-				Triggers: []buildv1.BuildTriggerPolicy{
-					{Type: buildv1.ConfigChangeBuildTriggerType},
-				},
-				RunPolicy: buildv1.BuildRunPolicySerialLatestOnly,
+			Spec: buildv1.BuildSpec{
 				CommonSpec: buildv1.CommonSpec{
 					ServiceAccount: "builder",
 					Source: buildv1.BuildSource{
@@ -130,10 +126,10 @@ var _ = Describe("Maker_MakeBuildConfigTemplate", func() {
 
 		hash, err := hashstructure.Hash(expected.Spec.CommonSpec.Source, nil)
 		Expect(err).NotTo(HaveOccurred())
-		annotations := map[string]string{buildConfigHashAnnotation: fmt.Sprintf("%d", hash)}
+		annotations := map[string]string{buildHashAnnotation: fmt.Sprintf("%d", hash)}
 		expected.SetAnnotations(annotations)
 
-		bc, err := NewMaker(build.NewHelper(), scheme).MakeBuildConfigTemplate(mod, mapping, targetKernel,
+		bc, err := NewMaker(build.NewHelper(), scheme).MakeBuildTemplate(mod, mapping, targetKernel,
 			containerImage, true, nil)
 		Expect(err).NotTo(HaveOccurred())
 
@@ -171,7 +167,7 @@ var _ = Describe("Maker_MakeBuildConfigTemplate", func() {
 				mockKODM.EXPECT().GetImage(gomock.Any()).Return("", errors.New("random error")),
 			)
 
-			_, err := maker.MakeBuildConfigTemplate(kmmv1beta1.Module{}, kmmv1beta1.KernelMapping{}, "", "", false, mockKODM)
+			_, err := maker.MakeBuildTemplate(kmmv1beta1.Module{}, kmmv1beta1.KernelMapping{}, "", "", false, mockKODM)
 			Expect(err).To(HaveOccurred())
 		})
 
@@ -196,7 +192,7 @@ var _ = Describe("Maker_MakeBuildConfigTemplate", func() {
 				mockBuildHelper.EXPECT().ApplyBuildArgOverrides(gomock.Any(), gomock.Any()).Return(buildArgs),
 			)
 
-			bct, err := maker.MakeBuildConfigTemplate(kmmv1beta1.Module{}, kmmv1beta1.KernelMapping{}, "", "", false, mockKODM)
+			bct, err := maker.MakeBuildTemplate(kmmv1beta1.Module{}, kmmv1beta1.KernelMapping{}, "", "", false, mockKODM)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(bct.Spec.CommonSpec.Strategy.DockerStrategy.BuildArgs)).To(Equal(1))
 			Expect(bct.Spec.CommonSpec.Strategy.DockerStrategy.BuildArgs[0].Name).To(Equal(buildArgs[0].Name))

--- a/internal/build/buildconfig/mock_maker.go
+++ b/internal/build/buildconfig/mock_maker.go
@@ -36,17 +36,17 @@ func (m *MockMaker) EXPECT() *MockMakerMockRecorder {
 	return m.recorder
 }
 
-// MakeBuildConfigTemplate mocks base method.
-func (m *MockMaker) MakeBuildConfigTemplate(mod v1beta1.Module, mapping v1beta1.KernelMapping, targetKernel, containerImage string, pushImage bool, kernelOsDtkMapping syncronizedmap.KernelOsDtkMapping) (*v1.BuildConfig, error) {
+// MakeBuildTemplate mocks base method.
+func (m *MockMaker) MakeBuildTemplate(mod v1beta1.Module, mapping v1beta1.KernelMapping, targetKernel, containerImage string, pushImage bool, kernelOsDtkMapping syncronizedmap.KernelOsDtkMapping) (*v1.Build, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MakeBuildConfigTemplate", mod, mapping, targetKernel, containerImage, pushImage, kernelOsDtkMapping)
-	ret0, _ := ret[0].(*v1.BuildConfig)
+	ret := m.ctrl.Call(m, "MakeBuildTemplate", mod, mapping, targetKernel, containerImage, pushImage, kernelOsDtkMapping)
+	ret0, _ := ret[0].(*v1.Build)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// MakeBuildConfigTemplate indicates an expected call of MakeBuildConfigTemplate.
-func (mr *MockMakerMockRecorder) MakeBuildConfigTemplate(mod, mapping, targetKernel, containerImage, pushImage, kernelOsDtkMapping interface{}) *gomock.Call {
+// MakeBuildTemplate indicates an expected call of MakeBuildTemplate.
+func (mr *MockMakerMockRecorder) MakeBuildTemplate(mod, mapping, targetKernel, containerImage, pushImage, kernelOsDtkMapping interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeBuildConfigTemplate", reflect.TypeOf((*MockMaker)(nil).MakeBuildConfigTemplate), mod, mapping, targetKernel, containerImage, pushImage, kernelOsDtkMapping)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeBuildTemplate", reflect.TypeOf((*MockMaker)(nil).MakeBuildTemplate), mod, mapping, targetKernel, containerImage, pushImage, kernelOsDtkMapping)
 }

--- a/internal/build/buildconfig/mock_manager.go
+++ b/internal/build/buildconfig/mock_manager.go
@@ -36,32 +36,17 @@ func (m *MockOpenShiftBuildsHelper) EXPECT() *MockOpenShiftBuildsHelperMockRecor
 	return m.recorder
 }
 
-// GetBuildConfig mocks base method.
-func (m *MockOpenShiftBuildsHelper) GetBuildConfig(ctx context.Context, mod v1beta1.Module, targetKernel string) (*v1.BuildConfig, error) {
+// GetBuild mocks base method.
+func (m *MockOpenShiftBuildsHelper) GetBuild(ctx context.Context, mod v1beta1.Module, targetKernel string) (*v1.Build, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBuildConfig", ctx, mod, targetKernel)
-	ret0, _ := ret[0].(*v1.BuildConfig)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetBuildConfig indicates an expected call of GetBuildConfig.
-func (mr *MockOpenShiftBuildsHelperMockRecorder) GetBuildConfig(ctx, mod, targetKernel interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBuildConfig", reflect.TypeOf((*MockOpenShiftBuildsHelper)(nil).GetBuildConfig), ctx, mod, targetKernel)
-}
-
-// GetLatestBuild mocks base method.
-func (m *MockOpenShiftBuildsHelper) GetLatestBuild(ctx context.Context, namespace, buildConfigName string) (*v1.Build, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetLatestBuild", ctx, namespace, buildConfigName)
+	ret := m.ctrl.Call(m, "GetBuild", ctx, mod, targetKernel)
 	ret0, _ := ret[0].(*v1.Build)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetLatestBuild indicates an expected call of GetLatestBuild.
-func (mr *MockOpenShiftBuildsHelperMockRecorder) GetLatestBuild(ctx, namespace, buildConfigName interface{}) *gomock.Call {
+// GetBuild indicates an expected call of GetBuild.
+func (mr *MockOpenShiftBuildsHelperMockRecorder) GetBuild(ctx, mod, targetKernel interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLatestBuild", reflect.TypeOf((*MockOpenShiftBuildsHelper)(nil).GetLatestBuild), ctx, namespace, buildConfigName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBuild", reflect.TypeOf((*MockOpenShiftBuildsHelper)(nil).GetBuild), ctx, mod, targetKernel)
 }

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -14,10 +14,10 @@ import (
 )
 
 const (
-	VerificationStatusReasonBuildConfigPresent = "Verification successful, all driver-containers have paired BuildConfigs in the recipe"
-	VerificationStatusReasonNoDaemonSet        = "Verification successful, no driver-container present in the recipe"
-	VerificationStatusReasonUnknown            = "Verification has not started yet"
-	VerificationStatusReasonVerified           = "Verification successful, this Module would be verified again in this Preflight CR"
+	VerificationStatusReasonBuildConfigurationPresent = "Verification successful, all driver-containers have paired Build Configurations in the recipe"
+	VerificationStatusReasonNoDaemonSet               = "Verification successful, no driver-container present in the recipe"
+	VerificationStatusReasonUnknown                   = "Verification has not started yet"
+	VerificationStatusReasonVerified                  = "Verification successful, this Module would be verified again in this Preflight CR"
 )
 
 //go:generate mockgen -source=preflight.go -package=preflight -destination=mock_preflight_api.go


### PR DESCRIPTION
Since changes to BuildConfig status does no produce events for reconciliation, we move KKM to work with Builds. This PR's changes are:
1) use Build as an entity for schedule module loader Builds 2) module reconciler is watching only builds
3) changes to unit tests