### PR TITLE
Do not pass the kernel-OS-DTK mapping around

### DIFF
--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -33,7 +33,6 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/registry"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/sign"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/statusupdater"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/syncronizedmap"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -55,17 +54,16 @@ import (
 type ModuleReconciler struct {
 	client.Client
 
-	authFactory        auth.RegistryAuthGetterFactory
-	buildAPI           build.Manager
-	signAPI            sign.SignManager
-	rbacAPI            rbac.RBACCreator
-	daemonAPI          daemonset.DaemonSetCreator
-	kernelAPI          module.KernelMapper
-	metricsAPI         metrics.Metrics
-	registry           registry.Registry
-	filter             *filter.Filter
-	statusUpdaterAPI   statusupdater.ModuleStatusUpdater
-	kernelOsDtkMapping syncronizedmap.KernelOsDtkMapping
+	authFactory      auth.RegistryAuthGetterFactory
+	buildAPI         build.Manager
+	signAPI          sign.SignManager
+	rbacAPI          rbac.RBACCreator
+	daemonAPI        daemonset.DaemonSetCreator
+	kernelAPI        module.KernelMapper
+	metricsAPI       metrics.Metrics
+	registry         registry.Registry
+	filter           *filter.Filter
+	statusUpdaterAPI statusupdater.ModuleStatusUpdater
 }
 
 func NewModuleReconciler(
@@ -79,21 +77,19 @@ func NewModuleReconciler(
 	filter *filter.Filter,
 	registry registry.Registry,
 	authFactory auth.RegistryAuthGetterFactory,
-	statusUpdaterAPI statusupdater.ModuleStatusUpdater,
-	kernelOsDtkMapping syncronizedmap.KernelOsDtkMapping) *ModuleReconciler {
+	statusUpdaterAPI statusupdater.ModuleStatusUpdater) *ModuleReconciler {
 	return &ModuleReconciler{
-		Client:             client,
-		authFactory:        authFactory,
-		buildAPI:           buildAPI,
-		signAPI:            signAPI,
-		rbacAPI:            rbacAPI,
-		daemonAPI:          daemonAPI,
-		kernelAPI:          kernelAPI,
-		metricsAPI:         metricsAPI,
-		filter:             filter,
-		registry:           registry,
-		statusUpdaterAPI:   statusUpdaterAPI,
-		kernelOsDtkMapping: kernelOsDtkMapping,
+		Client:           client,
+		authFactory:      authFactory,
+		buildAPI:         buildAPI,
+		signAPI:          signAPI,
+		rbacAPI:          rbacAPI,
+		daemonAPI:        daemonAPI,
+		kernelAPI:        kernelAPI,
+		metricsAPI:       metricsAPI,
+		filter:           filter,
+		registry:         registry,
+		statusUpdaterAPI: statusUpdaterAPI,
 	}
 }
 
@@ -306,7 +302,7 @@ func (r *ModuleReconciler) handleBuild(ctx context.Context,
 	logger.Info("Image not pull-able; building in-cluster")
 
 	buildRes, err := r.buildAPI.Sync(log.IntoContext(ctx, logger), *mod, *km, kernelVersion,
-		containerImage, true, r.kernelOsDtkMapping)
+		containerImage, true)
 	if err != nil {
 		return false, fmt.Errorf("could not synchronize the build: %w", err)
 	}

--- a/controllers/module_reconciler_test.go
+++ b/controllers/module_reconciler_test.go
@@ -90,7 +90,6 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			mockRegistry,
 			nil,
 			mockSU,
-			nil,
 		)
 
 		Expect(
@@ -165,7 +164,6 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			mockRegistry,
 			nil,
 			mockSU,
-			nil,
 		)
 
 		dsByKernelVersion := make(map[string]*appsv1.DaemonSet)
@@ -233,7 +231,6 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			mockRegistry,
 			nil,
 			mockSU,
-			nil,
 		)
 
 		dsByKernelVersion := make(map[string]*appsv1.DaemonSet)
