### PR TITLE
adding build verification to preflight (#65)

### DIFF
--- a/api/v1beta1/preflightvalidation_types.go
+++ b/api/v1beta1/preflightvalidation_types.go
@@ -21,10 +21,12 @@ import (
 )
 
 const (
-	VerificationTrue       string = "True"
-	VerificationFalse      string = "False"
-	VerificationStageImage string = "Image"
-	VerificationStageBuild string = "Build"
+	VerificationTrue          string = "True"
+	VerificationFalse         string = "False"
+	VerificationStageImage    string = "Image"
+	VerificationStageBuild    string = "Build"
+	VerificationStageRequeued string = "Requeued"
+	VerificationStageDone     string = "Done"
 )
 
 // PreflightValidationSpec describes the desired state of the resource, such as the kernel version
@@ -53,7 +55,7 @@ type CRStatus struct {
 	// image (image existence verification), build(build process verification)
 	// +required
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=Image;Build
+	// +kubebuilder:validation:Enum=Image;Build;Requeued;Done
 	VerificationStage string `json:"verificationStage"`
 
 	// LastTransitionTime is the last time the CR status transitioned from one status to another.

--- a/config/crd/bases/kmm.sigs.k8s.io_preflightvalidations.yaml
+++ b/config/crd/bases/kmm.sigs.k8s.io_preflightvalidations.yaml
@@ -72,6 +72,8 @@ spec:
                       enum:
                       - Image
                       - Build
+                      - Requeued
+                      - Done
                       type: string
                     verificationStatus:
                       description: 'Status of Module CR verification: true (verified),

--- a/internal/preflight/mock_preflight_api.go
+++ b/internal/preflight/mock_preflight_api.go
@@ -36,16 +36,69 @@ func (m *MockPreflightAPI) EXPECT() *MockPreflightAPIMockRecorder {
 }
 
 // PreflightUpgradeCheck mocks base method.
-func (m *MockPreflightAPI) PreflightUpgradeCheck(ctx context.Context, mod *v1beta1.Module, kernelVersion string) (bool, string) {
+func (m *MockPreflightAPI) PreflightUpgradeCheck(ctx context.Context, pv *v1beta1.PreflightValidation, mod *v1beta1.Module, kernelVersion string) (bool, string) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PreflightUpgradeCheck", ctx, mod, kernelVersion)
+	ret := m.ctrl.Call(m, "PreflightUpgradeCheck", ctx, pv, mod, kernelVersion)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(string)
 	return ret0, ret1
 }
 
 // PreflightUpgradeCheck indicates an expected call of PreflightUpgradeCheck.
-func (mr *MockPreflightAPIMockRecorder) PreflightUpgradeCheck(ctx, mod, kernelVersion interface{}) *gomock.Call {
+func (mr *MockPreflightAPIMockRecorder) PreflightUpgradeCheck(ctx, pv, mod, kernelVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreflightUpgradeCheck", reflect.TypeOf((*MockPreflightAPI)(nil).PreflightUpgradeCheck), ctx, mod, kernelVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreflightUpgradeCheck", reflect.TypeOf((*MockPreflightAPI)(nil).PreflightUpgradeCheck), ctx, pv, mod, kernelVersion)
+}
+
+// MockpreflightHelperAPI is a mock of preflightHelperAPI interface.
+type MockpreflightHelperAPI struct {
+	ctrl     *gomock.Controller
+	recorder *MockpreflightHelperAPIMockRecorder
+}
+
+// MockpreflightHelperAPIMockRecorder is the mock recorder for MockpreflightHelperAPI.
+type MockpreflightHelperAPIMockRecorder struct {
+	mock *MockpreflightHelperAPI
+}
+
+// NewMockpreflightHelperAPI creates a new mock instance.
+func NewMockpreflightHelperAPI(ctrl *gomock.Controller) *MockpreflightHelperAPI {
+	mock := &MockpreflightHelperAPI{ctrl: ctrl}
+	mock.recorder = &MockpreflightHelperAPIMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockpreflightHelperAPI) EXPECT() *MockpreflightHelperAPIMockRecorder {
+	return m.recorder
+}
+
+// verifyBuild mocks base method.
+func (m *MockpreflightHelperAPI) verifyBuild(ctx context.Context, mapping *v1beta1.KernelMapping, mod *v1beta1.Module, kernelVersion string) (bool, string) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "verifyBuild", ctx, mapping, mod, kernelVersion)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(string)
+	return ret0, ret1
+}
+
+// verifyBuild indicates an expected call of verifyBuild.
+func (mr *MockpreflightHelperAPIMockRecorder) verifyBuild(ctx, mapping, mod, kernelVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "verifyBuild", reflect.TypeOf((*MockpreflightHelperAPI)(nil).verifyBuild), ctx, mapping, mod, kernelVersion)
+}
+
+// verifyImage mocks base method.
+func (m *MockpreflightHelperAPI) verifyImage(ctx context.Context, mapping *v1beta1.KernelMapping, mod *v1beta1.Module, kernelVersion string) (bool, string) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "verifyImage", ctx, mapping, mod, kernelVersion)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(string)
+	return ret0, ret1
+}
+
+// verifyImage indicates an expected call of verifyImage.
+func (mr *MockpreflightHelperAPIMockRecorder) verifyImage(ctx, mapping, mod, kernelVersion interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "verifyImage", reflect.TypeOf((*MockpreflightHelperAPI)(nil).verifyImage), ctx, mapping, mod, kernelVersion)
 }

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -6,47 +6,54 @@ import (
 
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/auth"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/build"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/module"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/registry"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/statusupdater"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/syncronizedmap"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
-	VerificationStatusReasonBuildConfigurationPresent = "Verification successful, all driver-containers have paired Build Configurations in the recipe"
-	VerificationStatusReasonNoDaemonSet               = "Verification successful, no driver-container present in the recipe"
-	VerificationStatusReasonUnknown                   = "Verification has not started yet"
-	VerificationStatusReasonVerified                  = "Verification successful, this Module would be verified again in this Preflight CR"
+	VerificationStatusReasonBuildConfigPresent = "Verification successful, all driver-containers have paired BuildConfigs in the recipe"
+	VerificationStatusReasonNoDaemonSet        = "Verification successful, no driver-container present in the recipe"
+	VerificationStatusReasonUnknown            = "Verification has not started yet"
+	VerificationStatusReasonVerified           = "Verification successful (%s), this Module will not be verified again in this Preflight CR"
 )
 
