### PR TITLE
Only reconcile openshift/driver-toolkit

### DIFF
--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -164,6 +164,12 @@ func DeletingPredicate() predicate.Predicate {
 	})
 }
 
+func MatchesNamespacedNamePredicate(nsn types.NamespacedName) predicate.Predicate {
+	return predicate.NewPredicateFuncs(func(object client.Object) bool {
+		return object.GetName() == nsn.Name && object.GetNamespace() == nsn.Namespace
+	})
+}
+
 // PodHasSpecNodeName returns a predicate that returns true if the object is a *v1.Pod and its .spec.nodeName
 // property is set.
 func PodHasSpecNodeName() predicate.Predicate {

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -365,6 +365,33 @@ var _ = Describe("DeletingPredicate", func() {
 	)
 })
 
+var _ = Describe("MatchesNamespacedNamePredicate", func() {
+	const (
+		name      = "name"
+		namespace = "namespace"
+	)
+
+	p := MatchesNamespacedNamePredicate(types.NamespacedName{Name: name, Namespace: namespace})
+
+	DescribeTable("should return the expected value",
+		func(nsn types.NamespacedName, expected bool) {
+			cm := v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: nsn.Name, Namespace: nsn.Namespace},
+			}
+
+			Expect(
+				p.Create(event.CreateEvent{Object: &cm}),
+			).To(
+				Equal(expected),
+			)
+		},
+		Entry("bad name", types.NamespacedName{Name: "other-name", Namespace: namespace}, false),
+		Entry("bad namespace", types.NamespacedName{Name: name, Namespace: "other-namespace"}, false),
+		Entry("both bad", types.NamespacedName{Name: "other-name", Namespace: "other-namespace"}, false),
+		Entry("both good", types.NamespacedName{Name: name, Namespace: namespace}, true),
+	)
+})
+
 var _ = Describe("PodHasSpecNodeName", func() {
 	p := PodHasSpecNodeName()
 


### PR DESCRIPTION
Only watch the openshift/driver-toolkit ImageStream.
Filter out reconciliation requests for other ImageStreams.
Use a namespace-scoped client.

/cc @ybettan @enriquebelarte @yevgeny-shnaidman 