### PR TITLE
Mount the OpenShift service certificate

### DIFF
--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -22,6 +22,9 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
+    - kind: ManagedClusterModule
+      name: managedclustermodules.kmm.sigs.k8s.io
+      version: v1beta1
     - kind: Module
       name: modules.kmm.sigs.k8s.io
       version: v1beta1
@@ -67,6 +70,33 @@ spec:
           - get
           - list
           - patch
+          - watch
+        - apiGroups:
+          - cluster.open-cluster-management.io
+          resources:
+          - clusterclaims
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - cluster.open-cluster-management.io
+          resourceNames:
+          - kernel-versions.kmm.node.kubernetes.io
+          resources:
+          - clusterclaims
+          verbs:
+          - delete
+          - patch
+          - update
+        - apiGroups:
+          - cluster.open-cluster-management.io
+          resources:
+          - managedclusters
+          verbs:
+          - get
+          - list
           - watch
         - apiGroups:
           - ""
@@ -124,10 +154,32 @@ spec:
         - apiGroups:
           - kmm.sigs.k8s.io
           resources:
+          - managedclustermodules
+          verbs:
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - kmm.sigs.k8s.io
+          resources:
+          - managedclustermodules/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - kmm.sigs.k8s.io
+          resources:
+          - managedclustermodules/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - kmm.sigs.k8s.io
+          resources:
           - modules
           verbs:
-          - create
-          - delete
           - get
           - list
           - patch
@@ -196,6 +248,18 @@ spec:
           verbs:
           - use
         - apiGroups:
+          - work.open-cluster-management.io
+          resources:
+          - manifestworks
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
           - authentication.k8s.io
           resources:
           - tokenreviews
@@ -227,34 +291,12 @@ spec:
             spec:
               containers:
               - args:
-                - --secure-listen-address=0.0.0.0:8443
-                - --upstream=http://127.0.0.1:8080/
-                - --logtostderr=true
-                - --v=0
-                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
-                name: kube-rbac-proxy
-                ports:
-                - containerPort: 8443
-                  name: https
-                  protocol: TCP
-                resources:
-                  limits:
-                    cpu: 500m
-                    memory: 128Mi
-                  requests:
-                    cpu: 5m
-                    memory: 64Mi
-                securityContext:
-                  allowPrivilegeEscalation: false
-                  capabilities:
-                    drop:
-                    - ALL
-              - args:
-                - --health-probe-bind-address=:8081
-                - --metrics-bind-address=127.0.0.1:8080
-                - --leader-elect
+                - --config=controller_manager_config.yaml
                 command:
                 - /usr/local/bin/manager
+                env:
+                - name: SSL_CERT_DIR
+                  value: /etc/pki/ca-trust/extracted/pem
                 image: quay.io/edge-infrastructure/kernel-module-management-operator:latest
                 imagePullPolicy: Always
                 livenessProbe:
@@ -283,9 +325,35 @@ spec:
                     drop:
                     - ALL
                 volumeMounts:
+                - mountPath: /controller_manager_config.yaml
+                  name: manager-config
+                  subPath: controller_manager_config.yaml
                 - mountPath: /etc/pki/ca-trust/extracted/pem
                   name: trusted-ca
                   readOnly: true
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=0
+                image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                  protocol: TCP
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 5m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
               nodeSelector:
                 node-role.kubernetes.io/master: ""
               securityContext:
@@ -300,11 +368,21 @@ spec:
                 operator: Equal
               volumes:
               - configMap:
-                  items:
-                  - key: ca-bundle.crt
-                    path: tls-ca-bundle.pem
-                  name: kmm-operator-trusted-ca
-                name: trusted-ca
+                  name: kmm-operator-manager-config
+                name: manager-config
+              - name: trusted-ca
+                projected:
+                  sources:
+                  - configMap:
+                      items:
+                      - key: ca-bundle.crt
+                        path: tls-ca-bundle.pem
+                      name: kmm-operator-cluster-ca
+                  - configMap:
+                      items:
+                      - key: service-ca.crt
+                        path: ocp-service-ca-bundle.pem
+                      name: kmm-operator-service-ca
       permissions:
       - rules:
         - apiGroups:

--- a/bundle/manifests/kmm-operator-cluster-ca_v1_configmap.yaml
+++ b/bundle/manifests/kmm-operator-cluster-ca_v1_configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data: {}
+kind: ConfigMap
+metadata:
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: kmm-operator-cluster-ca

--- a/bundle/manifests/kmm-operator-manager-config_v1_configmap.yaml
+++ b/bundle/manifests/kmm-operator-manager-config_v1_configmap.yaml
@@ -6,7 +6,7 @@ data:
     health:
       healthProbeBindAddress: :8081
     metrics:
-      bindAddress: 127.0.0.1:8080
+      bindAddress: :8080
     webhook:
       port: 9443
     leaderElection:

--- a/bundle/manifests/kmm-operator-service-ca_v1_configmap.yaml
+++ b/bundle/manifests/kmm-operator-service-ca_v1_configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data: {}
+kind: ConfigMap
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  name: kmm-operator-service-ca

