### PR TITLE
Install Go as we need it for the post cherry-pick commands

### DIFF
--- a/.github/workflows/gitstream.yml
+++ b/.github/workflows/gitstream.yml
@@ -35,6 +35,11 @@ jobs:
           ref: main
           path: _gitstream_downstream
 
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.19'
+
       - name: Bring upstream commits
         run: gitstream sync
         env:


### PR DESCRIPTION
The current GitStream config runs two `go` commands after each cherry-pick: https://github.com/rh-ecosystem-edge/kernel-module-management/blob/main/.github/gitstream.yml#L16-L17

Setup Go in the GitStream CI workflow to be able to run those commands.