### PR TITLE
Add auth API for accessing cluster pull secret

### DIFF
--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -92,3 +92,35 @@ var _ = Describe("registrySecretAuthGetter_GetKeyChain", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 })
+
+var _ = Describe("NewClusterAuthGetter", func() {
+	var (
+		ctrl       *gomock.Controller
+		ctx        context.Context
+		factory    *registryAuthGetterFactory
+		mockClient *client.MockClient
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		ctx = context.TODO()
+		mockClient = client.NewMockClient(ctrl)
+		factory = NewRegistryAuthGetterFactory(mockClient, nil).(*registryAuthGetterFactory)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	It("shoudl work as expected", func() {
+		namespacedNamespace := types.NamespacedName{
+			Name:      pullSecretName,
+			Namespace: pullSecretNamespace,
+		}
+		mockClient.EXPECT().Get(ctx, namespacedNamespace, gomock.Any()).Return(nil)
+
+		registryAuthGetter := factory.NewClusterAuthGetter()
+		_, err := registryAuthGetter.GetKeyChain(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/internal/auth/mock_auth.go
+++ b/internal/auth/mock_auth.go
@@ -74,6 +74,20 @@ func (m *MockRegistryAuthGetterFactory) EXPECT() *MockRegistryAuthGetterFactoryM
 	return m.recorder
 }
 
+// NewClusterAuthGetter mocks base method.
+func (m *MockRegistryAuthGetterFactory) NewClusterAuthGetter() RegistryAuthGetter {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewClusterAuthGetter")
+	ret0, _ := ret[0].(RegistryAuthGetter)
+	return ret0
+}
+
+// NewClusterAuthGetter indicates an expected call of NewClusterAuthGetter.
+func (mr *MockRegistryAuthGetterFactoryMockRecorder) NewClusterAuthGetter() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewClusterAuthGetter", reflect.TypeOf((*MockRegistryAuthGetterFactory)(nil).NewClusterAuthGetter))
+}
+
 // NewRegistryAuthGetterFrom mocks base method.
 func (m *MockRegistryAuthGetterFactory) NewRegistryAuthGetterFrom(mod *v1beta1.Module) RegistryAuthGetter {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This PR adds additional API hat allows producing authenticator that will use the cluster pull secret. This is downstream(OCP) only related. Currently it will be used by preflight code in order to access/parse release image