@@ -301,7 +298,6 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			mockRegistry,
 			nil,
 			mockSU,
-			nil,
 		)
 
 		dsByKernelVersion := make(map[string]*appsv1.DaemonSet)
@@ -379,7 +375,6 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			mockRegistry,
 			nil,
 			mockSU,
-			nil,
 		)
 
 		dsByKernelVersion := map[string]*appsv1.DaemonSet{kernelVersion: &ds}
@@ -456,7 +451,6 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			mockRegistry,
 			nil,
 			mockSU,
-			nil,
 		)
 
 		ds := appsv1.DaemonSet{
@@ -601,7 +595,6 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			mockRegistry,
 			nil,
 			mockSU,
-			nil,
 		)
 
 		dsByKernelVersion := map[string]*appsv1.DaemonSet{kernelVersion: &ds}
@@ -672,7 +665,6 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			mockRegistry,
 			nil,
 			mockSU,
-			nil,
 		)
 
 		ds := appsv1.DaemonSet{
@@ -775,7 +767,6 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 			mockRegistry,
 			nil,
 			mockSU,
-			nil,
 		)
 
 		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion, km.ContainerImage)
@@ -828,7 +819,6 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 			mockRegistry,
 			mockAuthFactory,
 			mockSU,
-			nil,
 		)
 
 		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion, km.ContainerImage)
@@ -874,7 +864,6 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 			mockRegistry,
 			mockAuthFactory,
 			mockSU,
-			nil,
 		)
 
 		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion, km.ContainerImage)
@@ -902,7 +891,7 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 				NewRegistryAuthGetterFrom(mod).
 				Return(authGetter),
 			mockRegistry.EXPECT().ImageExists(context.Background(), imageName, nil, authGetter).Return(false, nil),
-			mockBM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), km.ContainerImage, true, gomock.Any()).Return(buildRes, nil),
+			mockBM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), km.ContainerImage, true).Return(buildRes, nil),
 			mockMetrics.EXPECT().SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.BuildStage, false),
 		)
 
@@ -918,7 +907,6 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 			mockRegistry,
 			mockAuthFactory,
 			mockSU,
-			nil,
 		)
 
 		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion, km.ContainerImage)
@@ -946,7 +934,7 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 				NewRegistryAuthGetterFrom(mod).
 				Return(authGetter),
 			mockRegistry.EXPECT().ImageExists(context.Background(), imageName, nil, authGetter).Return(false, nil),
-			mockBM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), km.ContainerImage, true, gomock.Any()).Return(buildRes, nil),
+			mockBM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), km.ContainerImage, true).Return(buildRes, nil),
 			mockMetrics.EXPECT().SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.BuildStage, false),
 		)
 
@@ -962,7 +950,6 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 			mockRegistry,
 			mockAuthFactory,
 			mockSU,
-			nil,
 		)
 
 		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion, km.ContainerImage)
@@ -990,7 +977,7 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 				NewRegistryAuthGetterFrom(mod).
 				Return(authGetter),
 			mockRegistry.EXPECT().ImageExists(context.Background(), imageName, nil, authGetter).Return(false, nil),
-			mockBM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), km.ContainerImage, true, gomock.Any()).Return(buildRes, nil),
+			mockBM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), km.ContainerImage, true).Return(buildRes, nil),
 			mockMetrics.EXPECT().SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.BuildStage, true),
 		)
 
@@ -1006,7 +993,6 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 			mockRegistry,
 			mockAuthFactory,
 			mockSU,
-			nil,
 		)
 
 		res, err := mr.handleBuild(context.Background(), mod, km, kernelVersion, km.ContainerImage)