-//go:generate mockgen -source=preflight.go -package=preflight -destination=mock_preflight_api.go
+//go:generate mockgen -source=preflight.go -package=preflight -destination=mock_preflight_api.go PreflightAPI, preflightHelperAPI
 
 type PreflightAPI interface {
-	PreflightUpgradeCheck(ctx context.Context, mod *kmmv1beta1.Module, kernelVersion string) (bool, string)
+	PreflightUpgradeCheck(ctx context.Context, pv *kmmv1beta1.PreflightValidation, mod *kmmv1beta1.Module, kernelVersion string) (bool, string)
 }
 
 func NewPreflightAPI(
 	client client.Client,
+	buildAPI build.Manager,
 	registryAPI registry.Registry,
 	kernelAPI module.KernelMapper,
-	authFactory auth.RegistryAuthGetterFactory) PreflightAPI {
+	statusUpdater statusupdater.PreflightStatusUpdater,
+	authFactory auth.RegistryAuthGetterFactory,
+	kernelOsDtkMapping syncronizedmap.KernelOsDtkMapping) PreflightAPI {
+	helper := newPreflightHelper(client, buildAPI, registryAPI, authFactory, kernelOsDtkMapping)
 	return &preflight{
-		registryAPI: registryAPI,
-		kernelAPI:   kernelAPI,
-		client:      client,
-		authFactory: authFactory,
+		kernelAPI:     kernelAPI,
+		statusUpdater: statusUpdater,
+		helper:        helper,
 	}
 }
 
 type preflight struct {
-	client      client.Client
-	registryAPI registry.Registry
-	kernelAPI   module.KernelMapper
-	authFactory auth.RegistryAuthGetterFactory
+	kernelAPI     module.KernelMapper
+	statusUpdater statusupdater.PreflightStatusUpdater
+	helper        preflightHelperAPI
 }
 