--- a/bundle/manifests/kmm.sigs.k8s.io_managedclustermodules.yaml
+++ b/bundle/manifests/kmm.sigs.k8s.io_managedclustermodules.yaml
@@ -1,0 +1,2390 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: unapproved, testing-only
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: managedclustermodules.kmm.sigs.k8s.io
+spec:
+  group: kmm.sigs.k8s.io
+  names:
+    kind: ManagedClusterModule
+    listKind: ManagedClusterModuleList
+    plural: managedclustermodules
+    singular: managedclustermodule
+  scope: Cluster
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ManagedClusterModule is the Schema for the managedclustermodules
+          API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ManagedClusterModuleSpec defines the desired state of ManagedClusterModule
+            properties:
+              moduleSpec:
+                description: ModuleSpec describes how the KMM operator should deploy
+                  a Module on those nodes that need it.
+                properties:
+                  devicePlugin:
+                    description: DevicePlugin allows overriding some properties of
+                      the container that deploys the device plugin on the node. Name
+                      is ignored and is set automatically by the KMM Operator.
+                    properties:
+                      container:
+                        properties:
+                          args:
+                            description: 'Arguments to the entrypoint. The container
+                              image''s CMD is used if this is not provided. Variable
+                              references $(VAR_NAME) are expanded using the container''s
+                              environment. If a variable cannot be resolved, the reference
+                              in the input string will be unchanged. Double $$ are
+                              reduced to a single $, which allows for escaping the
+                              $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce
+                              the string literal "$(VAR_NAME)". Escaped references
+                              will never be expanded, regardless of whether the variable
+                              exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          command:
+                            description: 'Entrypoint array. Not executed within a
+                              shell. The container image''s ENTRYPOINT is used if
+                              this is not provided. Variable references $(VAR_NAME)
+                              are expanded using the container''s environment. If
+                              a variable cannot be resolved, the reference in the
+                              input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME)
+                              syntax: i.e. "$$(VAR_NAME)" will produce the string
+                              literal "$(VAR_NAME)". Escaped references will never
+                              be expanded, regardless of whether the variable exists
+                              or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                            items:
+                              type: string
+                            type: array
+                          env:
+                            description: List of environment variables to set in the
+                              container. Cannot be updated.
+                            items:
+                              description: EnvVar represents an environment variable
+                                present in a Container.
+                              properties:
+                                name:
+                                  description: Name of the environment variable. Must
+                                    be a C_IDENTIFIER.
+                                  type: string
+                                value:
+                                  description: 'Variable references $(VAR_NAME) are
+                                    expanded using the previously defined environment
+                                    variables in the container and any service environment
+                                    variables. If a variable cannot be resolved, the
+                                    reference in the input string will be unchanged.
+                                    Double $$ are reduced to a single $, which allows
+                                    for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
+                                    will produce the string literal "$(VAR_NAME)".
+                                    Escaped references will never be expanded, regardless
+                                    of whether the variable exists or not. Defaults
+                                    to "".'
+                                  type: string
+                                valueFrom:
+                                  description: Source for the environment variable's
+                                    value. Cannot be used if value is not empty.
+                                  properties:
+                                    configMapKeyRef:
+                                      description: Selects a key of a ConfigMap.
+                                      properties:
+                                        key:
+                                          description: The key to select.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the ConfigMap
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    fieldRef:
+                                      description: 'Selects a field of the pod: supports
+                                        metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
+                                        `metadata.annotations[''<KEY>'']`, spec.nodeName,
+                                        spec.serviceAccountName, status.hostIP, status.podIP,
+                                        status.podIPs.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath
+                                            is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select
+                                            in the specified API version.
+                                          type: string
+                                      required:
+                                      - fieldPath
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container:
+                                        only resources limits and requests (limits.cpu,
+                                        limits.memory, limits.ephemeral-storage, requests.cpu,
+                                        requests.memory and requests.ephemeral-storage)
+                                        are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for
+                                            volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          anyOf:
+                                          - type: integer
+                                          - type: string
+                                          description: Specifies the output format
+                                            of the exposed resources, defaults to
+                                            "1"
+                                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                          x-kubernetes-int-or-string: true
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                      - resource
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    secretKeyRef:
+                                      description: Selects a key of a secret in the
+                                        pod's namespace
+                                      properties:
+                                        key:
+                                          description: The key of the secret to select
+                                            from.  Must be a valid secret key.
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                        optional:
+                                          description: Specify whether the Secret
+                                            or its key must be defined
+                                          type: boolean
+                                      required:
+                                      - key
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  type: object
+                              required:
+                              - name
+                              type: object
+                            type: array
+                          image:
+                            description: Image is the name of the container image
+                              that the device plugin container will run.
+                            type: string
+                          imagePullPolicy:
+                            description: 'Image pull policy. One of Always, Never,
+                              IfNotPresent. Defaults to Always if :latest tag is specified,
+                              or IfNotPresent otherwise. Cannot be updated. More info:
+                              https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                            type: string
+                          resources:
+                            description: 'Compute Resources required by this container.
+                              Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            properties:
+                              limits:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Limits describes the maximum amount
+                                  of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                              requests:
+                                additionalProperties:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                                description: 'Requests describes the minimum amount
+                                  of compute resources required. If Requests is omitted
+                                  for a container, it defaults to Limits if that is
+                                  explicitly specified, otherwise to an implementation-defined
+                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                type: object
+                            type: object
+                          volumeMounts:
+                            description: VolumeMounts is a list of volume mounts that
+                              are appended to the default ones.
+                            items:
+                              description: VolumeMount describes a mounting of a Volume
+                                within a container.
+                              properties:
+                                mountPath:
+                                  description: Path within the container at which
+                                    the volume should be mounted.  Must not contain
+                                    ':'.
+                                  type: string
+                                mountPropagation:
+                                  description: mountPropagation determines how mounts
+                                    are propagated from the host to container and
+                                    the other way around. When not set, MountPropagationNone
+                                    is used. This field is beta in 1.10.
+                                  type: string
+                                name:
+                                  description: This must match the Name of a Volume.
+                                  type: string
+                                readOnly:
+                                  description: Mounted read-only if true, read-write
+                                    otherwise (false or unspecified). Defaults to
+                                    false.
+                                  type: boolean
+                                subPath:
+                                  description: Path within the volume from which the
+                                    container's volume should be mounted. Defaults
+                                    to "" (volume's root).
+                                  type: string
+                                subPathExpr:
+                                  description: Expanded path within the volume from
+                                    which the container's volume should be mounted.
+                                    Behaves similarly to SubPath but environment variable
+                                    references $(VAR_NAME) are expanded using the
+                                    container's environment. Defaults to "" (volume's
+                                    root). SubPathExpr and SubPath are mutually exclusive.
+                                  type: string
+                              required:
+                              - mountPath
+                              - name
+                              type: object
+                            type: array
+                        required:
+                        - image
+                        type: object
+                      serviceAccountName:
+                        description: 'ServiceAccountName is the name of the ServiceAccount
+                          to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                        type: string
+                      volumes:
+                        items:
+                          description: Volume represents a named volume in a pod that
+                            may be accessed by any container in the pod.
+                          properties:
+                            awsElasticBlockStore:
+                              description: 'awsElasticBlockStore represents an AWS
+                                Disk resource that is attached to a kubelet''s host
+                                machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                              properties:
+                                fsType:
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                    TODO: how do we prevent errors in the filesystem
+                                    from compromising the machine'
+                                  type: string
+                                partition:
+                                  description: 'partition is the partition in the
+                                    volume that you want to mount. If omitted, the
+                                    default is to mount by volume name. Examples:
+                                    For volume /dev/sda1, you specify the partition
+                                    as "1". Similarly, the volume partition for /dev/sda
+                                    is "0" (or you can leave the property empty).'
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  description: 'readOnly value true will force the
+                                    readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  type: boolean
+                                volumeID:
+                                  description: 'volumeID is unique ID of the persistent
+                                    disk resource in AWS (Amazon EBS volume). More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            azureDisk:
+                              description: azureDisk represents an Azure Data Disk
+                                mount on the host and bind mount to the pod.
+                              properties:
+                                cachingMode:
+                                  description: 'cachingMode is the Host Caching mode:
+                                    None, Read Only, Read Write.'
+                                  type: string
+                                diskName:
+                                  description: diskName is the Name of the data disk
+                                    in the blob storage
+                                  type: string
+                                diskURI:
+                                  description: diskURI is the URI of data disk in
+                                    the blob storage
+                                  type: string
+                                fsType:
+                                  description: fsType is Filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                kind:
+                                  description: 'kind expected values are Shared: multiple
+                                    blob disks per storage account  Dedicated: single
+                                    blob disk per storage account  Managed: azure
+                                    managed data disk (only in managed availability
+                                    set). defaults to shared'
+                                  type: string
+                                readOnly:
+                                  description: readOnly Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                              required:
+                              - diskName
+                              - diskURI
+                              type: object
+                            azureFile:
+                              description: azureFile represents an Azure File Service
+                                mount on the host and bind mount to the pod.
+                              properties:
+                                readOnly:
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                                secretName:
+                                  description: secretName is the  name of secret that
+                                    contains Azure Storage Account Name and Key
+                                  type: string
+                                shareName:
+                                  description: shareName is the azure share Name
+                                  type: string
+                              required:
+                              - secretName
+                              - shareName
+                              type: object
+                            cephfs:
+                              description: cephFS represents a Ceph FS mount on the
+                                host that shares a pod's lifetime
+                              properties:
+                                monitors:
+                                  description: 'monitors is Required: Monitors is
+                                    a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  items:
+                                    type: string
+                                  type: array
+                                path:
+                                  description: 'path is Optional: Used as the mounted
+                                    root, rather than the full Ceph tree, default
+                                    is /'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly is Optional: Defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: boolean
+                                secretFile:
+                                  description: 'secretFile is Optional: SecretFile
+                                    is the path to key ring for User, default is /etc/ceph/user.secret
+                                    More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: string
+                                secretRef:
+                                  description: 'secretRef is Optional: SecretRef is
+                                    reference to the authentication secret for User,
+                                    default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  description: 'user is optional: User is the rados
+                                    user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                  type: string
+                              required:
+                              - monitors
+                              type: object
+                            cinder:
+                              description: 'cinder represents a cinder volume attached
+                                and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                              properties:
+                                fsType:
+                                  description: 'fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Examples: "ext4", "xfs", "ntfs".
+                                    Implicitly inferred to be "ext4" if unspecified.
+                                    More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: boolean
+                                secretRef:
+                                  description: 'secretRef is optional: points to a
+                                    secret object containing parameters used to connect
+                                    to OpenStack.'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeID:
+                                  description: 'volumeID used to identify the volume
+                                    in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            configMap:
+                              description: configMap represents a configMap that should
+                                populate this volume
+                              properties:
+                                defaultMode:
+                                  description: 'defaultMode is optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: items if unspecified, each key-value
+                                    pair in the Data field of the referenced ConfigMap
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the ConfigMap, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: key is the key to project.
+                                        type: string
+                                      mode:
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file. Must
+                                          be an octal value between 0000 and 0777
+                                          or a decimal value between 0 and 511. YAML
+                                          accepts both octal and decimal values, JSON
+                                          requires decimal values for mode bits. If
+                                          not specified, the volume defaultMode will
+                                          be used. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: path is the relative path of
+                                          the file to map the key to. May not be an
+                                          absolute path. May not contain the path
+                                          element '..'. May not start with the string
+                                          '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                name:
+                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind,
+                                    uid?'
+                                  type: string
+                                optional:
+                                  description: optional specify whether the ConfigMap
+                                    or its keys must be defined
+                                  type: boolean
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            csi:
+                              description: csi (Container Storage Interface) represents
+                                ephemeral storage that is handled by certain external
+                                CSI drivers (Beta feature).
+                              properties:
+                                driver:
+                                  description: driver is the name of the CSI driver
+                                    that handles this volume. Consult with your admin
+                                    for the correct name as registered in the cluster.
+                                  type: string
+                                fsType:
+                                  description: fsType to mount. Ex. "ext4", "xfs",
+                                    "ntfs". If not provided, the empty value is passed
+                                    to the associated CSI driver which will determine
+                                    the default filesystem to apply.
+                                  type: string
+                                nodePublishSecretRef:
+                                  description: nodePublishSecretRef is a reference
+                                    to the secret object containing sensitive information
+                                    to pass to the CSI driver to complete the CSI
+                                    NodePublishVolume and NodeUnpublishVolume calls.
+                                    This field is optional, and  may be empty if no
+                                    secret is required. If the secret object contains
+                                    more than one secret, all secret references are
+                                    passed.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                readOnly:
+                                  description: readOnly specifies a read-only configuration
+                                    for the volume. Defaults to false (read/write).
+                                  type: boolean
+                                volumeAttributes:
+                                  additionalProperties:
+                                    type: string
+                                  description: volumeAttributes stores driver-specific
+                                    properties that are passed to the CSI driver.
+                                    Consult your driver's documentation for supported
+                                    values.
+                                  type: object
+                              required:
+                              - driver
+                              type: object
+                            downwardAPI:
+                              description: downwardAPI represents downward API about
+                                the pod that should populate this volume
+                              properties:
+                                defaultMode:
+                                  description: 'Optional: mode bits to use on created
+                                    files by default. Must be a Optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: Items is a list of downward API volume
+                                    file
+                                  items:
+                                    description: DownwardAPIVolumeFile represents
+                                      information to create the file containing the
+                                      pod field
+                                    properties:
+                                      fieldRef:
+                                        description: 'Required: Selects a field of
+                                          the pod: only annotations, labels, name
+                                          and namespace are supported.'
+                                        properties:
+                                          apiVersion:
+                                            description: Version of the schema the
+                                              FieldPath is written in terms of, defaults
+                                              to "v1".
+                                            type: string
+                                          fieldPath:
+                                            description: Path of the field to select
+                                              in the specified API version.
+                                            type: string
+                                        required:
+                                        - fieldPath
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      mode:
+                                        description: 'Optional: mode bits used to
+                                          set permissions on this file, must be an
+                                          octal value between 0000 and 0777 or a decimal
+                                          value between 0 and 511. YAML accepts both
+                                          octal and decimal values, JSON requires
+                                          decimal values for mode bits. If not specified,
+                                          the volume defaultMode will be used. This
+                                          might be in conflict with other options
+                                          that affect the file mode, like fsGroup,
+                                          and the result can be other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: 'Required: Path is  the relative
+                                          path name of the file to be created. Must
+                                          not be absolute or contain the ''..'' path.
+                                          Must be utf-8 encoded. The first item of
+                                          the relative path must not start with ''..'''
+                                        type: string
+                                      resourceFieldRef:
+                                        description: 'Selects a resource of the container:
+                                          only resources limits and requests (limits.cpu,
+                                          limits.memory, requests.cpu and requests.memory)
+                                          are currently supported.'
+                                        properties:
+                                          containerName:
+                                            description: 'Container name: required
+                                              for volumes, optional for env vars'
+                                            type: string
+                                          divisor:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            description: Specifies the output format
+                                              of the exposed resources, defaults to
+                                              "1"
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          resource:
+                                            description: 'Required: resource to select'
+                                            type: string
+                                        required:
+                                        - resource
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                    required:
+                                    - path
+                                    type: object
+                                  type: array
+                              type: object
+                            emptyDir:
+                              description: 'emptyDir represents a temporary directory
+                                that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                              properties:
+                                medium:
+                                  description: 'medium represents what type of storage
+                                    medium should back this directory. The default
+                                    is "" which means to use the node''s default medium.
+                                    Must be an empty string (default) or Memory. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                  type: string
+                                sizeLimit:
+                                  anyOf:
+                                  - type: integer
+                                  - type: string
+                                  description: 'sizeLimit is the total amount of local
+                                    storage required for this EmptyDir volume. The
+                                    size limit is also applicable for memory medium.
+                                    The maximum usage on memory medium EmptyDir would
+                                    be the minimum value between the SizeLimit specified
+                                    here and the sum of memory limits of all containers
+                                    in a pod. The default is nil which means that
+                                    the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                  x-kubernetes-int-or-string: true
+                              type: object
+                            ephemeral:
+                              description: "ephemeral represents a volume that is
+                                handled by a cluster storage driver. The volume's
+                                lifecycle is tied to the pod that defines it - it
+                                will be created before the pod starts, and deleted
+                                when the pod is removed. \n Use this if: a) the volume
+                                is only needed while the pod runs, b) features of
+                                normal volumes like restoring from snapshot or capacity
+                                tracking are needed, c) the storage driver is specified
+                                through a storage class, and d) the storage driver
+                                supports dynamic volume provisioning through a PersistentVolumeClaim
+                                (see EphemeralVolumeSource for more information on
+                                the connection between this volume type and PersistentVolumeClaim).
+                                \n Use PersistentVolumeClaim or one of the vendor-specific
+                                APIs for volumes that persist for longer than the
+                                lifecycle of an individual pod. \n Use CSI for light-weight
+                                local ephemeral volumes if the CSI driver is meant
+                                to be used that way - see the documentation of the
+                                driver for more information. \n A pod can use both
+                                types of ephemeral volumes and persistent volumes
+                                at the same time."
+                              properties:
+                                volumeClaimTemplate:
+                                  description: "Will be used to create a stand-alone
+                                    PVC to provision the volume. The pod in which
+                                    this EphemeralVolumeSource is embedded will be
+                                    the owner of the PVC, i.e. the PVC will be deleted
+                                    together with the pod.  The name of the PVC will
+                                    be `<pod name>-<volume name>` where `<volume name>`
+                                    is the name from the `PodSpec.Volumes` array entry.
+                                    Pod validation will reject the pod if the concatenated
+                                    name is not valid for a PVC (for example, too
+                                    long). \n An existing PVC with that name that
+                                    is not owned by the pod will *not* be used for
+                                    the pod to avoid using an unrelated volume by
+                                    mistake. Starting the pod is then blocked until
+                                    the unrelated PVC is removed. If such a pre-created
+                                    PVC is meant to be used by the pod, the PVC has
+                                    to updated with an owner reference to the pod
+                                    once the pod exists. Normally this should not
+                                    be necessary, but it may be useful when manually
+                                    reconstructing a broken cluster. \n This field
+                                    is read-only and no changes will be made by Kubernetes
+                                    to the PVC after it has been created. \n Required,
+                                    must not be nil."
+                                  properties:
+                                    metadata:
+                                      description: May contain labels and annotations
+                                        that will be copied into the PVC when creating
+                                        it. No other fields are allowed and will be
+                                        rejected during validation.
+                                      type: object
+                                    spec:
+                                      description: The specification for the PersistentVolumeClaim.
+                                        The entire content is copied unchanged into
+                                        the PVC that gets created from this template.
+                                        The same fields as in a PersistentVolumeClaim
+                                        are also valid here.
+                                      properties:
+                                        accessModes:
+                                          description: 'accessModes contains the desired
+                                            access modes the volume should have. More
+                                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                          items:
+                                            type: string
+                                          type: array
+                                        dataSource:
+                                          description: 'dataSource field can be used
+                                            to specify either: * An existing VolumeSnapshot
+                                            object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                            * An existing PVC (PersistentVolumeClaim)
+                                            If the provisioner or an external controller
+                                            can support the specified data source,
+                                            it will create a new volume based on the
+                                            contents of the specified data source.
+                                            If the AnyVolumeDataSource feature gate
+                                            is enabled, this field will always have
+                                            the same contents as the DataSourceRef
+                                            field.'
+                                          properties:
+                                            apiGroup:
+                                              description: APIGroup is the group for
+                                                the resource being referenced. If
+                                                APIGroup is not specified, the specified
+                                                Kind must be in the core API group.
+                                                For any other third-party types, APIGroup
+                                                is required.
+                                              type: string
+                                            kind:
+                                              description: Kind is the type of resource
+                                                being referenced
+                                              type: string
+                                            name:
+                                              description: Name is the name of resource
+                                                being referenced
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        dataSourceRef:
+                                          description: 'dataSourceRef specifies the
+                                            object from which to populate the volume
+                                            with data, if a non-empty volume is desired.
+                                            This may be any local object from a non-empty
+                                            API group (non core object) or a PersistentVolumeClaim
+                                            object. When this field is specified,
+                                            volume binding will only succeed if the
+                                            type of the specified object matches some
+                                            installed volume populator or dynamic
+                                            provisioner. This field will replace the
+                                            functionality of the DataSource field
+                                            and as such if both fields are non-empty,
+                                            they must have the same value. For backwards
+                                            compatibility, both fields (DataSource
+                                            and DataSourceRef) will be set to the
+                                            same value automatically if one of them
+                                            is empty and the other is non-empty. There
+                                            are two important differences between
+                                            DataSource and DataSourceRef: * While
+                                            DataSource only allows two specific types
+                                            of objects, DataSourceRef allows any non-core
+                                            object, as well as PersistentVolumeClaim
+                                            objects. * While DataSource ignores disallowed
+                                            values (dropping them), DataSourceRef
+                                            preserves all values, and generates an
+                                            error if a disallowed value is specified.
+                                            (Beta) Using this field requires the AnyVolumeDataSource
+                                            feature gate to be enabled.'
+                                          properties:
+                                            apiGroup:
+                                              description: APIGroup is the group for
+                                                the resource being referenced. If
+                                                APIGroup is not specified, the specified
+                                                Kind must be in the core API group.
+                                                For any other third-party types, APIGroup
+                                                is required.
+                                              type: string
+                                            kind:
+                                              description: Kind is the type of resource
+                                                being referenced
+                                              type: string
+                                            name:
+                                              description: Name is the name of resource
+                                                being referenced
+                                              type: string
+                                          required:
+                                          - kind
+                                          - name
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        resources:
+                                          description: 'resources represents the minimum
+                                            resources the volume should have. If RecoverVolumeExpansionFailure
+                                            feature is enabled users are allowed to
+                                            specify resource requirements that are
+                                            lower than previous value but must still
+                                            be higher than capacity recorded in the
+                                            status field of the claim. More info:
+                                            https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                          properties:
+                                            limits:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Limits describes the maximum
+                                                amount of compute resources allowed.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                            requests:
+                                              additionalProperties:
+                                                anyOf:
+                                                - type: integer
+                                                - type: string
+                                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                x-kubernetes-int-or-string: true
+                                              description: 'Requests describes the
+                                                minimum amount of compute resources
+                                                required. If Requests is omitted for
+                                                a container, it defaults to Limits
+                                                if that is explicitly specified, otherwise
+                                                to an implementation-defined value.
+                                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                              type: object
+                                          type: object
+                                        selector:
+                                          description: selector is a label query over
+                                            volumes to consider for binding.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list
+                                                of label selector requirements. The
+                                                requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement
+                                                  is a selector that contains values,
+                                                  a key, and an operator that relates
+                                                  the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label
+                                                      key that the selector applies
+                                                      to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents
+                                                      a key's relationship to a set
+                                                      of values. Valid operators are
+                                                      In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array
+                                                      of string values. If the operator
+                                                      is In or NotIn, the values array
+                                                      must be non-empty. If the operator
+                                                      is Exists or DoesNotExist, the
+                                                      values array must be empty.
+                                                      This array is replaced during
+                                                      a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of
+                                                {key,value} pairs. A single {key,value}
+                                                in the matchLabels map is equivalent
+                                                to an element of matchExpressions,
+                                                whose key field is "key", the operator
+                                                is "In", and the values array contains
+                                                only "value". The requirements are
+                                                ANDed.
+                                              type: object
+                                          type: object
+                                          x-kubernetes-map-type: atomic
+                                        storageClassName:
+                                          description: 'storageClassName is the name
+                                            of the StorageClass required by the claim.
+                                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                          type: string
+                                        volumeMode:
+                                          description: volumeMode defines what type
+                                            of volume is required by the claim. Value
+                                            of Filesystem is implied when not included
+                                            in claim spec.
+                                          type: string
+                                        volumeName:
+                                          description: volumeName is the binding reference
+                                            to the PersistentVolume backing this claim.
+                                          type: string
+                                      type: object
+                                  required:
+                                  - spec
+                                  type: object
+                              type: object
+                            fc:
+                              description: fc represents a Fibre Channel resource
+                                that is attached to a kubelet's host machine and then
+                                exposed to the pod.
+                              properties:
+                                fsType:
+                                  description: 'fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. TODO: how
+                                    do we prevent errors in the filesystem from compromising
+                                    the machine'
+                                  type: string
+                                lun:
+                                  description: 'lun is Optional: FC target lun number'
+                                  format: int32
+                                  type: integer
+                                readOnly:
+                                  description: 'readOnly is Optional: Defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts.'
+                                  type: boolean
+                                targetWWNs:
+                                  description: 'targetWWNs is Optional: FC target
+                                    worldwide names (WWNs)'
+                                  items:
+                                    type: string
+                                  type: array
+                                wwids:
+                                  description: 'wwids Optional: FC volume world wide
+                                    identifiers (wwids) Either wwids or combination
+                                    of targetWWNs and lun must be set, but not both
+                                    simultaneously.'
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            flexVolume:
+                              description: flexVolume represents a generic volume
+                                resource that is provisioned/attached using an exec
+                                based plugin.
+                              properties:
+                                driver:
+                                  description: driver is the name of the driver to
+                                    use for this volume.
+                                  type: string
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". The
+                                    default filesystem depends on FlexVolume script.
+                                  type: string
+                                options:
+                                  additionalProperties:
+                                    type: string
+                                  description: 'options is Optional: this field holds
+                                    extra command options if any.'
+                                  type: object
+                                readOnly:
+                                  description: 'readOnly is Optional: defaults to
+                                    false (read/write). ReadOnly here will force the
+                                    ReadOnly setting in VolumeMounts.'
+                                  type: boolean
+                                secretRef:
+                                  description: 'secretRef is Optional: secretRef is
+                                    reference to the secret object containing sensitive
+                                    information to pass to the plugin scripts. This
+                                    may be empty if no secret object is specified.
+                                    If the secret object contains more than one secret,
+                                    all secrets are passed to the plugin scripts.'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              required:
+                              - driver
+                              type: object
+                            flocker:
+                              description: flocker represents a Flocker volume attached
+                                to a kubelet's host machine. This depends on the Flocker
+                                control service being running
+                              properties:
+                                datasetName:
+                                  description: datasetName is Name of the dataset
+                                    stored as metadata -> name on the dataset for
+                                    Flocker should be considered as deprecated
+                                  type: string
+                                datasetUUID:
+                                  description: datasetUUID is the UUID of the dataset.
+                                    This is unique identifier of a Flocker dataset
+                                  type: string
+                              type: object
+                            gcePersistentDisk:
+                              description: 'gcePersistentDisk represents a GCE Disk
+                                resource that is attached to a kubelet''s host machine
+                                and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                              properties:
+                                fsType:
+                                  description: 'fsType is filesystem type of the volume
+                                    that you want to mount. Tip: Ensure that the filesystem
+                                    type is supported by the host operating system.
+                                    Examples: "ext4", "xfs", "ntfs". Implicitly inferred
+                                    to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                                    TODO: how do we prevent errors in the filesystem
+                                    from compromising the machine'
+                                  type: string
+                                partition:
+                                  description: 'partition is the partition in the
+                                    volume that you want to mount. If omitted, the
+                                    default is to mount by volume name. Examples:
+                                    For volume /dev/sda1, you specify the partition
+                                    as "1". Similarly, the volume partition for /dev/sda
+                                    is "0" (or you can leave the property empty).
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  format: int32
+                                  type: integer
+                                pdName:
+                                  description: 'pdName is unique name of the PD resource
+                                    in GCE. Used to identify the disk in GCE. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the ReadOnly
+                                    setting in VolumeMounts. Defaults to false. More
+                                    info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                  type: boolean
+                              required:
+                              - pdName
+                              type: object
+                            gitRepo:
+                              description: 'gitRepo represents a git repository at
+                                a particular revision. DEPRECATED: GitRepo is deprecated.
+                                To provision a container with a git repo, mount an
+                                EmptyDir into an InitContainer that clones the repo
+                                using git, then mount the EmptyDir into the Pod''s
+                                container.'
+                              properties:
+                                directory:
+                                  description: directory is the target directory name.
+                                    Must not contain or start with '..'.  If '.' is
+                                    supplied, the volume directory will be the git
+                                    repository.  Otherwise, if specified, the volume
+                                    will contain the git repository in the subdirectory
+                                    with the given name.
+                                  type: string
+                                repository:
+                                  description: repository is the URL
+                                  type: string
+                                revision:
+                                  description: revision is the commit hash for the
+                                    specified revision.
+                                  type: string
+                              required:
+                              - repository
+                              type: object
+                            glusterfs:
+                              description: 'glusterfs represents a Glusterfs mount
+                                on the host that shares a pod''s lifetime. More info:
+                                https://examples.k8s.io/volumes/glusterfs/README.md'
+                              properties:
+                                endpoints:
+                                  description: 'endpoints is the endpoint name that
+                                    details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: string
+                                path:
+                                  description: 'path is the Glusterfs volume path.
+                                    More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the Glusterfs
+                                    volume to be mounted with read-only permissions.
+                                    Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                  type: boolean
+                              required:
+                              - endpoints
+                              - path
+                              type: object
+                            hostPath:
+                              description: 'hostPath represents a pre-existing file
+                                or directory on the host machine that is directly
+                                exposed to the container. This is generally used for
+                                system agents or other privileged things that are
+                                allowed to see the host machine. Most containers will
+                                NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                --- TODO(jonesdl) We need to restrict who can use
+                                host directory mounts and who can/can not mount host
+                                directories as read/write.'
+                              properties:
+                                path:
+                                  description: 'path of the directory on the host.
+                                    If the path is a symlink, it will follow the link
+                                    to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  type: string
+                                type:
+                                  description: 'type for HostPath Volume Defaults
+                                    to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                  type: string
+                              required:
+                              - path
+                              type: object
+                            iscsi:
+                              description: 'iscsi represents an ISCSI Disk resource
+                                that is attached to a kubelet''s host machine and
+                                then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                              properties:
+                                chapAuthDiscovery:
+                                  description: chapAuthDiscovery defines whether support
+                                    iSCSI Discovery CHAP authentication
+                                  type: boolean
+                                chapAuthSession:
+                                  description: chapAuthSession defines whether support
+                                    iSCSI Session CHAP authentication
+                                  type: boolean
+                                fsType:
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                    TODO: how do we prevent errors in the filesystem
+                                    from compromising the machine'
+                                  type: string
+                                initiatorName:
+                                  description: initiatorName is the custom iSCSI Initiator
+                                    Name. If initiatorName is specified with iscsiInterface
+                                    simultaneously, new iSCSI interface <target portal>:<volume
+                                    name> will be created for the connection.
+                                  type: string
+                                iqn:
+                                  description: iqn is the target iSCSI Qualified Name.
+                                  type: string
+                                iscsiInterface:
+                                  description: iscsiInterface is the interface Name
+                                    that uses an iSCSI transport. Defaults to 'default'
+                                    (tcp).
+                                  type: string
+                                lun:
+                                  description: lun represents iSCSI Target Lun number.
+                                  format: int32
+                                  type: integer
+                                portals:
+                                  description: portals is the iSCSI Target Portal
+                                    List. The portal is either an IP or ip_addr:port
+                                    if the port is other than default (typically TCP
+                                    ports 860 and 3260).
+                                  items:
+                                    type: string
+                                  type: array
+                                readOnly:
+                                  description: readOnly here will force the ReadOnly
+                                    setting in VolumeMounts. Defaults to false.
+                                  type: boolean
+                                secretRef:
+                                  description: secretRef is the CHAP Secret for iSCSI
+                                    target and initiator authentication
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                targetPortal:
+                                  description: targetPortal is iSCSI Target Portal.
+                                    The Portal is either an IP or ip_addr:port if
+                                    the port is other than default (typically TCP
+                                    ports 860 and 3260).
+                                  type: string
+                              required:
+                              - iqn
+                              - lun
+                              - targetPortal
+                              type: object
+                            name:
+                              description: 'name of the volume. Must be a DNS_LABEL
+                                and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                              type: string
+                            nfs:
+                              description: 'nfs represents an NFS mount on the host
+                                that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                              properties:
+                                path:
+                                  description: 'path that is exported by the NFS server.
+                                    More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the NFS export
+                                    to be mounted with read-only permissions. Defaults
+                                    to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: boolean
+                                server:
+                                  description: 'server is the hostname or IP address
+                                    of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                  type: string
+                              required:
+                              - path
+                              - server
+                              type: object
+                            persistentVolumeClaim:
+                              description: 'persistentVolumeClaimVolumeSource represents
+                                a reference to a PersistentVolumeClaim in the same
+                                namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                              properties:
+                                claimName:
+                                  description: 'claimName is the name of a PersistentVolumeClaim
+                                    in the same namespace as the pod using this volume.
+                                    More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                  type: string
+                                readOnly:
+                                  description: readOnly Will force the ReadOnly setting
+                                    in VolumeMounts. Default false.
+                                  type: boolean
+                              required:
+                              - claimName
+                              type: object
+                            photonPersistentDisk:
+                              description: photonPersistentDisk represents a PhotonController
+                                persistent disk attached and mounted on kubelets host
+                                machine
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                pdID:
+                                  description: pdID is the ID that identifies Photon
+                                    Controller persistent disk
+                                  type: string
+                              required:
+                              - pdID
+                              type: object
+                            portworxVolume:
+                              description: portworxVolume represents a portworx volume
+                                attached and mounted on kubelets host machine
+                              properties:
+                                fsType:
+                                  description: fSType represents the filesystem type
+                                    to mount Must be a filesystem type supported by
+                                    the host operating system. Ex. "ext4", "xfs".
+                                    Implicitly inferred to be "ext4" if unspecified.
+                                  type: string
+                                readOnly:
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                                volumeID:
+                                  description: volumeID uniquely identifies a Portworx
+                                    volume
+                                  type: string
+                              required:
+                              - volumeID
+                              type: object
+                            projected:
+                              description: projected items for all in one resources
+                                secrets, configmaps, and downward API
+                              properties:
+                                defaultMode:
+                                  description: defaultMode are the mode bits used
+                                    to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Directories within the path
+                                    are not affected by this setting. This might be
+                                    in conflict with other options that affect the
+                                    file mode, like fsGroup, and the result can be
+                                    other mode bits set.
+                                  format: int32
+                                  type: integer
+                                sources:
+                                  description: sources is the list of volume projections
+                                  items:
+                                    description: Projection that may be projected
+                                      along with other supported volume types
+                                    properties:
+                                      configMap:
+                                        description: configMap information about the
+                                          configMap data to project
+                                        properties:
+                                          items:
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced ConfigMap will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the ConfigMap, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
+                                                    '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: optional specify whether
+                                              the ConfigMap or its keys must be defined
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      downwardAPI:
+                                        description: downwardAPI information about
+                                          the downwardAPI data to project
+                                        properties:
+                                          items:
+                                            description: Items is a list of DownwardAPIVolume
+                                              file
+                                            items:
+                                              description: DownwardAPIVolumeFile represents
+                                                information to create the file containing
+                                                the pod field
+                                              properties:
+                                                fieldRef:
+                                                  description: 'Required: Selects
+                                                    a field of the pod: only annotations,
+                                                    labels, name and namespace are
+                                                    supported.'
+                                                  properties:
+                                                    apiVersion:
+                                                      description: Version of the
+                                                        schema the FieldPath is written
+                                                        in terms of, defaults to "v1".
+                                                      type: string
+                                                    fieldPath:
+                                                      description: Path of the field
+                                                        to select in the specified
+                                                        API version.
+                                                      type: string
+                                                  required:
+                                                  - fieldPath
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                                mode:
+                                                  description: 'Optional: mode bits
+                                                    used to set permissions on this
+                                                    file, must be an octal value between
+                                                    0000 and 0777 or a decimal value
+                                                    between 0 and 511. YAML accepts
+                                                    both octal and decimal values,
+                                                    JSON requires decimal values for
+                                                    mode bits. If not specified, the
+                                                    volume defaultMode will be used.
+                                                    This might be in conflict with
+                                                    other options that affect the
+                                                    file mode, like fsGroup, and the
+                                                    result can be other mode bits
+                                                    set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: 'Required: Path is  the
+                                                    relative path name of the file
+                                                    to be created. Must not be absolute
+                                                    or contain the ''..'' path. Must
+                                                    be utf-8 encoded. The first item
+                                                    of the relative path must not
+                                                    start with ''..'''
+                                                  type: string
+                                                resourceFieldRef:
+                                                  description: 'Selects a resource
+                                                    of the container: only resources
+                                                    limits and requests (limits.cpu,
+                                                    limits.memory, requests.cpu and
+                                                    requests.memory) are currently
+                                                    supported.'
+                                                  properties:
+                                                    containerName:
+                                                      description: 'Container name:
+                                                        required for volumes, optional
+                                                        for env vars'
+                                                      type: string
+                                                    divisor:
+                                                      anyOf:
+                                                      - type: integer
+                                                      - type: string
+                                                      description: Specifies the output
+                                                        format of the exposed resources,
+                                                        defaults to "1"
+                                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                      x-kubernetes-int-or-string: true
+                                                    resource:
+                                                      description: 'Required: resource
+                                                        to select'
+                                                      type: string
+                                                  required:
+                                                  - resource
+                                                  type: object
+                                                  x-kubernetes-map-type: atomic
+                                              required:
+                                              - path
+                                              type: object
+                                            type: array
+                                        type: object
+                                      secret:
+                                        description: secret information about the
+                                          secret data to project
+                                        properties:
+                                          items:
+                                            description: items if unspecified, each
+                                              key-value pair in the Data field of
+                                              the referenced Secret will be projected
+                                              into the volume as a file whose name
+                                              is the key and content is the value.
+                                              If specified, the listed keys will be
+                                              projected into the specified paths,
+                                              and unlisted keys will not be present.
+                                              If a key is specified which is not present
+                                              in the Secret, the volume setup will
+                                              error unless it is marked optional.
+                                              Paths must be relative and may not contain
+                                              the '..' path or start with '..'.
+                                            items:
+                                              description: Maps a string key to a
+                                                path within a volume.
+                                              properties:
+                                                key:
+                                                  description: key is the key to project.
+                                                  type: string
+                                                mode:
+                                                  description: 'mode is Optional:
+                                                    mode bits used to set permissions
+                                                    on this file. Must be an octal
+                                                    value between 0000 and 0777 or
+                                                    a decimal value between 0 and
+                                                    511. YAML accepts both octal and
+                                                    decimal values, JSON requires
+                                                    decimal values for mode bits.
+                                                    If not specified, the volume defaultMode
+                                                    will be used. This might be in
+                                                    conflict with other options that
+                                                    affect the file mode, like fsGroup,
+                                                    and the result can be other mode
+                                                    bits set.'
+                                                  format: int32
+                                                  type: integer
+                                                path:
+                                                  description: path is the relative
+                                                    path of the file to map the key
+                                                    to. May not be an absolute path.
+                                                    May not contain the path element
+                                                    '..'. May not start with the string
+                                                    '..'.
+                                                  type: string
+                                              required:
+                                              - key
+                                              - path
+                                              type: object
+                                            type: array
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                          optional:
+                                            description: optional field specify whether
+                                              the Secret or its key must be defined
+                                            type: boolean
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      serviceAccountToken:
+                                        description: serviceAccountToken is information
+                                          about the serviceAccountToken data to project
+                                        properties:
+                                          audience:
+                                            description: audience is the intended
+                                              audience of the token. A recipient of
+                                              a token must identify itself with an
+                                              identifier specified in the audience
+                                              of the token, and otherwise should reject
+                                              the token. The audience defaults to
+                                              the identifier of the apiserver.
+                                            type: string
+                                          expirationSeconds:
+                                            description: expirationSeconds is the
+                                              requested duration of validity of the
+                                              service account token. As the token
+                                              approaches expiration, the kubelet volume
+                                              plugin will proactively rotate the service
+                                              account token. The kubelet will start
+                                              trying to rotate the token if the token
+                                              is older than 80 percent of its time
+                                              to live or if the token is older than
+                                              24 hours.Defaults to 1 hour and must
+                                              be at least 10 minutes.
+                                            format: int64
+                                            type: integer
+                                          path:
+                                            description: path is the path relative
+                                              to the mount point of the file to project
+                                              the token into.
+                                            type: string
+                                        required:
+                                        - path
+                                        type: object
+                                    type: object
+                                  type: array
+                              type: object
+                            quobyte:
+                              description: quobyte represents a Quobyte mount on the
+                                host that shares a pod's lifetime
+                              properties:
+                                group:
+                                  description: group to map volume access to Default
+                                    is no group
+                                  type: string
+                                readOnly:
+                                  description: readOnly here will force the Quobyte
+                                    volume to be mounted with read-only permissions.
+                                    Defaults to false.
+                                  type: boolean
+                                registry:
+                                  description: registry represents a single or multiple
+                                    Quobyte Registry services specified as a string
+                                    as host:port pair (multiple entries are separated
+                                    with commas) which acts as the central registry
+                                    for volumes
+                                  type: string
+                                tenant:
+                                  description: tenant owning the given Quobyte volume
+                                    in the Backend Used with dynamically provisioned
+                                    Quobyte volumes, value is set by the plugin
+                                  type: string
+                                user:
+                                  description: user to map volume access to Defaults
+                                    to serivceaccount user
+                                  type: string
+                                volume:
+                                  description: volume is a string that references
+                                    an already created Quobyte volume by name.
+                                  type: string
+                              required:
+                              - registry
+                              - volume
+                              type: object
+                            rbd:
+                              description: 'rbd represents a Rados Block Device mount
+                                on the host that shares a pod''s lifetime. More info:
+                                https://examples.k8s.io/volumes/rbd/README.md'
+                              properties:
+                                fsType:
+                                  description: 'fsType is the filesystem type of the
+                                    volume that you want to mount. Tip: Ensure that
+                                    the filesystem type is supported by the host operating
+                                    system. Examples: "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified. More info:
+                                    https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                    TODO: how do we prevent errors in the filesystem
+                                    from compromising the machine'
+                                  type: string
+                                image:
+                                  description: 'image is the rados image name. More
+                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                keyring:
+                                  description: 'keyring is the path to key ring for
+                                    RBDUser. Default is /etc/ceph/keyring. More info:
+                                    https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                monitors:
+                                  description: 'monitors is a collection of Ceph monitors.
+                                    More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  items:
+                                    type: string
+                                  type: array
+                                pool:
+                                  description: 'pool is the rados pool name. Default
+                                    is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                                readOnly:
+                                  description: 'readOnly here will force the ReadOnly
+                                    setting in VolumeMounts. Defaults to false. More
+                                    info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: boolean
+                                secretRef:
+                                  description: 'secretRef is name of the authentication
+                                    secret for RBDUser. If provided overrides keyring.
+                                    Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                user:
+                                  description: 'user is the rados user name. Default
+                                    is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                  type: string
+                              required:
+                              - image
+                              - monitors
+                              type: object
+                            scaleIO:
+                              description: scaleIO represents a ScaleIO persistent
+                                volume attached and mounted on Kubernetes nodes.
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Default
+                                    is "xfs".
+                                  type: string
+                                gateway:
+                                  description: gateway is the host address of the
+                                    ScaleIO API Gateway.
+                                  type: string
+                                protectionDomain:
+                                  description: protectionDomain is the name of the
+                                    ScaleIO Protection Domain for the configured storage.
+                                  type: string
+                                readOnly:
+                                  description: readOnly Defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: secretRef references to the secret
+                                    for ScaleIO user and other sensitive information.
+                                    If this is not provided, Login operation will
+                                    fail.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                sslEnabled:
+                                  description: sslEnabled Flag enable/disable SSL
+                                    communication with Gateway, default false
+                                  type: boolean
+                                storageMode:
+                                  description: storageMode indicates whether the storage
+                                    for a volume should be ThickProvisioned or ThinProvisioned.
+                                    Default is ThinProvisioned.
+                                  type: string
+                                storagePool:
+                                  description: storagePool is the ScaleIO Storage
+                                    Pool associated with the protection domain.
+                                  type: string
+                                system:
+                                  description: system is the name of the storage system
+                                    as configured in ScaleIO.
+                                  type: string
+                                volumeName:
+                                  description: volumeName is the name of a volume
+                                    already created in the ScaleIO system that is
+                                    associated with this volume source.
+                                  type: string
+                              required:
+                              - gateway
+                              - secretRef
+                              - system
+                              type: object
+                            secret:
+                              description: 'secret represents a secret that should
+                                populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                              properties:
+                                defaultMode:
+                                  description: 'defaultMode is Optional: mode bits
+                                    used to set permissions on created files by default.
+                                    Must be an octal value between 0000 and 0777 or
+                                    a decimal value between 0 and 511. YAML accepts
+                                    both octal and decimal values, JSON requires decimal
+                                    values for mode bits. Defaults to 0644. Directories
+                                    within the path are not affected by this setting.
+                                    This might be in conflict with other options that
+                                    affect the file mode, like fsGroup, and the result
+                                    can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                items:
+                                  description: items If unspecified, each key-value
+                                    pair in the Data field of the referenced Secret
+                                    will be projected into the volume as a file whose
+                                    name is the key and content is the value. If specified,
+                                    the listed keys will be projected into the specified
+                                    paths, and unlisted keys will not be present.
+                                    If a key is specified which is not present in
+                                    the Secret, the volume setup will error unless
+                                    it is marked optional. Paths must be relative
+                                    and may not contain the '..' path or start with
+                                    '..'.
+                                  items:
+                                    description: Maps a string key to a path within
+                                      a volume.
+                                    properties:
+                                      key:
+                                        description: key is the key to project.
+                                        type: string
+                                      mode:
+                                        description: 'mode is Optional: mode bits
+                                          used to set permissions on this file. Must
+                                          be an octal value between 0000 and 0777
+                                          or a decimal value between 0 and 511. YAML
+                                          accepts both octal and decimal values, JSON
+                                          requires decimal values for mode bits. If
+                                          not specified, the volume defaultMode will
+                                          be used. This might be in conflict with
+                                          other options that affect the file mode,
+                                          like fsGroup, and the result can be other
+                                          mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: path is the relative path of
+                                          the file to map the key to. May not be an
+                                          absolute path. May not contain the path
+                                          element '..'. May not start with the string
+                                          '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                optional:
+                                  description: optional field specify whether the
+                                    Secret or its keys must be defined
+                                  type: boolean
+                                secretName:
+                                  description: 'secretName is the name of the secret
+                                    in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                  type: string
+                              type: object
+                            storageos:
+                              description: storageOS represents a StorageOS volume
+                                attached and mounted on Kubernetes nodes.
+                              properties:
+                                fsType:
+                                  description: fsType is the filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                readOnly:
+                                  description: readOnly defaults to false (read/write).
+                                    ReadOnly here will force the ReadOnly setting
+                                    in VolumeMounts.
+                                  type: boolean
+                                secretRef:
+                                  description: secretRef specifies the secret to use
+                                    for obtaining the StorageOS API credentials.  If
+                                    not specified, default values will be attempted.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                volumeName:
+                                  description: volumeName is the human-readable name
+                                    of the StorageOS volume.  Volume names are only
+                                    unique within a namespace.
+                                  type: string
+                                volumeNamespace:
+                                  description: volumeNamespace specifies the scope
+                                    of the volume within StorageOS.  If no namespace
+                                    is specified then the Pod's namespace will be
+                                    used.  This allows the Kubernetes name scoping
+                                    to be mirrored within StorageOS for tighter integration.
+                                    Set VolumeName to any name to override the default
+                                    behaviour. Set to "default" if you are not using
+                                    namespaces within StorageOS. Namespaces that do
+                                    not pre-exist within StorageOS will be created.
+                                  type: string
+                              type: object
+                            vsphereVolume:
+                              description: vsphereVolume represents a vSphere volume
+                                attached and mounted on kubelets host machine
+                              properties:
+                                fsType:
+                                  description: fsType is filesystem type to mount.
+                                    Must be a filesystem type supported by the host
+                                    operating system. Ex. "ext4", "xfs", "ntfs". Implicitly
+                                    inferred to be "ext4" if unspecified.
+                                  type: string
+                                storagePolicyID:
+                                  description: storagePolicyID is the storage Policy
+                                    Based Management (SPBM) profile ID associated
+                                    with the StoragePolicyName.
+                                  type: string
+                                storagePolicyName:
+                                  description: storagePolicyName is the storage Policy
+                                    Based Management (SPBM) profile name.
+                                  type: string
+                                volumePath:
+                                  description: volumePath is the path that identifies
+                                    vSphere volume vmdk
+                                  type: string
+                              required:
+                              - volumePath
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    required:
+                    - container
+                    type: object
+                  imageRepoSecret:
+                    description: ImageRepoSecret is an optional secret that is used
+                      to pull both the module loader and the device plugin, and to
+                      push the resulting image from the module loader build, if enabled.
+                    properties:
+                      name:
+                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          TODO: Add other useful fields. apiVersion, kind, uid?'
+                        type: string
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  moduleLoader:
+                    description: ModuleLoader allows overriding some properties of
+                      the container that loads the kernel module on the node. Name
+                      and image are ignored and are set automatically by the KMM Operator.
+                    properties:
+                      container:
+                        description: Container holds the properties for the module
+                          loader container that runs modprobe.
+                        properties:
+                          build:
+                            description: Build contains build instructions.
+                            properties:
+                              baseImageRegistryTLS:
+                                description: BaseImageRegistryTLS contains settings
+                                  determining how to access registries of the base
+                                  images in the build-process' Dockerfile.
+                                properties:
+                                  insecure:
+                                    description: If Insecure is true, the operator
+                                      will be able to access a registry in an insecure
+                                      (plain HTTP) protocol.
+                                    type: boolean
+                                  insecureSkipTLSVerify:
+                                    description: If InsecureSkipTLSVerify, the operator
+                                      will accept any certificate provided by the
+                                      registry.
+                                    type: boolean
+                                type: object
+                              buildArgs:
+                                description: BuildArgs is an array of build variables
+                                  that are provided to the image building backend.
+                                items:
+                                  description: BuildArg represents a build argument
+                                    used when building a container image.
+                                  properties:
+                                    name:
+                                      type: string
+                                    value:
+                                      type: string
+                                  required:
+                                  - name
+                                  - value
+                                  type: object
+                                type: array
+                              dockerfileConfigMap:
+                                description: ConfigMap that holds Dockerfile contents
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              kanikoParams:
+                                description: KanikoParams is used to customize the
+                                  building process of the image.
+                                properties:
+                                  tag:
+                                    description: Kaniko image tag to use when creating
+                                      the build Job
+                                    type: string
+                                type: object
+                              secrets:
+                                description: Secrets is an optional list of secrets
+                                  to be made available to the build system. Those
+                                  secrets should be used for private resources such
+                                  as a private Github repo. For container registries
+                                  auth use module.spec.imagePullSecret instead.
+                                items:
+                                  description: LocalObjectReference contains enough
+                                    information to let you locate the referenced object
+                                    inside the same namespace.
+                                  properties:
+                                    name:
+                                      description: 'Name of the referent. More info:
+                                        https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion,
+                                        kind, uid?'
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                type: array
+                            required:
+                            - dockerfileConfigMap
+                            type: object
+                          containerImage:
+                            description: ContainerImage is a top-level field
+                            type: string
+                          imagePullPolicy:
+                            description: 'Image pull policy. One of Always, Never,
+                              IfNotPresent. Defaults to Always if :latest tag is specified,
+                              or IfNotPresent otherwise. Cannot be updated. More info:
+                              https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                            type: string
+                          kernelMappings:
+                            description: KernelMappings is a list of kernel mappings.
+                              When a node's labels match Selector, then the KMM Operator
+                              will look for the first mapping that matches its kernel
+                              version, and use the corresponding container image to
+                              run the DriverContainer.
+                            items:
+                              description: KernelMapping pairs kernel versions with
+                                a DriverContainer image. Kernel versions can be matched
+                                literally or using a regular expression.
+                              properties:
+                                build:
+                                  description: Build enables in-cluster builds for
+                                    this mapping and allows overriding the Module's
+                                    build settings.
+                                  properties:
+                                    baseImageRegistryTLS:
+                                      description: BaseImageRegistryTLS contains settings
+                                        determining how to access registries of the
+                                        base images in the build-process' Dockerfile.
+                                      properties:
+                                        insecure:
+                                          description: If Insecure is true, the operator
+                                            will be able to access a registry in an
+                                            insecure (plain HTTP) protocol.
+                                          type: boolean
+                                        insecureSkipTLSVerify:
+                                          description: If InsecureSkipTLSVerify, the
+                                            operator will accept any certificate provided
+                                            by the registry.
+                                          type: boolean
+                                      type: object
+                                    buildArgs:
+                                      description: BuildArgs is an array of build
+                                        variables that are provided to the image building
+                                        backend.
+                                      items:
+                                        description: BuildArg represents a build argument
+                                          used when building a container image.
+                                        properties:
+                                          name:
+                                            type: string
+                                          value:
+                                            type: string
+                                        required:
+                                        - name
+                                        - value
+                                        type: object
+                                      type: array
+                                    dockerfileConfigMap:
+                                      description: ConfigMap that holds Dockerfile
+                                        contents
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    kanikoParams:
+                                      description: KanikoParams is used to customize
+                                        the building process of the image.
+                                      properties:
+                                        tag:
+                                          description: Kaniko image tag to use when
+                                            creating the build Job
+                                          type: string
+                                      type: object
+                                    secrets:
+                                      description: Secrets is an optional list of
+                                        secrets to be made available to the build
+                                        system. Those secrets should be used for private
+                                        resources such as a private Github repo. For
+                                        container registries auth use module.spec.imagePullSecret
+                                        instead.
+                                      items:
+                                        description: LocalObjectReference contains
+                                          enough information to let you locate the
+                                          referenced object inside the same namespace.
+                                        properties:
+                                          name:
+                                            description: 'Name of the referent. More
+                                              info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                              TODO: Add other useful fields. apiVersion,
+                                              kind, uid?'
+                                            type: string
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      type: array
+                                  required:
+                                  - dockerfileConfigMap
+                                  type: object
+                                containerImage:
+                                  description: ContainerImage is the name of the DriverContainer
+                                    image that should be used to deploy the module.
+                                  type: string
+                                literal:
+                                  description: Literal defines a literal target kernel
+                                    version to be matched exactly against node kernels.
+                                  type: string
+                                regexp:
+                                  description: Regexp is a regular expression to be
+                                    match against node kernels.
+                                  type: string
+                                registryTLS:
+                                  description: RegistryTLS set the TLS configs for
+                                    accessing the registry of the module-loader's
+                                    image.
+                                  properties:
+                                    insecure:
+                                      description: If Insecure is true, the operator
+                                        will be able to access a registry in an insecure
+                                        (plain HTTP) protocol.
+                                      type: boolean
+                                    insecureSkipTLSVerify:
+                                      description: If InsecureSkipTLSVerify, the operator
+                                        will accept any certificate provided by the
+                                        registry.
+                                      type: boolean
+                                  type: object
+                                sign:
+                                  description: Sign enables in-cluster signing for
+                                    this mapping
+                                  properties:
+                                    certSecret:
+                                      description: a secret containing the public
+                                        key used to sign kernel modules for secureboot
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    filesToSign:
+                                      description: paths inside the image for the
+                                        kernel modules to sign (if ommited all kmods
+                                        are signed)
+                                      items:
+                                        type: string
+                                      type: array
+                                    keySecret:
+                                      description: a secret containing the private
+                                        key used to sign kernel modules for secureboot
+                                      properties:
+                                        name:
+                                          description: 'Name of the referent. More
+                                            info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                            TODO: Add other useful fields. apiVersion,
+                                            kind, uid?'
+                                          type: string
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    unsignedImage:
+                                      description: Image to sign, ignored if a Build
+                                        is present, required otherwise
+                                      type: string
+                                  required:
+                                  - certSecret
+                                  - keySecret
+                                  type: object
+                              required:
+                              - containerImage
+                              type: object
+                            minItems: 1
+                            type: array
+                          modprobe:
+                            description: Modprobe is a set of properties to customize
+                              which module modprobe loads and with which properties.
+                            properties:
+                              args:
+                                description: 'Args is an optional list of arguments
+                                  to be passed to modprobe before the name of the
+                                  kernel module. The resulting commands will be: `modprobe
+                                  ${Args} module_name`.'
+                                properties:
+                                  load:
+                                    description: Load is an optional list of arguments
+                                      to be used when loading the kernel module.
+                                    items:
+                                      type: string
+                                    minItems: 1
+                                    type: array
+                                  unload:
+                                    description: Unload is an optional list of arguments
+                                      to be used when unloading the kernel module.
+                                    items:
+                                      type: string
+                                    minItems: 1
+                                    type: array
+                                type: object
+                              dirName:
+                                default: /opt
+                                description: DirName is the root directory for modules.
+                                  It adds `-d ${DirName}` to the modprobe command-line.
+                                type: string
+                              firmwarePath:
+                                description: FirmwarePath is the path of the firmware(s).
+                                  The firmware(s) will be copied to the host for the
+                                  kernel to find them.
+                                type: string
+                              moduleName:
+                                description: ModuleName is the name of the Module
+                                  to be loaded.
+                                type: string
+                              parameters:
+                                description: 'Parameters is an optional list of kernel
+                                  module parameters to be provided to modprobe. They
+                                  should be in the form of key=value and will be separated
+                                  by spaces in the modprobe command. The resulting
+                                  loading command will be: `modprobe module_name ${Parameters}`.'
+                                items:
+                                  type: string
+                                type: array
+                              rawArgs:
+                                description: 'If RawArgs are specified, they are passed
+                                  straight to the modprobe binary; all other properties
+                                  in this object are ignored. The resulting commands
+                                  will be: `modprobe ${RawArgs}`.'
+                                properties:
+                                  load:
+                                    description: Load is an optional list of arguments
+                                      to be used when loading the kernel module.
+                                    items:
+                                      type: string
+                                    minItems: 1
+                                    type: array
+                                  unload:
+                                    description: Unload is an optional list of arguments
+                                      to be used when unloading the kernel module.
+                                    items:
+                                      type: string
+                                    minItems: 1
+                                    type: array
+                                type: object
+                            required:
+                            - moduleName
+                            type: object
+                          registryTLS:
+                            description: RegistryTLS set the TLS configs for accessing
+                              the registry of the module-loader's image.
+                            properties:
+                              insecure:
+                                description: If Insecure is true, the operator will
+                                  be able to access a registry in an insecure (plain
+                                  HTTP) protocol.
+                                type: boolean
+                              insecureSkipTLSVerify:
+                                description: If InsecureSkipTLSVerify, the operator
+                                  will accept any certificate provided by the registry.
+                                type: boolean
+                            type: object
+                          sign:
+                            description: Sign provides default kmod signing settings
+                            properties:
+                              certSecret:
+                                description: a secret containing the public key used
+                                  to sign kernel modules for secureboot
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              filesToSign:
+                                description: paths inside the image for the kernel
+                                  modules to sign (if ommited all kmods are signed)
+                                items:
+                                  type: string
+                                type: array
+                              keySecret:
+                                description: a secret containing the private key used
+                                  to sign kernel modules for secureboot
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info:
+                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind,
+                                      uid?'
+                                    type: string
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              unsignedImage:
+                                description: Image to sign, ignored if a Build is
+                                  present, required otherwise
+                                type: string
+                            required:
+                            - certSecret
+                            - keySecret
+                            type: object
+                        required:
+                        - kernelMappings
+                        - modprobe
+                        type: object
+                      serviceAccountName:
+                        description: 'ServiceAccountName is the name of the ServiceAccount
+                          to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
+                        type: string
+                    required:
+                    - container
+                    type: object
+                  selector:
+                    additionalProperties:
+                      type: string
+                    description: Selector describes on which nodes the Module should
+                      be loaded and optionally built.
+                    type: object
+                required:
+                - moduleLoader
+                - selector
+                type: object
+              namespace:
+                description: Namespace describes the Spoke namespace, in which the
+                  ModuleSpec should be applied.
+                type: string
+              selector:
+                additionalProperties:
+                  type: string
+                description: Selector describes on which managed clusters the ModuleSpec
+                  should be applied.
+                type: object
+            required:
+            - selector
+            type: object
+          status:
+            description: ManagedClusterModuleStatus defines the observed state of
+              ManagedClusterModule.
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/kmm.sigs.k8s.io_modules.yaml
+++ b/bundle/manifests/kmm.sigs.k8s.io_modules.yaml
@@ -1874,6 +1874,21 @@ spec:
                       build:
                         description: Build contains build instructions.
                         properties:
+                          baseImageRegistryTLS:
+                            description: BaseImageRegistryTLS contains settings determining
+                              how to access registries of the base images in the build-process'
+                              Dockerfile.
+                            properties:
+                              insecure:
+                                description: If Insecure is true, the operator will
+                                  be able to access a registry in an insecure (plain
+                                  HTTP) protocol.
+                                type: boolean
+                              insecureSkipTLSVerify:
+                                description: If InsecureSkipTLSVerify, the operator
+                                  will accept any certificate provided by the registry.
+                                type: boolean
+                            type: object
                           buildArgs:
                             description: BuildArgs is an array of build variables
                               that are provided to the image building backend.
@@ -1908,32 +1923,6 @@ spec:
                                 description: Kaniko image tag to use when creating
                                   the build Job
                                 type: string
-                            type: object
-                          pull:
-                            description: Pull contains settings determining how to
-                              pull the base images of the build process.
-                            properties:
-                              insecure:
-                                description: If Insecure is true, images can be pulled
-                                  from an insecure (plain HTTP) registry.
-                                type: boolean
-                              insecureSkipTLSVerify:
-                                description: If InsecureSkipTLSVerify, the operator
-                                  will accept any certificate provided by the registry.
-                                type: boolean
-                            type: object
-                          push:
-                            description: Push contains settings determining how to
-                              push a built DriverContainer image.
-                            properties:
-                              insecure:
-                                description: If Insecure is true, built images can
-                                  be pushed to an insecure (plain HTTP) registry.
-                                type: boolean
-                              insecureSkipTLSVerify:
-                                description: If InsecureSkipTLSVerify, the operator
-                                  will accept any certificate provided by the registry.
-                                type: boolean
                             type: object
                           secrets:
                             description: Secrets is an optional list of secrets to