@@ -1071,7 +1057,6 @@ var _ = Describe("ModuleReconciler_handleSigning", func() {
 			mockRegistry,
 			mockAuthFactory,
 			mockSU,
-			nil,
 		)
 
 		res, err := mr.handleSigning(context.Background(), mod, km, kernelVersion, km.ContainerImage)
@@ -1116,7 +1101,6 @@ var _ = Describe("ModuleReconciler_handleSigning", func() {
 			mockRegistry,
 			mockAuthFactory,
 			mockSU,
-			nil,
 		)
 
 		res, err := mr.handleSigning(context.Background(), mod, km, kernelVersion, km.ContainerImage)
@@ -1157,7 +1141,6 @@ var _ = Describe("ModuleReconciler_handleSigning", func() {
 			mockRegistry,
 			mockAuthFactory,
 			mockSU,
-			nil,
 		)
 
 		res, err := mr.handleSigning(context.Background(), mod, km, kernelVersion, km.ContainerImage)
@@ -1199,7 +1182,6 @@ var _ = Describe("ModuleReconciler_handleSigning", func() {
 			mockRegistry,
 			mockAuthFactory,
 			mockSU,
-			nil,
 		)
 		res, err := mr.handleSigning(context.Background(), mod, km, kernelVersion, km.ContainerImage)
 		Expect(err).NotTo(HaveOccurred())
@@ -1240,7 +1222,6 @@ var _ = Describe("ModuleReconciler_handleSigning", func() {
 			mockRegistry,
 			mockAuthFactory,
 			mockSU,
-			nil,
 		)
 		res, err := mr.handleSigning(context.Background(), mod, km, kernelVersion, km.ContainerImage)
 		Expect(err).NotTo(HaveOccurred())
@@ -1281,7 +1262,6 @@ var _ = Describe("ModuleReconciler_handleSigning", func() {
 			mockRegistry,
 			mockAuthFactory,
 			mockSU,
-			nil,
 		)
 		res, err := mr.handleSigning(context.Background(), mod, km, kernelVersion, km.ContainerImage)
 		Expect(err).NotTo(HaveOccurred())
@@ -1322,7 +1302,6 @@ var _ = Describe("ModuleReconciler_handleSigning", func() {
 			mockRegistry,
 			mockAuthFactory,
 			mockSU,
-			nil,
 		)
 		res, err := mr.handleSigning(context.Background(), mod, km, kernelVersion, km.ContainerImage)
 		Expect(err).NotTo(HaveOccurred())
@@ -1342,7 +1321,7 @@ var _ = Describe("ModuleReconciler_getNodesListBySelector", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
-		mr = NewModuleReconciler(clnt, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		mr = NewModuleReconciler(clnt, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	})
 
 	ctx := context.Background()

--- a/internal/build/buildconfig/manager.go
+++ b/internal/build/buildconfig/manager.go
@@ -8,7 +8,6 @@ import (
 	buildv1 "github.com/openshift/api/build/v1"
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	kmmbuild "github.com/rh-ecosystem-edge/kernel-module-management/internal/build"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/syncronizedmap"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -41,12 +40,18 @@ func (bcm *buildManager) GarbageCollect(ctx context.Context, mod kmmv1beta1.Modu
 	return nil, nil
 }
 
-func (bcm *buildManager) Sync(ctx context.Context, mod kmmv1beta1.Module, m kmmv1beta1.KernelMapping,
-	targetKernel, targetImage string, pushImage bool, kernelOsDtkMapping syncronizedmap.KernelOsDtkMapping) (kmmbuild.Result, error) {
+func (bcm *buildManager) Sync(
+	ctx context.Context,
+	mod kmmv1beta1.Module,
+	m kmmv1beta1.KernelMapping,
+	targetKernel,
+	targetImage string,
+	pushImage bool,
+) (kmmbuild.Result, error) {
 
 	logger := log.FromContext(ctx)
 
-	buildTemplate, err := bcm.maker.MakeBuildTemplate(ctx, mod, m, targetKernel, targetImage, pushImage, kernelOsDtkMapping)
+	buildTemplate, err := bcm.maker.MakeBuildTemplate(ctx, mod, m, targetKernel, targetImage, pushImage)
 	if err != nil {
 		return kmmbuild.Result{}, fmt.Errorf("could not make Build template: %v", err)
 	}

--- a/internal/build/buildconfig/manager_test.go
+++ b/internal/build/buildconfig/manager_test.go
@@ -11,7 +11,6 @@ import (
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	kmmbuild "github.com/rh-ecosystem-edge/kernel-module-management/internal/build"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/syncronizedmap"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -76,13 +75,12 @@ var _ = Describe("Manager_Sync", func() {
 		}
 
 		gomock.InOrder(
-			mockMaker.EXPECT().MakeBuildTemplate(ctx, mod, mapping, targetKernel, containerImage, true, gomock.Any()).Return(&build, nil),
+			mockMaker.EXPECT().MakeBuildTemplate(ctx, mod, mapping, targetKernel, containerImage, true).Return(&build, nil),
 			mockOpenShiftBuildsHelper.EXPECT().GetBuild(ctx, mod, targetKernel).Return(nil, errNoMatchingBuild),
 			mockKubeClient.EXPECT().Create(ctx, &build),
 		)
 
-		kernelOsDtkMapping := syncronizedmap.NewKernelOsDtkMapping()
-		res, err := m.Sync(ctx, mod, mapping, targetKernel, mapping.ContainerImage, true, kernelOsDtkMapping)
+		res, err := m.Sync(ctx, mod, mapping, targetKernel, mapping.ContainerImage, true)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res.Status).To(BeEquivalentTo(kmmbuild.StatusCreated))
 		Expect(res.Requeue).To(BeTrue())
@@ -124,12 +122,11 @@ var _ = Describe("Manager_Sync", func() {
 			}
 
 			gomock.InOrder(
-				mockMaker.EXPECT().MakeBuildTemplate(ctx, mod, mapping, targetKernel, containerImage, true, gomock.Any()).Return(&build, nil),
+				mockMaker.EXPECT().MakeBuildTemplate(ctx, mod, mapping, targetKernel, containerImage, true).Return(&build, nil),
 				mockOpenShiftBuildsHelper.EXPECT().GetBuild(ctx, mod, targetKernel).Return(&build, nil),
 			)
 
-			kernelOsDtkMapping := syncronizedmap.NewKernelOsDtkMapping()
-			res, err := m.Sync(ctx, mod, mapping, targetKernel, mapping.ContainerImage, true, kernelOsDtkMapping)
+			res, err := m.Sync(ctx, mod, mapping, targetKernel, mapping.ContainerImage, true)
 
 			if expectError {
 				Expect(err).To(HaveOccurred())

--- a/internal/build/buildconfig/mock_maker.go
+++ b/internal/build/buildconfig/mock_maker.go
@@ -11,7 +11,6 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1 "github.com/openshift/api/build/v1"
 	v1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
-	syncronizedmap "github.com/rh-ecosystem-edge/kernel-module-management/internal/syncronizedmap"
 )
 
 // MockMaker is a mock of Maker interface.
@@ -38,16 +37,16 @@ func (m *MockMaker) EXPECT() *MockMakerMockRecorder {
 }
 
 // MakeBuildTemplate mocks base method.
-func (m *MockMaker) MakeBuildTemplate(ctx context.Context, mod v1beta1.Module, mapping v1beta1.KernelMapping, targetKernel, containerImage string, pushImage bool, kernelOsDtkMapping syncronizedmap.KernelOsDtkMapping) (*v1.Build, error) {
+func (m *MockMaker) MakeBuildTemplate(ctx context.Context, mod v1beta1.Module, mapping v1beta1.KernelMapping, targetKernel, containerImage string, pushImage bool) (*v1.Build, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MakeBuildTemplate", ctx, mod, mapping, targetKernel, containerImage, pushImage, kernelOsDtkMapping)
+	ret := m.ctrl.Call(m, "MakeBuildTemplate", ctx, mod, mapping, targetKernel, containerImage, pushImage)
 	ret0, _ := ret[0].(*v1.Build)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MakeBuildTemplate indicates an expected call of MakeBuildTemplate.
-func (mr *MockMakerMockRecorder) MakeBuildTemplate(ctx, mod, mapping, targetKernel, containerImage, pushImage, kernelOsDtkMapping interface{}) *gomock.Call {
+func (mr *MockMakerMockRecorder) MakeBuildTemplate(ctx, mod, mapping, targetKernel, containerImage, pushImage interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeBuildTemplate", reflect.TypeOf((*MockMaker)(nil).MakeBuildTemplate), ctx, mod, mapping, targetKernel, containerImage, pushImage, kernelOsDtkMapping)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeBuildTemplate", reflect.TypeOf((*MockMaker)(nil).MakeBuildTemplate), ctx, mod, mapping, targetKernel, containerImage, pushImage)
 }

--- a/internal/build/manager.go
+++ b/internal/build/manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/syncronizedmap"
 )
 
 type Status string
@@ -23,7 +22,6 @@ type Result struct {
 //go:generate mockgen -source=manager.go -package=build -destination=mock_manager.go
 
 type Manager interface {
-	Sync(ctx context.Context, mod kmmv1beta1.Module, m kmmv1beta1.KernelMapping, targetKernel string, targetImage string,
-		pushImage bool, kernelOsDtkMapping syncronizedmap.KernelOsDtkMapping) (Result, error)
+	Sync(ctx context.Context, mod kmmv1beta1.Module, m kmmv1beta1.KernelMapping, targetKernel string, targetImage string, pushImage bool) (Result, error)
 	GarbageCollect(ctx context.Context, mod kmmv1beta1.Module) ([]string, error)
 }

--- a/internal/build/mock_manager.go
+++ b/internal/build/mock_manager.go
@@ -10,7 +10,6 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
-	syncronizedmap "github.com/rh-ecosystem-edge/kernel-module-management/internal/syncronizedmap"
 )
 
 // MockManager is a mock of Manager interface.
@@ -52,16 +51,16 @@ func (mr *MockManagerMockRecorder) GarbageCollect(ctx, mod interface{}) *gomock.
 }
 
 // Sync mocks base method.
-func (m_2 *MockManager) Sync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping, targetKernel, targetImage string, pushImage bool, kernelOsDtkMapping syncronizedmap.KernelOsDtkMapping) (Result, error) {
+func (m_2 *MockManager) Sync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping, targetKernel, targetImage string, pushImage bool) (Result, error) {
 	m_2.ctrl.T.Helper()
-	ret := m_2.ctrl.Call(m_2, "Sync", ctx, mod, m, targetKernel, targetImage, pushImage, kernelOsDtkMapping)
+	ret := m_2.ctrl.Call(m_2, "Sync", ctx, mod, m, targetKernel, targetImage, pushImage)
 	ret0, _ := ret[0].(Result)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Sync indicates an expected call of Sync.
-func (mr *MockManagerMockRecorder) Sync(ctx, mod, m, targetKernel, targetImage, pushImage, kernelOsDtkMapping interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) Sync(ctx, mod, m, targetKernel, targetImage, pushImage interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockManager)(nil).Sync), ctx, mod, m, targetKernel, targetImage, pushImage, kernelOsDtkMapping)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockManager)(nil).Sync), ctx, mod, m, targetKernel, targetImage, pushImage)
 }

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/module"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/registry"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/statusupdater"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/syncronizedmap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -288,7 +287,6 @@ var _ = Describe("preflightHelper_verifyBuild", func() {
 		ctrl         *gomock.Controller
 		mockBuildAPI *build.MockManager
 		clnt         *client.MockClient
-		mockKODM     *syncronizedmap.MockKernelOsDtkMapping
 		ph           *preflightHelper
 	)
 
@@ -296,11 +294,9 @@ var _ = Describe("preflightHelper_verifyBuild", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
 		mockBuildAPI = build.NewMockManager(ctrl)
-		mockKODM = syncronizedmap.NewMockKernelOsDtkMapping(ctrl)
 		ph = &preflightHelper{
-			client:             clnt,
-			buildAPI:           mockBuildAPI,
-			kernelOsDtkMapping: mockKODM,
+			client:   clnt,
+			buildAPI: mockBuildAPI,
 		}
 
 	})
@@ -313,7 +309,7 @@ var _ = Describe("preflightHelper_verifyBuild", func() {
 		mod.Spec.ModuleLoader.Container.Build = &kmmv1beta1.Build{}
 		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
 		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion,
-			mapping.ContainerImage, false, mockKODM).Return(build.Result{}, fmt.Errorf("some error"))
+			mapping.ContainerImage, false).Return(build.Result{}, fmt.Errorf("some error"))
 
 		res, msg := ph.verifyBuild(context.Background(), pv, &mapping, mod)
 		Expect(res).To(BeFalse())
@@ -325,7 +321,7 @@ var _ = Describe("preflightHelper_verifyBuild", func() {
 		mod.Spec.ModuleLoader.Container.Build = &kmmv1beta1.Build{}
 		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
 		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion,
-			mapping.ContainerImage, false, mockKODM).Return(build.Result{Status: build.StatusCompleted}, nil)
+			mapping.ContainerImage, false).Return(build.Result{Status: build.StatusCompleted}, nil)
 
 		res, msg := ph.verifyBuild(context.Background(), pv, &mapping, mod)
 		Expect(res).To(BeTrue())
@@ -337,7 +333,7 @@ var _ = Describe("preflightHelper_verifyBuild", func() {
 		mod.Spec.ModuleLoader.Container.Build = &kmmv1beta1.Build{}
 		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
 		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion,
-			mapping.ContainerImage, false, mockKODM).Return(build.Result{Status: build.StatusInProgress}, nil)
+			mapping.ContainerImage, false).Return(build.Result{Status: build.StatusInProgress}, nil)
 
 		res, msg := ph.verifyBuild(context.Background(), pv, &mapping, mod)
 		Expect(res).To(BeFalse())

--- a/main.go
+++ b/main.go
@@ -170,7 +170,7 @@ func main() {
 	helperAPI := build.NewHelper()
 	buildAPI := buildconfig.NewManager(
 		client,
-		buildconfig.NewMaker(client, helperAPI, scheme),
+		buildconfig.NewMaker(client, helperAPI, scheme, kernelOsDtkMapping),
 		buildconfig.NewOpenShiftBuildsHelper(client),
 	)
 
@@ -187,7 +187,7 @@ func main() {
 	preflightStatusUpdaterAPI := statusupdater.NewPreflightStatusUpdater(client)
 	registryAPI := registry.NewRegistry()
 	authFactory := auth.NewRegistryAuthGetterFactory(client, kubernetes.NewForConfigOrDie(restConfig))
-	preflightAPI := preflight.NewPreflightAPI(client, buildAPI, registryAPI, kernelAPI, preflightStatusUpdaterAPI, authFactory, kernelOsDtkMapping)
+	preflightAPI := preflight.NewPreflightAPI(client, buildAPI, registryAPI, kernelAPI, preflightStatusUpdaterAPI, authFactory)
 
 	mc := controllers.NewModuleReconciler(
 		client,
@@ -201,7 +201,6 @@ func main() {
 		registryAPI,
 		authFactory,
 		moduleStatusUpdaterAPI,
-		kernelOsDtkMapping,
 	)
 
 	if err = mc.SetupWithManager(mgr, kernelLabel); err != nil {


### PR DESCRIPTION
Make the kernel version --> OS version --> DTK image an instance variable of `build.Maker` instead of passing it around.

/cc @mresvanis @ybettan @yevgeny-shnaidman