### PR TITLE
Adding support for image push during preflight build verification (#76)

### DIFF
--- a/api/v1beta1/preflightvalidation_types.go
+++ b/api/v1beta1/preflightvalidation_types.go
@@ -37,6 +37,11 @@ type PreflightValidationSpec struct {
 	// KernelImage describes the kernel image that all Modules need to be checked against.
 	// +kubebuilder:validation:Required
 	KernelVersion string `json:"kernelVersion"`
+
+	// Boolean flag that determines whether images build during preflight must also
+	// be pushed to a defined repository
+	// +optional
+	PushBuiltImage bool `json:"pushBuiltImage"`
 }
 
 type CRStatus struct {

--- a/config/crd/bases/kmm.sigs.k8s.io_preflightvalidations.yaml
+++ b/config/crd/bases/kmm.sigs.k8s.io_preflightvalidations.yaml
@@ -44,6 +44,10 @@ spec:
                 description: KernelImage describes the kernel image that all Modules
                   need to be checked against.
                 type: string
+              pushBuiltImage:
+                description: Boolean flag that determines whether images build during
+                  preflight must also be pushed to a defined repository
+                type: boolean
             required:
             - kernelVersion
             type: object

--- a/controllers/preflightvalidation_reconciler.go
+++ b/controllers/preflightvalidation_reconciler.go
@@ -63,11 +63,11 @@ func NewPreflightValidationReconciler(
 func (r *PreflightValidationReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("preflightvalidation").
-		For(&kmmv1beta1.PreflightValidation{}).
+		For(&kmmv1beta1.PreflightValidation{}, builder.WithPredicates(filter.PreflightReconcilerUpdatePredicate())).
 		Watches(
 			&source.Kind{Type: &kmmv1beta1.Module{}},
 			handler.EnqueueRequestsFromMapFunc(r.filter.EnqueueAllPreflightValidations),
-			builder.WithPredicates(filter.PreflightReconcilerModulePredicate()),
+			builder.WithPredicates(filter.PreflightReconcilerUpdatePredicate()),
 		).
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 1,
@@ -120,7 +120,7 @@ func (r *PreflightValidationReconciler) runPreflightValidation(ctx context.Conte
 	for _, module := range modulesToCheck {
 		log.Info("start module preflight validation", "name", module.Name)
 
-		verified, message := r.preflight.PreflightUpgradeCheck(ctx, pv, &module, pv.Spec.KernelVersion)
+		verified, message := r.preflight.PreflightUpgradeCheck(ctx, pv, &module)
 
 		log.Info("module preflight validation result", "name", module.Name, "verified", verified)
 

--- a/controllers/preflightvalidation_reconciler_test.go
+++ b/controllers/preflightvalidation_reconciler_test.go
@@ -102,7 +102,7 @@ var _ = Describe("PreflightValidationReconciler_Reconcile", func() {
 				},
 			),
 			mockSU.EXPECT().PreflightPresetStatuses(ctx, &pv, sets.NewString(mod.Name), []string{}).Return(nil),
-			mockPreflight.EXPECT().PreflightUpgradeCheck(ctx, &pv, &mod, "some kernel version").Return(true, "some message"),
+			mockPreflight.EXPECT().PreflightUpgradeCheck(ctx, &pv, &mod).Return(true, "some message"),
 			mockSU.EXPECT().PreflightSetVerificationStatus(ctx, &pv, mod.Name, kmmv1beta1.VerificationTrue, "some message").Return(nil),
 			mockSU.EXPECT().PreflightSetVerificationStage(ctx, &pv, mod.Name, kmmv1beta1.VerificationStageDone).Return(nil),
 			clnt.EXPECT().Get(context.Background(), nsn, &kmmv1beta1.PreflightValidation{}).DoAndReturn(
@@ -153,7 +153,7 @@ var _ = Describe("PreflightValidationReconciler_Reconcile", func() {
 				},
 			),
 			mockSU.EXPECT().PreflightPresetStatuses(ctx, &pv, sets.NewString(mod.Name), []string{}).Return(nil),
-			mockPreflight.EXPECT().PreflightUpgradeCheck(ctx, &pv, &mod, "some kernel version").Return(true, "some message"),
+			mockPreflight.EXPECT().PreflightUpgradeCheck(ctx, &pv, &mod).Return(true, "some message"),
 			mockSU.EXPECT().PreflightSetVerificationStatus(ctx, &pv, mod.Name, kmmv1beta1.VerificationTrue, "some message").Return(nil),
 			mockSU.EXPECT().PreflightSetVerificationStage(ctx, &pv, mod.Name, kmmv1beta1.VerificationStageDone).Return(nil),
 			clnt.EXPECT().Get(context.Background(), nsn, &kmmv1beta1.PreflightValidation{}).DoAndReturn(

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -195,6 +195,6 @@ func PodReadinessChangedPredicate(logger logr.Logger) predicate.Predicate {
 	}
 }
 
-func PreflightReconcilerModulePredicate() predicate.Predicate {
+func PreflightReconcilerUpdatePredicate() predicate.Predicate {
 	return predicate.GenerationChangedPredicate{}
 }

--- a/internal/preflight/mock_preflight_api.go
+++ b/internal/preflight/mock_preflight_api.go
@@ -36,18 +36,18 @@ func (m *MockPreflightAPI) EXPECT() *MockPreflightAPIMockRecorder {
 }
 
 // PreflightUpgradeCheck mocks base method.
-func (m *MockPreflightAPI) PreflightUpgradeCheck(ctx context.Context, pv *v1beta1.PreflightValidation, mod *v1beta1.Module, kernelVersion string) (bool, string) {
+func (m *MockPreflightAPI) PreflightUpgradeCheck(ctx context.Context, pv *v1beta1.PreflightValidation, mod *v1beta1.Module) (bool, string) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PreflightUpgradeCheck", ctx, pv, mod, kernelVersion)
+	ret := m.ctrl.Call(m, "PreflightUpgradeCheck", ctx, pv, mod)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(string)
 	return ret0, ret1
 }
 
 // PreflightUpgradeCheck indicates an expected call of PreflightUpgradeCheck.
-func (mr *MockPreflightAPIMockRecorder) PreflightUpgradeCheck(ctx, pv, mod, kernelVersion interface{}) *gomock.Call {
+func (mr *MockPreflightAPIMockRecorder) PreflightUpgradeCheck(ctx, pv, mod interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreflightUpgradeCheck", reflect.TypeOf((*MockPreflightAPI)(nil).PreflightUpgradeCheck), ctx, pv, mod, kernelVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PreflightUpgradeCheck", reflect.TypeOf((*MockPreflightAPI)(nil).PreflightUpgradeCheck), ctx, pv, mod)
 }
 
 // MockpreflightHelperAPI is a mock of preflightHelperAPI interface.
@@ -74,18 +74,18 @@ func (m *MockpreflightHelperAPI) EXPECT() *MockpreflightHelperAPIMockRecorder {
 }
 
 // verifyBuild mocks base method.
-func (m *MockpreflightHelperAPI) verifyBuild(ctx context.Context, mapping *v1beta1.KernelMapping, mod *v1beta1.Module, kernelVersion string) (bool, string) {
+func (m *MockpreflightHelperAPI) verifyBuild(ctx context.Context, pv *v1beta1.PreflightValidation, mapping *v1beta1.KernelMapping, mod *v1beta1.Module) (bool, string) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "verifyBuild", ctx, mapping, mod, kernelVersion)
+	ret := m.ctrl.Call(m, "verifyBuild", ctx, pv, mapping, mod)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(string)
 	return ret0, ret1
 }
 
 // verifyBuild indicates an expected call of verifyBuild.
-func (mr *MockpreflightHelperAPIMockRecorder) verifyBuild(ctx, mapping, mod, kernelVersion interface{}) *gomock.Call {
+func (mr *MockpreflightHelperAPIMockRecorder) verifyBuild(ctx, pv, mapping, mod interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "verifyBuild", reflect.TypeOf((*MockpreflightHelperAPI)(nil).verifyBuild), ctx, mapping, mod, kernelVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "verifyBuild", reflect.TypeOf((*MockpreflightHelperAPI)(nil).verifyBuild), ctx, pv, mapping, mod)
 }
 
 // verifyImage mocks base method.

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -27,7 +27,7 @@ const (
 //go:generate mockgen -source=preflight.go -package=preflight -destination=mock_preflight_api.go PreflightAPI, preflightHelperAPI
 
 type PreflightAPI interface {
-	PreflightUpgradeCheck(ctx context.Context, pv *kmmv1beta1.PreflightValidation, mod *kmmv1beta1.Module, kernelVersion string) (bool, string)
+	PreflightUpgradeCheck(ctx context.Context, pv *kmmv1beta1.PreflightValidation, mod *kmmv1beta1.Module) (bool, string)
 }
 
 func NewPreflightAPI(
@@ -52,8 +52,9 @@ type preflight struct {
 	helper        preflightHelperAPI
 }
 
-func (p *preflight) PreflightUpgradeCheck(ctx context.Context, pv *kmmv1beta1.PreflightValidation, mod *kmmv1beta1.Module, kernelVersion string) (bool, string) {
+func (p *preflight) PreflightUpgradeCheck(ctx context.Context, pv *kmmv1beta1.PreflightValidation, mod *kmmv1beta1.Module) (bool, string) {
 	log := ctrlruntime.LoggerFrom(ctx)
+	kernelVersion := pv.Spec.KernelVersion
 	mapping, err := p.kernelAPI.FindMappingForKernel(mod.Spec.ModuleLoader.Container.KernelMappings, kernelVersion)
 	if err != nil {
 		return false, fmt.Sprintf("Failed to find kernel mapping in the module %s for kernel version %s", mod.Name, kernelVersion)
@@ -80,12 +81,12 @@ func (p *preflight) PreflightUpgradeCheck(ctx context.Context, pv *kmmv1beta1.Pr
 		log.Info(utils.WarnString("failed to update the stage of Module CR in preflight to build stage"), "module", mod.Name, "error", err)
 	}
 
-	return p.helper.verifyBuild(ctx, mapping, mod, kernelVersion)
+	return p.helper.verifyBuild(ctx, pv, mapping, mod)
 }
 
 type preflightHelperAPI interface {
 	verifyImage(ctx context.Context, mapping *kmmv1beta1.KernelMapping, mod *kmmv1beta1.Module, kernelVersion string) (bool, string)
-	verifyBuild(ctx context.Context, mapping *kmmv1beta1.KernelMapping, mod *kmmv1beta1.Module, kernelVersion string) (bool, string)
+	verifyBuild(ctx context.Context, pv *kmmv1beta1.PreflightValidation, mapping *kmmv1beta1.KernelMapping, mod *kmmv1beta1.Module) (bool, string)
 }
 
 type preflightHelper struct {
@@ -139,15 +140,22 @@ func (p *preflightHelper) verifyImage(ctx context.Context, mapping *kmmv1beta1.K
 	return false, fmt.Sprintf("image %s does not contain kernel module for kernel %s on any layer", image, kernelVersion)
 }
 
-func (p *preflightHelper) verifyBuild(ctx context.Context, mapping *kmmv1beta1.KernelMapping, mod *kmmv1beta1.Module, kernelVersion string) (bool, string) {
+func (p *preflightHelper) verifyBuild(ctx context.Context,
+	pv *kmmv1beta1.PreflightValidation,
+	mapping *kmmv1beta1.KernelMapping,
+	mod *kmmv1beta1.Module) (bool, string) {
 	// at this stage we know that eiher mapping Build or Container build are defined
-	buildRes, err := p.buildAPI.Sync(ctx, *mod, *mapping, kernelVersion, mapping.ContainerImage, false, p.kernelOsDtkMapping)
+	buildRes, err := p.buildAPI.Sync(ctx, *mod, *mapping, pv.Spec.KernelVersion, mapping.ContainerImage, pv.Spec.PushBuiltImage, p.kernelOsDtkMapping)
 	if err != nil {
-		return false, fmt.Sprintf("Failed to verify build for module %s, kernel version %s, error %s", mod.Name, kernelVersion, err)
+		return false, fmt.Sprintf("Failed to verify build for module %s, kernel version %s, error %s", mod.Name, pv.Spec.KernelVersion, err)
 	}
 
 	if buildRes.Status == build.StatusCompleted {
-		return true, fmt.Sprintf(VerificationStatusReasonVerified, "build compiles")
+		msg := "build compiles"
+		if pv.Spec.PushBuiltImage {
+			msg += " and image pushed"
+		}
+		return true, fmt.Sprintf(VerificationStatusReasonVerified, msg)
 	}
 	return false, "Waiting for build verification"
 }


### PR DESCRIPTION
1) add a field to the Preflight CRD spec , that signifies if customer
   wants to push the image during preflight verification
2) add support for image push during preflight Build stage 3) add Generator filter to preflight Watch, to skip being scheduled
   on Preflight status changes