### PR TITLE
Enable configuration flags via ConfigMap (#143)

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -32,7 +32,7 @@ patchesStrategicMerge:
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type
-#- manager_config_patch.yaml
+- manager_config_patch.yaml
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml

--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -3,9 +3,9 @@ kind: ControllerManagerConfig
 health:
   healthProbeBindAddress: :8081
 metrics:
-  bindAddress: 127.0.0.1:8080
+  bindAddress: :8080
 webhook:
   port: 9443
 leaderElection:
-  leaderElect: true
+  leaderElect: false
   resourceName: c5baf8af.sigs.k8s.io

--- a/main.go
+++ b/main.go
@@ -118,14 +118,23 @@ func main() {
 
 	restConfig := ctrl.GetConfigOrDie()
 
-	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
+	options := ctrl.Options{
 		Scheme:                 scheme,
 		MetricsBindAddress:     metricsAddr,
 		Port:                   9443,
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "c5baf8af.sigs.k8s.io",
-	})
+	}
+	if configFile != "" {
+		options, err = options.AndFrom(ctrl.ConfigFile().AtPath(configFile))
+		if err != nil {
+			setupLogger.Error(err, "unable to load the config file")
+			os.Exit(1)
+		}
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
 	if err != nil {
 		setupLogger.Error(err, "unable to start manager")
 		os.Exit(1)


### PR DESCRIPTION
This change enables controller configuration via a versioned config file, referred to as "component config". Configuration options can now be passed to the controller by a ConfigMap.

- https://book.kubebuilder.io/component-config-tutorial/tutorial.html

Signed-off-by: Michail Resvanis <mresvani@redhat.com>

/cc @mresvanis 

Fixes #239