### PR TITLE
Trim plus sign in kernel version (#77)

### DIFF
--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -216,7 +216,7 @@ func (r *ModuleReconciler) getRelevantKernelMappingsAndNodes(ctx context.Context
 
 	for _, node := range targetedNodes {
 		osConfig := r.kernelAPI.GetNodeOSConfig(&node)
-		kernelVersion := node.Status.NodeInfo.KernelVersion
+		kernelVersion := strings.TrimSuffix(node.Status.NodeInfo.KernelVersion, "+")
 
 		nodeLogger := logger.WithValues(
 			"node", node.Name,

--- a/controllers/node_kernel_reconciler.go
+++ b/controllers/node_kernel_reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/filter"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/syncronizedmap"
@@ -45,7 +46,7 @@ func (r *NodeKernelReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, fmt.Errorf("could not get node: %v", err)
 	}
 
-	kernelVersion := node.Status.NodeInfo.KernelVersion
+	kernelVersion := strings.TrimSuffix(node.Status.NodeInfo.KernelVersion, "+")
 	osImageVersion := osVersionRegexp.FindString(node.Status.NodeInfo.OSImage)
 	if osImageVersion == "" {
 		return ctrl.Result{}, fmt.Errorf("could not get node %s osImageVersion", node.Name)


### PR DESCRIPTION
Google Kubernetes Engine using COS as nodes sets

kernel versions ending in a '+' sign which

breaks KMM as it is not a valid ending

for Kubernetes labelling syntax

---
This is not really useful downstream, but we still backport to have the codebase as similar as possible.
Fixes #167
/cc @enriquebelarte @ybettan