@@ -1980,6 +1969,22 @@ spec:
                               description: Build enables in-cluster builds for this
                                 mapping and allows overriding the Module's build settings.
                               properties:
+                                baseImageRegistryTLS:
+                                  description: BaseImageRegistryTLS contains settings
+                                    determining how to access registries of the base
+                                    images in the build-process' Dockerfile.
+                                  properties:
+                                    insecure:
+                                      description: If Insecure is true, the operator
+                                        will be able to access a registry in an insecure
+                                        (plain HTTP) protocol.
+                                      type: boolean
+                                    insecureSkipTLSVerify:
+                                      description: If InsecureSkipTLSVerify, the operator
+                                        will accept any certificate provided by the
+                                        registry.
+                                      type: boolean
+                                  type: object
                                 buildArgs:
                                   description: BuildArgs is an array of build variables
                                     that are provided to the image building backend.
@@ -2016,35 +2021,6 @@ spec:
                                         the build Job
                                       type: string
                                   type: object
-                                pull:
-                                  description: Pull contains settings determining
-                                    how to pull the base images of the build process.
-                                  properties:
-                                    insecure:
-                                      description: If Insecure is true, images can
-                                        be pulled from an insecure (plain HTTP) registry.
-                                      type: boolean
-                                    insecureSkipTLSVerify:
-                                      description: If InsecureSkipTLSVerify, the operator
-                                        will accept any certificate provided by the
-                                        registry.
-                                      type: boolean
-                                  type: object
-                                push:
-                                  description: Push contains settings determining
-                                    how to push a built DriverContainer image.
-                                  properties:
-                                    insecure:
-                                      description: If Insecure is true, built images
-                                        can be pushed to an insecure (plain HTTP)
-                                        registry.
-                                      type: boolean
-                                    insecureSkipTLSVerify:
-                                      description: If InsecureSkipTLSVerify, the operator
-                                        will accept any certificate provided by the
-                                        registry.
-                                      type: boolean
-                                  type: object
                                 secrets:
                                   description: Secrets is an optional list of secrets
                                     to be made available to the build system. Those
