### PR TITLE
Ignore mocks in test coverage report via codecov config (#36)

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "**/mock_*.go"


### PR DESCRIPTION
Codecov is configured to ignore mocks when generating its coverage report, instead of manually removing mocks from the unit test coverage report.

- https://docs.codecov.com/docs/codecov-yaml
- https://docs.codecov.com/docs/codecovyml-reference#ignore

Signed-off-by: Michail Resvanis <mresvani@redhat.com>

Signed-off-by: Michail Resvanis <mresvani@redhat.com>

Fixes #133

Upstream-Commit: ee64914e7ecd6109bbe7ea5d59fb22c68056a787