### PR TITLE
Signing jobmanager requires permissions to add/delete/list jobs

### DIFF
--- a/bundle/manifests/kmm-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/kmm-operator.clusterserviceversion.yaml
@@ -51,23 +51,24 @@ spec:
           - patch
           - watch
         - apiGroups:
-          - build.openshift.io
+          - batch
           resources:
-          - buildconfigs
+          - jobs
           verbs:
           - create
           - delete
-          - get
           - list
-          - patch
           - watch
         - apiGroups:
           - build.openshift.io
           resources:
           - builds
           verbs:
+          - create
+          - delete
           - get
           - list
+          - patch
           - watch
         - apiGroups:
           - ""

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -17,6 +17,15 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - list
+  - watch
+- apiGroups:
   - build.openshift.io
   resources:
   - builds

--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -108,6 +108,7 @@ func NewModuleReconciler(
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=rolebindings,verbs=create;delete;get;list;patch;watch
 //+kubebuilder:rbac:groups="rbac.authorization.k8s.io",resources=clusterroles,verbs=bind,resourceNames=module-loader;device-plugin
 //+kubebuilder:rbac:groups="build.openshift.io",resources=builds,verbs=get;list;create;delete;watch;patch
+//+kubebuilder:rbac:groups="batch",resources=jobs,verbs=create;list;watch;delete
 
 // Reconcile lists all nodes and looks for kernels that match its mappings.
 // For each mapping that matches at least one node in the cluster, it creates a DaemonSet running the container image


### PR DESCRIPTION
Signing jobmanager needs to be able to create the signing job and tell when it has completed.

(These permissions are in upstream for the kaniko build job, but weren't needed here for buildconfig. Now we need them here as well)