@@ -2076,24 +2052,24 @@ spec:
                               description: Literal defines a literal target kernel
                                 version to be matched exactly against node kernels.
                               type: string
-                            pull:
-                              description: Pull contains settings determining how
-                                to check if the ModuleLoader image already exists
-                                and allows overriding of the ModuleLoader's pull options
+                            regexp:
+                              description: Regexp is a regular expression to be match
+                                against node kernels.
+                              type: string
+                            registryTLS:
+                              description: RegistryTLS set the TLS configs for accessing
+                                the registry of the module-loader's image.
                               properties:
                                 insecure:
-                                  description: If Insecure is true, images can be
-                                    pulled from an insecure (plain HTTP) registry.
+                                  description: If Insecure is true, the operator will
+                                    be able to access a registry in an insecure (plain
+                                    HTTP) protocol.
                                   type: boolean
                                 insecureSkipTLSVerify:
                                   description: If InsecureSkipTLSVerify, the operator
                                     will accept any certificate provided by the registry.
                                   type: boolean
                               type: object
-                            regexp:
-                              description: Regexp is a regular expression to be match
-                                against node kernels.
-                              type: string
                             sign:
                               description: Sign enables in-cluster signing for this
                                 mapping
@@ -2213,13 +2189,14 @@ spec:
                         required:
                         - moduleName
                         type: object