-func (p *preflight) PreflightUpgradeCheck(ctx context.Context, mod *kmmv1beta1.Module, kernelVersion string) (bool, string) {
+func (p *preflight) PreflightUpgradeCheck(ctx context.Context, pv *kmmv1beta1.PreflightValidation, mod *kmmv1beta1.Module, kernelVersion string) (bool, string) {
+	log := ctrlruntime.LoggerFrom(ctx)
 	mapping, err := p.kernelAPI.FindMappingForKernel(mod.Spec.ModuleLoader.Container.KernelMappings, kernelVersion)
 	if err != nil {
 		return false, fmt.Sprintf("Failed to find kernel mapping in the module %s for kernel version %s", mod.Name, kernelVersion)
@@ -58,13 +65,52 @@ func (p *preflight) PreflightUpgradeCheck(ctx context.Context, mod *kmmv1beta1.M
 		return false, fmt.Sprintf("Failed to substitute template in kernel mapping in the module %s for kernel version %s", mod.Name, kernelVersion)
 	}
 
-	return p.verifyImage(ctx, mapping, mod, kernelVersion)
+	err = p.statusUpdater.PreflightSetVerificationStage(ctx, pv, mod.Name, kmmv1beta1.VerificationStageImage)
+	if err != nil {
+		log.Info(utils.WarnString("failed to update the stage of Module CR in preflight to image stage"), "module", mod.Name, "error", err)
+	}
+
+	imageVerified, msg := p.helper.verifyImage(ctx, mapping, mod, kernelVersion)
+	if imageVerified || (mapping.Build == nil && mod.Spec.ModuleLoader.Container.Build == nil) {
+		return imageVerified, msg
+	}
+
+	err = p.statusUpdater.PreflightSetVerificationStage(ctx, pv, mod.Name, kmmv1beta1.VerificationStageBuild)
+	if err != nil {
+		log.Info(utils.WarnString("failed to update the stage of Module CR in preflight to build stage"), "module", mod.Name, "error", err)
+	}
+
+	return p.helper.verifyBuild(ctx, mapping, mod, kernelVersion)
 }
 
-func (p *preflight) verifyImage(ctx context.Context, mapping *kmmv1beta1.KernelMapping, mod *kmmv1beta1.Module, kernelVersion string) (bool, string) {
+type preflightHelperAPI interface {
+	verifyImage(ctx context.Context, mapping *kmmv1beta1.KernelMapping, mod *kmmv1beta1.Module, kernelVersion string) (bool, string)
+	verifyBuild(ctx context.Context, mapping *kmmv1beta1.KernelMapping, mod *kmmv1beta1.Module, kernelVersion string) (bool, string)
+}
+
+type preflightHelper struct {
+	client             client.Client
+	registryAPI        registry.Registry
+	buildAPI           build.Manager
+	authFactory        auth.RegistryAuthGetterFactory
+	kernelOsDtkMapping syncronizedmap.KernelOsDtkMapping
+}
+
+func newPreflightHelper(client client.Client, buildAPI build.Manager, registryAPI registry.Registry,
+	authFactory auth.RegistryAuthGetterFactory, kernelOsDtkMapping syncronizedmap.KernelOsDtkMapping) preflightHelperAPI {
+	return &preflightHelper{
+		client:             client,
+		buildAPI:           buildAPI,
+		registryAPI:        registryAPI,
+		authFactory:        authFactory,
+		kernelOsDtkMapping: kernelOsDtkMapping,
+	}
+}
+
+func (p *preflightHelper) verifyImage(ctx context.Context, mapping *kmmv1beta1.KernelMapping, mod *kmmv1beta1.Module, kernelVersion string) (bool, string) {
 	log := ctrlruntime.LoggerFrom(ctx)
 	image := mapping.ContainerImage
-	moduleName := mod.Spec.ModuleLoader.Container.Modprobe.ModuleName
+	moduleFileName := mod.Spec.ModuleLoader.Container.Modprobe.ModuleName + ".ko"
 	baseDir := mod.Spec.ModuleLoader.Container.Modprobe.DirName
 
 	pullOptions := module.GetRelevantPullOptions(mod, mapping)
@@ -83,12 +129,25 @@ func (p *preflight) verifyImage(ctx context.Context, mapping *kmmv1beta1.KernelM
 		}
 
 		// check kernel module file present in the directory of the kernel lib modules
-		if p.registryAPI.VerifyModuleExists(layer, baseDir, kernelVersion, moduleName) {
-			return true, VerificationStatusReasonVerified
+		if p.registryAPI.VerifyModuleExists(layer, baseDir, kernelVersion, moduleFileName) {
+			return true, fmt.Sprintf(VerificationStatusReasonVerified, "image accessible and verified")
 		}
-		log.V(1).Info("module is not present in the current layer", "image", image, "module name", moduleName, "kernel", kernelVersion, "dir", baseDir)
+		log.V(1).Info("module is not present in the current layer", "image", image, "module file name", moduleFileName, "kernel", kernelVersion, "dir", baseDir)
 	}
 
-	log.Info("driver for kernel is not present in the image", "kernel", kernelVersion, "image", image)
+	log.Info("driver for kernel is not present in the image", "baseDir", baseDir, "kernel", kernelVersion, "moduleFileName", moduleFileName, "image", image)
 	return false, fmt.Sprintf("image %s does not contain kernel module for kernel %s on any layer", image, kernelVersion)
+}
+
+func (p *preflightHelper) verifyBuild(ctx context.Context, mapping *kmmv1beta1.KernelMapping, mod *kmmv1beta1.Module, kernelVersion string) (bool, string) {
+	// at this stage we know that eiher mapping Build or Container build are defined
+	buildRes, err := p.buildAPI.Sync(ctx, *mod, *mapping, kernelVersion, mapping.ContainerImage, false, p.kernelOsDtkMapping)
+	if err != nil {
+		return false, fmt.Sprintf("Failed to verify build for module %s, kernel version %s, error %s", mod.Name, kernelVersion, err)
+	}
+
+	if buildRes.Status == build.StatusCompleted {
+		return true, fmt.Sprintf(VerificationStatusReasonVerified, "build compiles")
+	}
+	return false, "Waiting for build verification"
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -101,7 +101,8 @@ func (r *registry) GetLayerByDigest(digest string, pullConfig *RepoPullConfig) (
 }
 
 func (r *registry) VerifyModuleExists(layer v1.Layer, pathPrefix, kernelVersion, moduleFileName string) bool {
-	fullPath := filepath.Join(pathPrefix, modulesLocationPath, kernelVersion, moduleFileName)
+	// in layers headers, there is no root prefix
+	fullPath := filepath.Join(strings.TrimPrefix(pathPrefix, "/"), modulesLocationPath, kernelVersion, moduleFileName)
 	_, err := r.getHeaderStreamFromLayer(layer, fullPath)
 	return err == nil
 }

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -339,7 +339,7 @@ var _ = Describe("VerifyModuleExists", func() {
 	reg := NewRegistry()
 
 	It("file is not present", func() {
-		const fileName = "/etc/fileName"
+		const fileName = "etc/fileName"
 		layer, err := prepareLayer(fileName, []byte("some data"))
 		Expect(err).ToNot(HaveOccurred())
 
@@ -348,7 +348,7 @@ var _ = Describe("VerifyModuleExists", func() {
 	})
 
 	It("file is present", func() {
-		const fileName = "/opt/lib/modules/somekernel/module_name.ko"
+		const fileName = "opt/lib/modules/somekernel/module_name.ko"
 		layer, err := prepareLayer(fileName, []byte("some data"))
 		Expect(err).ToNot(HaveOccurred())
 

--- a/main.go
+++ b/main.go
@@ -187,7 +187,7 @@ func main() {
 	preflightStatusUpdaterAPI := statusupdater.NewPreflightStatusUpdater(client)
 	registryAPI := registry.NewRegistry()
 	authFactory := auth.NewRegistryAuthGetterFactory(client, kubernetes.NewForConfigOrDie(restConfig))
-	preflightAPI := preflight.NewPreflightAPI(client, registryAPI, kernelAPI, authFactory)
+	preflightAPI := preflight.NewPreflightAPI(client, buildAPI, registryAPI, kernelAPI, preflightStatusUpdaterAPI, authFactory, kernelOsDtkMapping)
 
 	mc := controllers.NewModuleReconciler(
 		client,


### PR DESCRIPTION
In case image of the Module is not available or
is does not contain the correct driver version,
preflight will check if Build configuration exists in Module yaml, and if it does, then it will try to build it. In case build is successful, then the module is considered to be verified

Upstream PR for cherry-pick:
https://github.com/kubernetes-sigs/kernel-module-management/commit/54ec19e957fa30e6faf425fb120aadf2e640251e