### PR TITLE
Remove /usr/lib references at DaemonSet (#50)

### DIFF
--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -22,10 +22,7 @@ import (
 const (
 	kubeletDevicePluginsVolumeName = "kubelet-device-plugins"
 	kubeletDevicePluginsPath       = "/var/lib/kubelet/device-plugins"
-	nodeLibModulesPath             = "/lib/modules"
 	nodeLibModulesVolumeName       = "node-lib-modules"
-	nodeUsrLibModulesPath          = "/usr/lib/modules"
-	nodeUsrLibModulesVolumeName    = "node-usr-lib-modules"
 	nodeVarLibFirmwarePath         = "/var/lib/firmware"
 	nodeVarLibFirmwareVolumeName   = "node-var-lib-firmware"
 	devicePluginKernelVersion      = ""
@@ -118,6 +115,8 @@ func (dc *daemonSetGenerator) SetDriverContainerAsDesired(ctx context.Context, d
 	nodeSelector := CopyMapStringString(mod.Spec.Selector)
 	nodeSelector[dc.kernelLabel] = kernelVersion
 
+	nodeLibModulesPath := "/lib/modules/" + kernelVersion
+
 	hostPathDirectory := v1.HostPathDirectory
 	hostPathDirectoryOrCreate := v1.HostPathDirectoryOrCreate
 
@@ -154,11 +153,6 @@ func (dc *daemonSetGenerator) SetDriverContainerAsDesired(ctx context.Context, d
 				ReadOnly:  true,
 				MountPath: nodeLibModulesPath,
 			},
-			{
-				Name:      nodeUsrLibModulesVolumeName,
-				ReadOnly:  true,
-				MountPath: nodeUsrLibModulesPath,
-			},
 		},
 	}
 
@@ -168,15 +162,6 @@ func (dc *daemonSetGenerator) SetDriverContainerAsDesired(ctx context.Context, d
 			VolumeSource: v1.VolumeSource{
 				HostPath: &v1.HostPathVolumeSource{
 					Path: nodeLibModulesPath,
-					Type: &hostPathDirectory,
-				},
-			},
-		},
-		{
-			Name: nodeUsrLibModulesVolumeName,
-			VolumeSource: v1.VolumeSource{
-				HostPath: &v1.HostPathVolumeSource{
-					Path: nodeUsrLibModulesPath,
 					Type: &hostPathDirectory,
 				},
 			},

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -77,7 +77,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 		err := dg.SetDriverContainerAsDesired(context.Background(), &ds, "test-image", mod, kernelVersion)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ds.Spec.Template.Spec.Containers).To(HaveLen(1))
-		Expect(ds.Spec.Template.Spec.Volumes).To(HaveLen(2))
+		Expect(ds.Spec.Template.Spec.Volumes).To(HaveLen(1))
 	})
 
 	It("should add the volume and volume mount for firmware if FirmwarePath is set", func() {
@@ -116,10 +116,10 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 		err := dg.SetDriverContainerAsDesired(context.Background(), &ds, "test-image", mod, kernelVersion)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(ds.Spec.Template.Spec.Volumes).To(HaveLen(3))
-		Expect(ds.Spec.Template.Spec.Volumes[2]).To(Equal(vol))
-		Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts).To(HaveLen(3))
-		Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts[2]).To(Equal(volm))
+		Expect(ds.Spec.Template.Spec.Volumes).To(HaveLen(2))
+		Expect(ds.Spec.Template.Spec.Volumes[1]).To(Equal(vol))
+		Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts).To(HaveLen(2))
+		Expect(ds.Spec.Template.Spec.Containers[0].VolumeMounts[1]).To(Equal(volm))
 	})
 
 	It("should add the default ServiceAccount to the module loader if it is not set in the spec", func() {
@@ -143,7 +143,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 			imageRepoSecretName = "image-repo-secret"
 			serviceAccountName  = "driver-service-account"
 		)
-
+		fullModulesPath := "/lib/modules/" + kernelVersion
 		mod := kmmv1beta1.Module{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: kmmv1beta1.GroupVersion.String(),
@@ -227,12 +227,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 									{
 										Name:      "node-lib-modules",
 										ReadOnly:  true,
-										MountPath: "/lib/modules",
-									},
-									{
-										Name:      "node-usr-lib-modules",
-										ReadOnly:  true,
-										MountPath: "/usr/lib/modules",
+										MountPath: fullModulesPath,
 									},
 								},
 								SecurityContext: &v1.SecurityContext{
@@ -261,16 +256,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 								Name: "node-lib-modules",
 								VolumeSource: v1.VolumeSource{
 									HostPath: &v1.HostPathVolumeSource{
-										Path: "/lib/modules",
-										Type: &directory,
-									},
-								},
-							},
-							{
-								Name: "node-usr-lib-modules",
-								VolumeSource: v1.VolumeSource{
-									HostPath: &v1.HostPathVolumeSource{
-										Path: "/usr/lib/modules",
+										Path: fullModulesPath,
 										Type: &directory,
 									},
 								},


### PR DESCRIPTION
In most cases shared libraries directory /lib is a dynamic link to
 /usr/lib but in some other cases as Ubuntu 18.04 LTS or Debian 11,
those directories have completely different content. In any case in-tree modules can be found on /lib/modules/KERNEL_VERSION/ so in order to avoid compatibility issues depending which OS Kubernetes nodes are running we should stick to /lib as a mount point for DaemonSet. Also nodeLibModulesPath has been restricted to /lib/modules/KERNEL_VERSION/.

/cc @enriquebelarte

Upstream-Commit: f7499feba6f2978d897b9b14c93a208b612131eb