-                      pull:
-                        description: Pull contains settings determining how to check
-                          if the ModuleLoader image already exists.
+                      registryTLS:
+                        description: RegistryTLS set the TLS configs for accessing
+                          the registry of the module-loader's image.
                         properties:
                           insecure:
-                            description: If Insecure is true, images can be pulled
-                              from an insecure (plain HTTP) registry.
+                            description: If Insecure is true, the operator will be
+                              able to access a registry in an insecure (plain HTTP)
+                              protocol.
                             type: boolean
                           insecureSkipTLSVerify:
                             description: If InsecureSkipTLSVerify, the operator will

--- a/config/manager/configmap-cluster-ca.yaml
+++ b/config/manager/configmap-cluster-ca.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-data: {}
 kind: ConfigMap
 metadata:
   labels:
     config.openshift.io/inject-trusted-cabundle: "true"
-  name: trusted-ca
+  name: cluster-ca
   namespace: system
+data: {}

--- a/config/manager/configmap-service-ca.yaml
+++ b/config/manager/configmap-service-ca.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  annotations:
+    service.beta.openshift.io/inject-cabundle: "true"
+  name: service-ca
+  namespace: system
+data: {}

--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -7,5 +7,5 @@ metrics:
 webhook:
   port: 9443
 leaderElection:
