### PR TITLE
Add kanikoParams to the CRD to match upstream

### DIFF
--- a/api/v1beta1/module_types.go
+++ b/api/v1beta1/module_types.go
@@ -49,6 +49,12 @@ type PushOptions struct {
 	InsecureSkipTLSVerify bool `json:"insecureSkipTLSVerify,omitempty"`
 }
 
+type KanikoParams struct {
+	// +optional
+	// Kaniko image tag to use when creating the build Job
+	Tag string `json:"tag,omitempty"`
+}
+
 type Build struct {
 	// +optional
 	// BuildArgs is an array of build variables that are provided to the image building backend.
@@ -69,6 +75,10 @@ type Build struct {
 	// Those secrets should be used for private resources such as a private Github repo.
 	// For container registries auth use module.spec.imagePullSecret instead.
 	Secrets []v1.LocalObjectReference `json:"secrets"`
+
+	// +optional
+	// KanikoParams is used to customize the building process of the image.
+	KanikoParams *KanikoParams `json:"kanikoParams,omitempty"`
 }
 
 type Sign struct {

--- a/bundle/manifests/kmm.sigs.k8s.io_modules.yaml
+++ b/bundle/manifests/kmm.sigs.k8s.io_modules.yaml
@@ -1892,6 +1892,15 @@ spec:
                             type: array
                           dockerfile:
                             type: string
+                          kanikoParams:
+                            description: KanikoParams is used to customize the building
+                              process of the image.
+                            properties:
+                              tag:
+                                description: Kaniko image tag to use when creating
+                                  the build Job
+                                type: string
+                            type: object
                           pull:
                             description: Pull contains settings determining how to
                               pull the base images of the build process.
@@ -1981,6 +1990,15 @@ spec:
                                   type: array
                                 dockerfile:
                                   type: string
+                                kanikoParams:
+                                  description: KanikoParams is used to customize the
+                                    building process of the image.
+                                  properties:
+                                    tag:
+                                      description: Kaniko image tag to use when creating
+                                        the build Job
+                                      type: string
+                                  type: object
                                 pull:
                                   description: Pull contains settings determining
                                     how to pull the base images of the build process.

--- a/config/crd/bases/kmm.sigs.k8s.io_modules.yaml
+++ b/config/crd/bases/kmm.sigs.k8s.io_modules.yaml
@@ -1892,6 +1892,15 @@ spec:
                             type: array
                           dockerfile:
                             type: string
+                          kanikoParams:
+                            description: KanikoParams is used to customize the building
+                              process of the image.
+                            properties:
+                              tag:
+                                description: Kaniko image tag to use when creating
+                                  the build Job
+                                type: string
+                            type: object
                           pull:
                             description: Pull contains settings determining how to
                               pull the base images of the build process.
@@ -1981,6 +1990,15 @@ spec:
                                   type: array
                                 dockerfile:
                                   type: string
+                                kanikoParams:
+                                  description: KanikoParams is used to customize the
+                                    building process of the image.
+                                  properties:
+                                    tag:
+                                      description: Kaniko image tag to use when creating
+                                        the build Job
+                                      type: string
+                                  type: object
                                 pull:
                                   description: Pull contains settings determining
                                     how to pull the base images of the build process.


### PR DESCRIPTION
Allow the user to configure which image's tag from kaniko want to use for the building process ([MGMT-11383](https://issues.redhat.com//browse/MGMT-11383))

Fixes #130 by only bringing the CRD changes. We want to remain fully CRD-compatible with upstream, but the associated logic cannot be implemented as we do not use Kaniko in OCP.

Upstream-Commit: 4cedc9e84d655ab56ce561ccfe01c4482bd1c7e5