### PR TITLE
Fix OLM bundle failing because of incorrect CSV filename (#134)

### DIFF
--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -1,7 +1,7 @@
 # These resources constitute the fully configured set of manifests
 # used to generate the 'manifests/' directory in a bundle.
 resources:
-- bases/kmm-operator.clusterserviceversion.yaml
+- bases/kernel-module-management.clusterserviceversion.yaml
 - ../default
 - ../samples
 - ../scorecard


### PR DESCRIPTION
Signed-off-by: Michail Resvanis <mresvani@redhat.com>

Upstream-Commit: e75461fdb9583b61907627ca7ba8132f378b7bad