-  leaderElect: false
+  leaderElect: true
   resourceName: c5baf8af.sigs.k8s.io

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,5 +1,6 @@
 resources:
-- configmap-ca.yaml
+- configmap-cluster-ca.yaml
+- configmap-service-ca.yaml
 - manager.yaml
 
 generatorOptions:
@@ -15,3 +16,6 @@ images:
 - name: controller
   newName: quay.io/edge-infrastructure/kernel-module-management-operator
   newTag: latest
+
+patchesStrategicMerge:
+- ocp.patch.yaml

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,15 +24,21 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/master: ''
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       securityContext:
         runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
       containers:
       - command:
-        - /usr/local/bin/manager
+        - /manager
         args:
         - --leader-elect
         image: controller:latest
@@ -40,8 +46,6 @@ spec:
         imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false
-          capabilities:
-            drop: [ALL]
         livenessProbe:
           httpGet:
             path: /healthz
@@ -63,20 +67,12 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
-        volumeMounts:
-          - name: trusted-ca
-            mountPath: /etc/pki/ca-trust/extracted/pem
-            readOnly: true
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
       tolerations:
         - key: node-role.kubernetes.io/master
           operator: Equal
           effect: NoSchedule
-      volumes:
-        - name: trusted-ca
-          configMap:
-            name: trusted-ca
-            items:
-              - key: ca-bundle.crt
-                path: tls-ca-bundle.pem
+        - key: node-role.kubernetes.io/control-plane
+          operator: Equal
+          effect: NoSchedule

--- a/config/manager/ocp.patch.yaml
+++ b/config/manager/ocp.patch.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      affinity:
+        $patch: delete
+      containers:
+        - name: manager
+          command: [/usr/local/bin/manager]
+          env:
+            - name: SSL_CERT_DIR
+              value: /etc/pki/ca-trust/extracted/pem
+          securityContext:
+            capabilities:
+              drop: [ALL]
+          volumeMounts:
+            - name: trusted-ca
+              mountPath: /etc/pki/ca-trust/extracted/pem
+              readOnly: true
+      nodeSelector:
+        node-role.kubernetes.io/master: ''
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      volumes:
+        - name: trusted-ca
+          projected:
+            sources:
+              - configMap:
+                  name: cluster-ca
+                  items:
+                    - key: ca-bundle.crt
+                      path: tls-ca-bundle.pem
+              - configMap:
+                  name: service-ca
+                  items:
+                    - key: service-ca.crt
+                      path: ocp-service-ca-bundle.pem
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          operator: Equal
+          effect: NoSchedule

--- a/config/manifests/bases/kernel-module-management.clusterserviceversion.yaml
+++ b/config/manifests/bases/kernel-module-management.clusterserviceversion.yaml
@@ -15,6 +15,12 @@ spec:
       kind: Module
       name: modules.kmm.sigs.k8s.io
       version: v1alpha1
+    - description: ManagedClusterModule is the Schema for the managedclustermodules
+        API
+      displayName: Managed Cluster Module
+      kind: ManagedClusterModule
+      name: managedclustermodules.kmm.sigs.k8s.io
+      version: v1beta1
     - description: Module is the Schema for the modules API
       displayName: Module
       kind: Module


### PR DESCRIPTION
Create a new ConfigMap and annotate it with `service.beta.openshift.io/inject-cabundle=true`.
Move all OCP manifest customizations to a separate patch.

Fixes [MGMT-12141](https://issues.redhat.com/browse/MGMT-12141)

/cc @mresvanis @yevgeny-shnaidman @ybettan 