### PR TITLE
Decouple build and sign from ModuleReconciler

### DIFF
--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -23,14 +23,12 @@ import (
 
 	buildv1 "github.com/openshift/api/build/v1"
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/auth"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/build"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/daemonset"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/filter"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/metrics"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/module"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/rbac"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/registry"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/sign"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/statusupdater"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
@@ -54,14 +52,12 @@ import (
 type ModuleReconciler struct {
 	client.Client
 
-	authFactory      auth.RegistryAuthGetterFactory
 	buildAPI         build.Manager
 	signAPI          sign.SignManager
 	rbacAPI          rbac.RBACCreator
 	daemonAPI        daemonset.DaemonSetCreator
 	kernelAPI        module.KernelMapper
 	metricsAPI       metrics.Metrics
-	registry         registry.Registry
 	filter           *filter.Filter
 	statusUpdaterAPI statusupdater.ModuleStatusUpdater
 }
@@ -75,12 +71,9 @@ func NewModuleReconciler(
 	kernelAPI module.KernelMapper,
 	metricsAPI metrics.Metrics,
 	filter *filter.Filter,
-	registry registry.Registry,
-	authFactory auth.RegistryAuthGetterFactory,
 	statusUpdaterAPI statusupdater.ModuleStatusUpdater) *ModuleReconciler {
 	return &ModuleReconciler{
 		Client:           client,
-		authFactory:      authFactory,
 		buildAPI:         buildAPI,
 		signAPI:          signAPI,
 		rbacAPI:          rbacAPI,
@@ -88,7 +81,6 @@ func NewModuleReconciler(
 		kernelAPI:        kernelAPI,
 		metricsAPI:       metricsAPI,
 		filter:           filter,
-		registry:         registry,
 		statusUpdaterAPI: statusUpdaterAPI,
 	}
 }
@@ -154,9 +146,9 @@ func (r *ModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	for kernelVersion, m := range mappings {
-		requeue, err := r.handleBuild(ctx, mod, m, kernelVersion, m.ContainerImage)
+		requeue, err := r.handleBuild(ctx, mod, m, kernelVersion)
 		if err != nil {
-			return res, fmt.Errorf("failed to handle build for kernel version %s: %w", kernelVersion, err)
+			return res, fmt.Errorf("failed to handle build for kernel version %s: %v", kernelVersion, err)
 		}
 		if requeue {
 			logger.Info("Build requires a requeue; skipping handling driver container for now", "kernelVersion", kernelVersion, "image", m)
@@ -164,7 +156,7 @@ func (r *ModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			continue
 		}
 
-		signrequeue, err := r.handleSigning(ctx, mod, m, kernelVersion, m.ContainerImage)
+		signrequeue, err := r.handleSigning(ctx, mod, m, kernelVersion)
 		if err != nil {
 			return res, fmt.Errorf("failed to handle signing for kernel version %s: %v", kernelVersion, err)
 		}
@@ -273,37 +265,20 @@ func (r *ModuleReconciler) getNodesListBySelector(ctx context.Context, mod *kmmv
 func (r *ModuleReconciler) handleBuild(ctx context.Context,
 	mod *kmmv1beta1.Module,
 	km *kmmv1beta1.KernelMapping,
-	kernelVersion string,
-	containerImage string) (bool, error) {
+	kernelVersion string) (bool, error) {
 
-	//if theres no build specified skip this section
-	if !r.willBuild(mod, km) {
-		return false, nil
-	}
-	//if build is specified AND sign is specified then we want to build an intermediate image
-	// and let sign produce the one specified in containerImage
-	if r.willSign(mod, km) {
-		containerImage = r.appendToTag(containerImage, mod.Namespace+"_"+mod.Name+"_kmm_unsigned")
-	}
-
-	logger := log.FromContext(ctx, "kernel version", kernelVersion, "image", containerImage)
-	logger.Info("Trying to pull the output image")
-
-	// build is specified and containerImage is either the final image, or the intermediate image tag depending on if sign is defined
-	// either way if containerImage exists we can skip building it
-	exists, err := r.checkImageExists(ctx, mod, km, containerImage)
+	shouldSync, err := r.buildAPI.ShouldSync(ctx, *mod, *km)
 	if err != nil {
-		return false, fmt.Errorf("failed to check existence of image %s for kernel %s: %w", containerImage, kernelVersion, err)
+		return false, fmt.Errorf("could not check if build synchronization is needed: %w", err)
 	}
-	if exists {
-		logger.Info("Image already exists; skipping build")
+	if !shouldSync {
 		return false, nil
 	}
 
-	logger.Info("Image not pull-able; building in-cluster")
+	logger := log.FromContext(ctx).WithValues("kernel version", kernelVersion, "image", km.ContainerImage)
+	buildCtx := log.IntoContext(ctx, logger)
 
-	buildRes, err := r.buildAPI.Sync(log.IntoContext(ctx, logger), *mod, *km, kernelVersion,
-		containerImage, true)
+	buildRes, err := r.buildAPI.Sync(buildCtx, *mod, *km, kernelVersion, true, mod)
 	if err != nil {
 		return false, fmt.Errorf("could not synchronize the build: %w", err)
 	}
@@ -318,65 +293,29 @@ func (r *ModuleReconciler) handleBuild(ctx context.Context,
 	return buildRes.Requeue, nil
 }
 
-// is sign defined in the CR
-func (r *ModuleReconciler) willSign(mod *kmmv1beta1.Module, km *kmmv1beta1.KernelMapping) bool {
-	if mod.Spec.ModuleLoader.Container.Sign == nil && km.Sign == nil {
-		return false
-	}
-	return true
-}
-
-// is build defined in the CR
-func (r *ModuleReconciler) willBuild(mod *kmmv1beta1.Module, km *kmmv1beta1.KernelMapping) bool {
-	if mod.Spec.ModuleLoader.Container.Build == nil && km.Build == nil {
-		return false
-	}
-	return true
-}
-
-// append tag to the image name cleanly, avoiding messing up the name or getting "name:-tag"
-func (r *ModuleReconciler) appendToTag(name string, tag string) string {
-	if strings.Contains(name, ":") {
-		return name + "_" + tag
-	} else {
-		return name + ":" + tag
-	}
-
-}
-
 func (r *ModuleReconciler) handleSigning(ctx context.Context,
 	mod *kmmv1beta1.Module,
 	km *kmmv1beta1.KernelMapping,
-	kernelVersion string,
-	containerImage string) (bool, error) {
+	kernelVersion string) (bool, error) {
 
-	// if sign is not specified skip
-	if !r.willSign(mod, km) {
-		return false, nil
-	}
-
-	// if its already built, skip
-	exists, err := r.checkImageExists(ctx, mod, km, containerImage)
+	shouldSync, err := r.signAPI.ShouldSync(ctx, *mod, *km)
 	if err != nil {
-		return false, fmt.Errorf("failed to check existence of image %s for kernel %s: %w", containerImage, kernelVersion, err)
+		return false, fmt.Errorf("cound not check if synchronization is needed: %w", err)
 	}
-	if exists {
+	if !shouldSync {
 		return false, nil
 	}
 
 	// if we need to sign AND we've built, then we must have built the intermediate image so must figure out its name
 	previousImage := ""
-	if r.willBuild(mod, km) {
-		previousImage = r.appendToTag(containerImage, mod.Namespace+"_"+mod.Name+"_kmm_unsigned")
-		if err != nil {
-			return false, err
-		}
+	if module.ShouldBeBuilt(mod.Spec, *km) {
+		previousImage = module.IntermediateImageName(mod.Name, mod.Namespace, km.ContainerImage)
 	}
 
-	logger := log.FromContext(ctx).WithValues("kernel version", kernelVersion, "image", containerImage)
+	logger := log.FromContext(ctx).WithValues("kernel version", kernelVersion, "image", km.ContainerImage)
 	signCtx := log.IntoContext(ctx, logger)
 
-	signRes, err := r.signAPI.Sync(signCtx, *mod, *km, kernelVersion, previousImage, containerImage, true)
+	signRes, err := r.signAPI.Sync(signCtx, *mod, *km, kernelVersion, previousImage, true, mod)
 	if err != nil {
 		return false, fmt.Errorf("could not synchronize the signing: %w", err)
 	}
@@ -389,16 +328,6 @@ func (r *ModuleReconciler) handleSigning(ctx context.Context,
 	}
 
 	return signRes.Requeue, nil
-}
-
-func (r *ModuleReconciler) checkImageExists(ctx context.Context, mod *kmmv1beta1.Module, km *kmmv1beta1.KernelMapping, imageName string) (bool, error) {
-	registryAuthGetter := r.authFactory.NewRegistryAuthGetterFrom(mod)
-	tlsOptions := module.GetRelevantTLSOptions(mod, km)
-	imageAvailable, err := r.registry.ImageExists(ctx, imageName, tlsOptions, registryAuthGetter)
-	if err != nil {
-		return false, fmt.Errorf("could not check if the image is available: %v", err)
-	}
-	return imageAvailable, nil
 }
 
 func (r *ModuleReconciler) handleDriverContainer(ctx context.Context,
@@ -479,7 +408,7 @@ func (r *ModuleReconciler) garbageCollect(ctx context.Context,
 	logger.Info("Garbage-collected DaemonSets", "names", deleted)
 
 	// Garbage collect for successfully finished build jobs
-	deleted, err = r.buildAPI.GarbageCollect(ctx, *mod)
+	deleted, err = r.buildAPI.GarbageCollect(ctx, mod.Name, mod.Namespace)
 	if err != nil {
 		return fmt.Errorf("could not garbage collect build objects: %v", err)
 	}

--- a/internal/build/buildconfig/manager_test.go
+++ b/internal/build/buildconfig/manager_test.go
@@ -4,99 +4,192 @@ import (
 	"context"
 	"errors"
 
-	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/golang/mock/gomock"
 	buildv1 "github.com/openshift/api/build/v1"
-	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
-	kmmbuild "github.com/rh-ecosystem-edge/kernel-module-management/internal/build"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/auth"
+	kmmbuild "github.com/rh-ecosystem-edge/kernel-module-management/internal/build"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/registry"
 )
 
-var _ = Describe("Manager_Sync", func() {
-	const (
-		containerImage = "some-image-name:tag"
-		moduleName     = "some-module-names"
-		namespace      = "some-namespace"
-		targetKernel   = "target-kernel"
-	)
-
-	var (
-		mockKubeClient            *client.MockClient
-		mockMaker                 *MockMaker
-		mockOpenShiftBuildsHelper *MockOpenShiftBuildsHelper
-	)
-
-	BeforeEach(func() {
-		ctrl := gomock.NewController(GinkgoT())
-		mockKubeClient = client.NewMockClient(ctrl)
-		mockMaker = NewMockMaker(ctrl)
-		mockOpenShiftBuildsHelper = NewMockOpenShiftBuildsHelper(ctrl)
-	})
-
-	ctx := context.Background()
-
-	It("should create a Build when none is present", func() {
+var _ = Describe("Manager", func() {
+	var _ = Describe("ShouldSync", func() {
+		var (
+			ctrl        *gomock.Controller
+			clnt        *client.MockClient
+			authFactory *auth.MockRegistryAuthGetterFactory
+			reg         *registry.MockRegistry
+		)
 		const (
-			buildName      = "some-build-config"
-			repoSecretName = "repo-secret"
+			moduleName = "module-name"
+			imageName  = "image-name"
+			namespace  = "some-namespace"
 		)
 
-		By("Authenticating with a secret")
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			clnt = client.NewMockClient(ctrl)
+			authFactory = auth.NewMockRegistryAuthGetterFactory(ctrl)
+			reg = registry.NewMockRegistry(ctrl)
+		})
 
-		mod := kmmv1beta1.Module{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      moduleName,
-				Namespace: namespace,
-			},
-			Spec: kmmv1beta1.ModuleSpec{
-				ImageRepoSecret: &v1.LocalObjectReference{Name: repoSecretName},
-			},
-		}
+		It("should return false if there was no build section", func() {
+			ctx := context.Background()
 
-		tlsOptions := kmmv1beta1.TLSOptions{}
+			mod := kmmv1beta1.Module{}
+			km := kmmv1beta1.KernelMapping{}
 
-		buildCfg := kmmv1beta1.Build{
-			BaseImageRegistryTLS: tlsOptions,
-		}
+			mgr := NewManager(clnt, nil, nil, authFactory, reg)
 
-		mapping := kmmv1beta1.KernelMapping{
-			Build:          &buildCfg,
-			ContainerImage: containerImage,
-		}
+			shouldSync, err := mgr.ShouldSync(ctx, mod, km)
 
-		m := NewManager(mockKubeClient, mockMaker, mockOpenShiftBuildsHelper)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(shouldSync).To(BeFalse())
+		})
 
-		build := buildv1.Build{
-			ObjectMeta: metav1.ObjectMeta{Name: buildName},
-		}
+		It("should return false if image already exists", func() {
+			ctx := context.Background()
 
-		gomock.InOrder(
-			mockMaker.EXPECT().MakeBuildTemplate(ctx, mod, mapping, targetKernel, containerImage, true).Return(&build, nil),
-			mockOpenShiftBuildsHelper.EXPECT().GetBuild(ctx, mod, targetKernel).Return(nil, errNoMatchingBuild),
-			mockKubeClient.EXPECT().Create(ctx, &build),
-		)
-
-		res, err := m.Sync(ctx, mod, mapping, targetKernel, mapping.ContainerImage, true)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(res.Status).To(BeEquivalentTo(kmmbuild.StatusCreated))
-		Expect(res.Requeue).To(BeTrue())
-	})
-
-	DescribeTable(
-		"should return the Build status when a Build is present",
-		func(phase buildv1.BuildPhase, expectedResult kmmbuild.Result, expectError bool) {
-			const buildName = "some-build"
-
-			By("Authenticating with the ServiceAccount's pull secret")
+			km := kmmv1beta1.KernelMapping{
+				Build:          &kmmv1beta1.Build{},
+				ContainerImage: imageName,
+			}
 
 			mod := kmmv1beta1.Module{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      moduleName,
 					Namespace: namespace,
+				},
+				Spec: kmmv1beta1.ModuleSpec{
+					ImageRepoSecret: &v1.LocalObjectReference{Name: "pull-push-secret"},
+				},
+			}
+
+			authGetter := &auth.MockRegistryAuthGetter{}
+			gomock.InOrder(
+				authFactory.EXPECT().NewRegistryAuthGetterFrom(&mod).Return(authGetter),
+				reg.EXPECT().ImageExists(ctx, imageName, gomock.Any(), authGetter).Return(true, nil),
+			)
+
+			mgr := NewManager(clnt, nil, nil, authFactory, reg)
+
+			shouldSync, err := mgr.ShouldSync(ctx, mod, km)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(shouldSync).To(BeFalse())
+		})
+
+		It("should return false and an error if image check fails", func() {
+			ctx := context.Background()
+
+			km := kmmv1beta1.KernelMapping{
+				Build:          &kmmv1beta1.Build{},
+				ContainerImage: imageName,
+			}
+
+			mod := kmmv1beta1.Module{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      moduleName,
+					Namespace: namespace,
+				},
+				Spec: kmmv1beta1.ModuleSpec{
+					ImageRepoSecret: &v1.LocalObjectReference{Name: "pull-push-secret"},
+				},
+			}
+
+			authGetter := &auth.MockRegistryAuthGetter{}
+			gomock.InOrder(
+				authFactory.EXPECT().NewRegistryAuthGetterFrom(&mod).Return(authGetter),
+				reg.EXPECT().ImageExists(ctx, imageName, gomock.Any(), authGetter).Return(false, errors.New("generic-registry-error")),
+			)
+
+			mgr := NewManager(clnt, nil, nil, authFactory, reg)
+
+			shouldSync, err := mgr.ShouldSync(ctx, mod, km)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("generic-registry-error"))
+			Expect(shouldSync).To(BeFalse())
+		})
+
+		It("should return true if image does not exist", func() {
+			ctx := context.Background()
+
+			km := kmmv1beta1.KernelMapping{
+				Build:          &kmmv1beta1.Build{},
+				ContainerImage: imageName,
+			}
+
+			mod := kmmv1beta1.Module{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      moduleName,
+					Namespace: namespace,
+				},
+				Spec: kmmv1beta1.ModuleSpec{
+					ImageRepoSecret: &v1.LocalObjectReference{Name: "pull-push-secret"},
+				},
+			}
+
+			authGetter := &auth.MockRegistryAuthGetter{}
+			gomock.InOrder(
+				authFactory.EXPECT().NewRegistryAuthGetterFrom(&mod).Return(authGetter),
+				reg.EXPECT().ImageExists(ctx, imageName, gomock.Any(), authGetter).Return(false, nil))
+
+			mgr := NewManager(clnt, nil, nil, authFactory, reg)
+
+			shouldSync, err := mgr.ShouldSync(ctx, mod, km)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(shouldSync).To(BeTrue())
+		})
+	})
+
+	var _ = Describe("Sync", func() {
+		const (
+			containerImage = "some-image-name:tag"
+			moduleName     = "some-module-names"
+			namespace      = "some-namespace"
+			targetKernel   = "target-kernel"
+		)
+
+		var (
+			mockKubeClient            *client.MockClient
+			mockMaker                 *MockMaker
+			mockOpenShiftBuildsHelper *MockOpenShiftBuildsHelper
+		)
+
+		BeforeEach(func() {
+			ctrl := gomock.NewController(GinkgoT())
+			mockKubeClient = client.NewMockClient(ctrl)
+			mockMaker = NewMockMaker(ctrl)
+			mockOpenShiftBuildsHelper = NewMockOpenShiftBuildsHelper(ctrl)
+		})
+
+		ctx := context.Background()
+
+		It("should create a Build when none is present", func() {
+			const (
+				buildName      = "some-build-config"
+				repoSecretName = "repo-secret"
+			)
+
+			By("Authenticating with a secret")
+
+			mod := kmmv1beta1.Module{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      moduleName,
+					Namespace: namespace,
+				},
+				Spec: kmmv1beta1.ModuleSpec{
+					ImageRepoSecret: &v1.LocalObjectReference{Name: repoSecretName},
 				},
 			}
 
@@ -111,37 +204,81 @@ var _ = Describe("Manager_Sync", func() {
 				ContainerImage: containerImage,
 			}
 
-			m := NewManager(mockKubeClient, mockMaker, mockOpenShiftBuildsHelper)
+			m := NewManager(mockKubeClient, mockMaker, mockOpenShiftBuildsHelper, nil, nil)
 
 			build := buildv1.Build{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        buildName,
-					Annotations: map[string]string{buildHashAnnotation: "some hash"},
-				},
-				Status: buildv1.BuildStatus{Phase: phase},
+				ObjectMeta: metav1.ObjectMeta{Name: buildName},
 			}
 
 			gomock.InOrder(
-				mockMaker.EXPECT().MakeBuildTemplate(ctx, mod, mapping, targetKernel, containerImage, true).Return(&build, nil),
-				mockOpenShiftBuildsHelper.EXPECT().GetBuild(ctx, mod, targetKernel).Return(&build, nil),
+				mockMaker.EXPECT().MakeBuildTemplate(ctx, mod, mapping, targetKernel, true, &mod).Return(&build, nil),
+				mockOpenShiftBuildsHelper.EXPECT().GetBuild(ctx, mod, targetKernel).Return(nil, errNoMatchingBuild),
+				mockKubeClient.EXPECT().Create(ctx, &build),
 			)
 
-			res, err := m.Sync(ctx, mod, mapping, targetKernel, mapping.ContainerImage, true)
+			res, err := m.Sync(ctx, mod, mapping, targetKernel, true, &mod)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(res.Status).To(BeEquivalentTo(kmmbuild.StatusCreated))
+			Expect(res.Requeue).To(BeTrue())
+		})
 
-			if expectError {
-				Expect(err).To(HaveOccurred())
-			} else {
-				Expect(err).NotTo(HaveOccurred())
-				Expect(res).To(BeEquivalentTo(expectedResult))
-			}
-		},
-		Entry(nil, buildv1.BuildPhaseComplete, kmmbuild.Result{Status: kmmbuild.StatusCompleted}, false),
-		Entry(nil, buildv1.BuildPhaseNew, kmmbuild.Result{Status: kmmbuild.StatusInProgress, Requeue: true}, false),
-		Entry(nil, buildv1.BuildPhasePending, kmmbuild.Result{Status: kmmbuild.StatusInProgress, Requeue: true}, false),
-		Entry(nil, buildv1.BuildPhaseRunning, kmmbuild.Result{Status: kmmbuild.StatusInProgress, Requeue: true}, false),
-		Entry(nil, buildv1.BuildPhaseFailed, kmmbuild.Result{}, true),
-		Entry(nil, buildv1.BuildPhaseCancelled, kmmbuild.Result{}, true),
-	)
+		DescribeTable(
+			"should return the Build status when a Build is present",
+			func(phase buildv1.BuildPhase, expectedResult kmmbuild.Result, expectError bool) {
+				const buildName = "some-build"
+
+				By("Authenticating with the ServiceAccount's pull secret")
+
+				mod := kmmv1beta1.Module{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      moduleName,
+						Namespace: namespace,
+					},
+				}
+
+				tlsOptions := kmmv1beta1.TLSOptions{}
+
+				buildCfg := kmmv1beta1.Build{
+					BaseImageRegistryTLS: tlsOptions,
+				}
+
+				mapping := kmmv1beta1.KernelMapping{
+					Build:          &buildCfg,
+					ContainerImage: containerImage,
+				}
+
+				m := NewManager(mockKubeClient, mockMaker, mockOpenShiftBuildsHelper, nil, nil)
+
+				build := buildv1.Build{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        buildName,
+						Annotations: map[string]string{buildHashAnnotation: "some hash"},
+					},
+					Status: buildv1.BuildStatus{Phase: phase},
+				}
+
+				gomock.InOrder(
+					mockMaker.EXPECT().MakeBuildTemplate(ctx, mod, mapping, targetKernel, true, &mod).Return(&build, nil),
+					mockOpenShiftBuildsHelper.EXPECT().GetBuild(ctx, mod, targetKernel).Return(&build, nil),
+				)
+
+				res, err := m.Sync(ctx, mod, mapping, targetKernel, true, &mod)
+
+				if expectError {
+					Expect(err).To(HaveOccurred())
+				} else {
+					Expect(err).NotTo(HaveOccurred())
+					Expect(res).To(BeEquivalentTo(expectedResult))
+				}
+			},
+			Entry(nil, buildv1.BuildPhaseComplete, kmmbuild.Result{Status: kmmbuild.StatusCompleted}, false),
+			Entry(nil, buildv1.BuildPhaseNew, kmmbuild.Result{Status: kmmbuild.StatusInProgress, Requeue: true}, false),
+			Entry(nil, buildv1.BuildPhasePending, kmmbuild.Result{Status: kmmbuild.StatusInProgress, Requeue: true}, false),
+			Entry(nil, buildv1.BuildPhaseRunning, kmmbuild.Result{Status: kmmbuild.StatusInProgress, Requeue: true}, false),
+			Entry(nil, buildv1.BuildPhaseFailed, kmmbuild.Result{}, true),
+			Entry(nil, buildv1.BuildPhaseCancelled, kmmbuild.Result{}, true),
+		)
+	})
 })
 
 var _ = Describe("OpenShiftBuildsHelper_GetBuild", func() {

--- a/internal/build/buildconfig/mock_maker.go
+++ b/internal/build/buildconfig/mock_maker.go
@@ -11,6 +11,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1 "github.com/openshift/api/build/v1"
 	v1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	v10 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // MockMaker is a mock of Maker interface.
@@ -37,16 +38,16 @@ func (m *MockMaker) EXPECT() *MockMakerMockRecorder {
 }
 
 // MakeBuildTemplate mocks base method.
-func (m *MockMaker) MakeBuildTemplate(ctx context.Context, mod v1beta1.Module, mapping v1beta1.KernelMapping, targetKernel, containerImage string, pushImage bool) (*v1.Build, error) {
+func (m *MockMaker) MakeBuildTemplate(ctx context.Context, mod v1beta1.Module, mapping v1beta1.KernelMapping, targetKernel string, pushImage bool, owner v10.Object) (*v1.Build, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MakeBuildTemplate", ctx, mod, mapping, targetKernel, containerImage, pushImage)
+	ret := m.ctrl.Call(m, "MakeBuildTemplate", ctx, mod, mapping, targetKernel, pushImage, owner)
 	ret0, _ := ret[0].(*v1.Build)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MakeBuildTemplate indicates an expected call of MakeBuildTemplate.
-func (mr *MockMakerMockRecorder) MakeBuildTemplate(ctx, mod, mapping, targetKernel, containerImage, pushImage interface{}) *gomock.Call {
+func (mr *MockMakerMockRecorder) MakeBuildTemplate(ctx, mod, mapping, targetKernel, pushImage, owner interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeBuildTemplate", reflect.TypeOf((*MockMaker)(nil).MakeBuildTemplate), ctx, mod, mapping, targetKernel, containerImage, pushImage)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeBuildTemplate", reflect.TypeOf((*MockMaker)(nil).MakeBuildTemplate), ctx, mod, mapping, targetKernel, pushImage, owner)
 }

--- a/internal/build/helper.go
+++ b/internal/build/helper.go
@@ -11,7 +11,7 @@ import (
 
 type Helper interface {
 	ApplyBuildArgOverrides(args []kmmv1beta1.BuildArg, overrides ...kmmv1beta1.BuildArg) []kmmv1beta1.BuildArg
-	GetRelevantBuild(mod kmmv1beta1.Module, km kmmv1beta1.KernelMapping) *kmmv1beta1.Build
+	GetRelevantBuild(modSpec kmmv1beta1.ModuleSpec, km kmmv1beta1.KernelMapping) *kmmv1beta1.Build
 }
 
 type helper struct{}
@@ -45,17 +45,16 @@ func (m *helper) ApplyBuildArgOverrides(args []kmmv1beta1.BuildArg, overrides ..
 	return args
 }
 
-func (m *helper) GetRelevantBuild(mod kmmv1beta1.Module, km kmmv1beta1.KernelMapping) *kmmv1beta1.Build {
-	if mod.Spec.ModuleLoader.Container.Build == nil {
-		// km.Build cannot be nil in case mod.Build is nil, checked above
+func (m *helper) GetRelevantBuild(modSpec kmmv1beta1.ModuleSpec, km kmmv1beta1.KernelMapping) *kmmv1beta1.Build {
+	if modSpec.ModuleLoader.Container.Build == nil {
 		return km.Build.DeepCopy()
 	}
 
 	if km.Build == nil {
-		return mod.Spec.ModuleLoader.Container.Build.DeepCopy()
+		return modSpec.ModuleLoader.Container.Build.DeepCopy()
 	}
 
-	buildConfig := mod.Spec.ModuleLoader.Container.Build.DeepCopy()
+	buildConfig := modSpec.ModuleLoader.Container.Build.DeepCopy()
 	buildConfig.DockerfileConfigMap = km.Build.DockerfileConfigMap
 
 	buildConfig.BuildArgs = m.ApplyBuildArgOverrides(buildConfig.BuildArgs, km.Build.BuildArgs...)

--- a/internal/build/helper_test.go
+++ b/internal/build/helper_test.go
@@ -31,7 +31,7 @@ var _ = Describe("GetRelevantBuild", func() {
 			},
 		}
 
-		res := nh.GetRelevantBuild(mod, km)
+		res := nh.GetRelevantBuild(mod.Spec, km)
 		Expect(res).To(Equal(km.Build))
 	})
 
@@ -51,7 +51,7 @@ var _ = Describe("GetRelevantBuild", func() {
 			Build: nil,
 		}
 
-		res := nh.GetRelevantBuild(mod, km)
+		res := nh.GetRelevantBuild(mod.Spec, km)
 		Expect(res).To(Equal(mod.Spec.ModuleLoader.Container.Build))
 	})
 
@@ -77,7 +77,7 @@ var _ = Describe("GetRelevantBuild", func() {
 			},
 		}
 
-		res := nh.GetRelevantBuild(mod, km)
+		res := nh.GetRelevantBuild(mod.Spec, km)
 		Expect(res.DockerfileConfigMap).To(Equal(km.Build.DockerfileConfigMap))
 		Expect(res.BaseImageRegistryTLS).To(Equal(mod.Spec.ModuleLoader.Container.Build.BaseImageRegistryTLS))
 	})

--- a/internal/build/manager.go
+++ b/internal/build/manager.go
@@ -3,6 +3,8 @@ package build
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 )
 
@@ -22,6 +24,18 @@ type Result struct {
 //go:generate mockgen -source=manager.go -package=build -destination=mock_manager.go
 
 type Manager interface {
-	Sync(ctx context.Context, mod kmmv1beta1.Module, m kmmv1beta1.KernelMapping, targetKernel string, targetImage string, pushImage bool) (Result, error)
-	GarbageCollect(ctx context.Context, mod kmmv1beta1.Module) ([]string, error)
+	GarbageCollect(ctx context.Context, modName, namespace string) ([]string, error)
+
+	ShouldSync(
+		ctx context.Context,
+		mod kmmv1beta1.Module,
+		m kmmv1beta1.KernelMapping) (bool, error)
+
+	Sync(
+		ctx context.Context,
+		mod kmmv1beta1.Module,
+		m kmmv1beta1.KernelMapping,
+		targetKernel string,
+		pushImage bool,
+		owner metav1.Object) (Result, error)
 }

--- a/internal/build/mock_helper.go
+++ b/internal/build/mock_helper.go
@@ -54,15 +54,15 @@ func (mr *MockHelperMockRecorder) ApplyBuildArgOverrides(args interface{}, overr
 }
 
 // GetRelevantBuild mocks base method.
-func (m *MockHelper) GetRelevantBuild(mod v1beta1.Module, km v1beta1.KernelMapping) *v1beta1.Build {
+func (m *MockHelper) GetRelevantBuild(modSpec v1beta1.ModuleSpec, km v1beta1.KernelMapping) *v1beta1.Build {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRelevantBuild", mod, km)
+	ret := m.ctrl.Call(m, "GetRelevantBuild", modSpec, km)
 	ret0, _ := ret[0].(*v1beta1.Build)
 	return ret0
 }
 
 // GetRelevantBuild indicates an expected call of GetRelevantBuild.
-func (mr *MockHelperMockRecorder) GetRelevantBuild(mod, km interface{}) *gomock.Call {
+func (mr *MockHelperMockRecorder) GetRelevantBuild(modSpec, km interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelevantBuild", reflect.TypeOf((*MockHelper)(nil).GetRelevantBuild), mod, km)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelevantBuild", reflect.TypeOf((*MockHelper)(nil).GetRelevantBuild), modSpec, km)
 }

--- a/internal/build/mock_manager.go
+++ b/internal/build/mock_manager.go
@@ -10,6 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // MockManager is a mock of Manager interface.
@@ -36,31 +37,46 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 }
 
 // GarbageCollect mocks base method.
-func (m *MockManager) GarbageCollect(ctx context.Context, mod v1beta1.Module) ([]string, error) {
+func (m *MockManager) GarbageCollect(ctx context.Context, modName, namespace string) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GarbageCollect", ctx, mod)
+	ret := m.ctrl.Call(m, "GarbageCollect", ctx, modName, namespace)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GarbageCollect indicates an expected call of GarbageCollect.
-func (mr *MockManagerMockRecorder) GarbageCollect(ctx, mod interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) GarbageCollect(ctx, modName, namespace interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockManager)(nil).GarbageCollect), ctx, mod)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockManager)(nil).GarbageCollect), ctx, modName, namespace)
+}
+
+// ShouldSync mocks base method.
+func (m_2 *MockManager) ShouldSync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping) (bool, error) {
+	m_2.ctrl.T.Helper()
+	ret := m_2.ctrl.Call(m_2, "ShouldSync", ctx, mod, m)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ShouldSync indicates an expected call of ShouldSync.
+func (mr *MockManagerMockRecorder) ShouldSync(ctx, mod, m interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldSync", reflect.TypeOf((*MockManager)(nil).ShouldSync), ctx, mod, m)
 }
 
 // Sync mocks base method.
-func (m_2 *MockManager) Sync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping, targetKernel, targetImage string, pushImage bool) (Result, error) {
+func (m_2 *MockManager) Sync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping, targetKernel string, pushImage bool, owner v1.Object) (Result, error) {
 	m_2.ctrl.T.Helper()
-	ret := m_2.ctrl.Call(m_2, "Sync", ctx, mod, m, targetKernel, targetImage, pushImage)
+	ret := m_2.ctrl.Call(m_2, "Sync", ctx, mod, m, targetKernel, pushImage, owner)
 	ret0, _ := ret[0].(Result)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Sync indicates an expected call of Sync.
-func (mr *MockManagerMockRecorder) Sync(ctx, mod, m, targetKernel, targetImage, pushImage interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) Sync(ctx, mod, m, targetKernel, pushImage, owner interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockManager)(nil).Sync), ctx, mod, m, targetKernel, targetImage, pushImage)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockManager)(nil).Sync), ctx, mod, m, targetKernel, pushImage, owner)
 }

--- a/internal/module/helper.go
+++ b/internal/module/helper.go
@@ -1,12 +1,64 @@
 package module
 
 import (
+	"context"
+	"fmt"
+	"strings"
+
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/auth"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/registry"
 )
 
-func GetRelevantTLSOptions(mod *kmmv1beta1.Module, km *kmmv1beta1.KernelMapping) *kmmv1beta1.TLSOptions {
+func TLSOptions(modSpec kmmv1beta1.ModuleSpec, km kmmv1beta1.KernelMapping) *kmmv1beta1.TLSOptions {
 	if km.RegistryTLS != nil {
 		return km.RegistryTLS
 	}
-	return mod.Spec.ModuleLoader.Container.RegistryTLS
+	return modSpec.ModuleLoader.Container.RegistryTLS
+}
+
+// AppendToTag adds the specified tag to the image name cleanly, i.e. by avoiding messing up
+// the name or getting "name:-tag"
+func AppendToTag(name string, tag string) string {
+	separator := ":"
+	if strings.Contains(name, ":") {
+		separator = "_"
+	}
+	return name + separator + tag
+}
+
+// IntermediateImageName returns the image name of the pre-signed module image name
+func IntermediateImageName(name, namespace, targetImage string) string {
+	return AppendToTag(targetImage, namespace+"_"+name+"_kmm_unsigned")
+}
+
+// ShouldBeBuilt indicates whether the specified KernelMapping of the
+// Module should be built or not.
+func ShouldBeBuilt(modSpec kmmv1beta1.ModuleSpec, km kmmv1beta1.KernelMapping) bool {
+	return modSpec.ModuleLoader.Container.Build != nil || km.Build != nil
+}
+
+// ShouldBeBuilt indicates whether the specified KernelMapping of the
+// Module should be signed or not.
+func ShouldBeSigned(modSpec kmmv1beta1.ModuleSpec, km kmmv1beta1.KernelMapping) bool {
+	return modSpec.ModuleLoader.Container.Sign != nil || km.Sign != nil
+}
+
+func ImageExists(
+	ctx context.Context,
+	authFactory auth.RegistryAuthGetterFactory,
+	reg registry.Registry,
+	mod kmmv1beta1.Module,
+	km kmmv1beta1.KernelMapping,
+	imageName string) (bool, error) {
+
+	registryAuthGetter := authFactory.NewRegistryAuthGetterFrom(&mod)
+
+	tlsOptions := TLSOptions(mod.Spec, km)
+	exists, err := reg.ImageExists(ctx, imageName, tlsOptions, registryAuthGetter)
+	if err != nil {
+		return false, fmt.Errorf("could not check if the image is available: %v", err)
+	}
+
+	return exists, nil
 }

--- a/internal/module/helper_test.go
+++ b/internal/module/helper_test.go
@@ -1,0 +1,299 @@
+package module
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	gomock "github.com/golang/mock/gomock"
+	v1 "k8s.io/api/core/v1"
+
+	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/auth"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/registry"
+)
+
+var _ = Describe("TLSOptions", func() {
+	It("should return the KernelMapping's TLSOptions if it's defined", func() {
+		mod := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					Container: kmmv1beta1.ModuleLoaderContainerSpec{},
+				},
+			},
+		}
+		km := kmmv1beta1.KernelMapping{
+			RegistryTLS: &kmmv1beta1.TLSOptions{},
+		}
+
+		Expect(
+			TLSOptions(mod.Spec, km),
+		).To(
+			Equal(km.RegistryTLS),
+		)
+	})
+
+	It("should return the Module's TLSOptions if the KernelMapping's TLSOptions is not defined", func() {
+		mod := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					Container: kmmv1beta1.ModuleLoaderContainerSpec{
+						RegistryTLS: &kmmv1beta1.TLSOptions{},
+					},
+				},
+			},
+		}
+		km := kmmv1beta1.KernelMapping{}
+
+		Expect(
+			TLSOptions(mod.Spec, km),
+		).To(
+			Equal(mod.Spec.ModuleLoader.Container.RegistryTLS),
+		)
+	})
+})
+
+var _ = Describe("AppendToTag", func() {
+	It("should append a tag to the image name", func() {
+		name := "some-container-image-name"
+		tag := "a-kmm-tag"
+
+		Expect(
+			AppendToTag(name, tag),
+		).To(
+			Equal(name + ":" + tag),
+		)
+	})
+
+	It("should add a suffix to the already present tag", func() {
+		name := "some-container-image-name:with-a-tag"
+		tag := "a-kmm-tag-suffix"
+
+		Expect(
+			AppendToTag(name, tag),
+		).To(
+			Equal(name + "_" + tag),
+		)
+	})
+})
+
+var _ = Describe("IntermediateImageName", func() {
+	It("should add the kmm_unsigned suffix to the target image name", func() {
+		Expect(
+			IntermediateImageName("module-name", "test-namespace", "some-image-name"),
+		).To(
+			Equal("some-image-name:test-namespace_module-name_kmm_unsigned"),
+		)
+	})
+})
+
+var _ = Describe("ShouldBeBuilt", func() {
+	It("should return true if the Module's Build is defined", func() {
+		mod := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					Container: kmmv1beta1.ModuleLoaderContainerSpec{
+						Build: &kmmv1beta1.Build{},
+					},
+				},
+			},
+		}
+		km := kmmv1beta1.KernelMapping{}
+
+		Expect(
+			ShouldBeBuilt(mod.Spec, km),
+		).To(
+			BeTrue(),
+		)
+	})
+
+	It("should return true if the KernelMapping's Build is defined", func() {
+		mod := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					Container: kmmv1beta1.ModuleLoaderContainerSpec{},
+				},
+			},
+		}
+		km := kmmv1beta1.KernelMapping{
+			Build: &kmmv1beta1.Build{},
+		}
+
+		Expect(
+			ShouldBeBuilt(mod.Spec, km),
+		).To(
+			BeTrue(),
+		)
+	})
+
+	It("should return false if neither the Module's nor the KernelMapping's Build is defined", func() {
+		mod := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					Container: kmmv1beta1.ModuleLoaderContainerSpec{},
+				},
+			},
+		}
+		km := kmmv1beta1.KernelMapping{}
+
+		Expect(
+			ShouldBeBuilt(mod.Spec, km),
+		).To(
+			BeFalse(),
+		)
+	})
+})
+
+var _ = Describe("ShouldBeSigned", func() {
+	It("should return true if the Module's Sign is defined", func() {
+		mod := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					Container: kmmv1beta1.ModuleLoaderContainerSpec{
+						Sign: &kmmv1beta1.Sign{},
+					},
+				},
+			},
+		}
+		km := kmmv1beta1.KernelMapping{}
+
+		Expect(
+			ShouldBeSigned(mod.Spec, km),
+		).To(
+			BeTrue(),
+		)
+	})
+
+	It("should return true if the KernelMapping's Sign is defined", func() {
+		mod := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					Container: kmmv1beta1.ModuleLoaderContainerSpec{},
+				},
+			},
+		}
+		km := kmmv1beta1.KernelMapping{
+			Sign: &kmmv1beta1.Sign{},
+		}
+
+		Expect(
+			ShouldBeSigned(mod.Spec, km),
+		).To(
+			BeTrue(),
+		)
+	})
+
+	It("should return false if neither the Module's nor the KernelMapping's Sign is defined", func() {
+		mod := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					Container: kmmv1beta1.ModuleLoaderContainerSpec{},
+				},
+			},
+		}
+		km := kmmv1beta1.KernelMapping{}
+
+		Expect(
+			ShouldBeSigned(mod.Spec, km),
+		).To(
+			BeFalse(),
+		)
+	})
+})
+
+var _ = Describe("ImageExists", func() {
+	const (
+		imageName = "image-name"
+		namespace = "test"
+	)
+
+	var (
+		ctrl *gomock.Controller
+
+		mockAuthFactory *auth.MockRegistryAuthGetterFactory
+		mockRegistry    *registry.MockRegistry
+
+		mod kmmv1beta1.Module
+		km  kmmv1beta1.KernelMapping
+		ctx context.Context
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+
+		mockAuthFactory = auth.NewMockRegistryAuthGetterFactory(ctrl)
+		mockRegistry = registry.NewMockRegistry(ctrl)
+
+		mod = kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					Container: kmmv1beta1.ModuleLoaderContainerSpec{},
+				},
+			},
+		}
+
+		km = kmmv1beta1.KernelMapping{}
+
+		ctx = context.Background()
+	})
+
+	It("should return true if the image exists", func() {
+		gomock.InOrder(
+			mockAuthFactory.EXPECT().NewRegistryAuthGetterFrom(&mod),
+			mockRegistry.EXPECT().ImageExists(ctx, imageName, nil, nil).Return(true, nil),
+		)
+
+		exists, err := ImageExists(ctx, mockAuthFactory, mockRegistry, mod, km, imageName)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exists).To(BeTrue())
+	})
+
+	It("should return false if the image does not exist", func() {
+		gomock.InOrder(
+			mockAuthFactory.EXPECT().NewRegistryAuthGetterFrom(&mod),
+			mockRegistry.EXPECT().ImageExists(ctx, imageName, nil, nil).Return(false, nil),
+		)
+
+		exists, err := ImageExists(ctx, mockAuthFactory, mockRegistry, mod, km, imageName)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exists).To(BeFalse())
+	})
+
+	It("should return an error if the registry call fails", func() {
+		gomock.InOrder(
+			mockAuthFactory.EXPECT().NewRegistryAuthGetterFrom(&mod),
+			mockRegistry.EXPECT().ImageExists(ctx, imageName, nil, nil).Return(false, errors.New("some-error")),
+		)
+
+		exists, err := ImageExists(ctx, mockAuthFactory, mockRegistry, mod, km, imageName)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("some-error"))
+		Expect(exists).To(BeFalse())
+	})
+
+	It("should use the ImageRepoSecret if one is specified", func() {
+		mod := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ImageRepoSecret: &v1.LocalObjectReference{
+					Name: "secret",
+				},
+			},
+		}
+
+		authGetter := &auth.MockRegistryAuthGetter{}
+		gomock.InOrder(
+			mockAuthFactory.EXPECT().NewRegistryAuthGetterFrom(&mod).Return(authGetter),
+			mockRegistry.EXPECT().ImageExists(ctx, imageName, nil, authGetter).Return(false, nil),
+		)
+
+		exists, err := ImageExists(ctx, mockAuthFactory, mockRegistry, mod, km, imageName)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(exists).To(BeFalse())
+	})
+})

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -110,7 +110,7 @@ func (p *preflightHelper) verifyImage(ctx context.Context, mapping *kmmv1beta1.K
 	moduleFileName := mod.Spec.ModuleLoader.Container.Modprobe.ModuleName + ".ko"
 	baseDir := mod.Spec.ModuleLoader.Container.Modprobe.DirName
 
-	tlsOptions := module.GetRelevantTLSOptions(mod, mapping)
+	tlsOptions := module.TLSOptions(mod.Spec, *mapping)
 	registryAuthGetter := p.authFactory.NewRegistryAuthGetterFrom(mod)
 	digests, repoConfig, err := p.registryAPI.GetLayersDigests(ctx, image, tlsOptions, registryAuthGetter)
 	if err != nil {
@@ -141,7 +141,7 @@ func (p *preflightHelper) verifyBuild(ctx context.Context,
 	mapping *kmmv1beta1.KernelMapping,
 	mod *kmmv1beta1.Module) (bool, string) {
 	// at this stage we know that eiher mapping Build or Container build are defined
-	buildRes, err := p.buildAPI.Sync(ctx, *mod, *mapping, pv.Spec.KernelVersion, mapping.ContainerImage, pv.Spec.PushBuiltImage)
+	buildRes, err := p.buildAPI.Sync(ctx, *mod, *mapping, pv.Spec.KernelVersion, pv.Spec.PushBuiltImage, pv)
 	if err != nil {
 		return false, fmt.Sprintf("Failed to verify build for module %s, kernel version %s, error %s", mod.Name, pv.Spec.KernelVersion, err)
 	}

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -308,36 +308,36 @@ var _ = Describe("preflightHelper_verifyBuild", func() {
 	It("sync failed", func() {
 		mod.Spec.ModuleLoader.Container.Build = &kmmv1beta1.Build{}
 		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
-		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion,
-			mapping.ContainerImage, false).Return(build.Result{}, fmt.Errorf("some error"))
+
+		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, pv.Spec.PushBuiltImage, pv).
+			Return(build.Result{}, fmt.Errorf("some error"))
 
 		res, msg := ph.verifyBuild(context.Background(), pv, &mapping, mod)
 		Expect(res).To(BeFalse())
 		Expect(msg).To(Equal(fmt.Sprintf("Failed to verify build for module %s, kernel version %s, error %s", mod.Name, kernelVersion, fmt.Errorf("some error"))))
-
 	})
 
 	It("sync completed", func() {
 		mod.Spec.ModuleLoader.Container.Build = &kmmv1beta1.Build{}
 		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
-		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion,
-			mapping.ContainerImage, false).Return(build.Result{Status: build.StatusCompleted}, nil)
+
+		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, pv.Spec.PushBuiltImage, pv).
+			Return(build.Result{Status: build.StatusCompleted}, nil)
 
 		res, msg := ph.verifyBuild(context.Background(), pv, &mapping, mod)
 		Expect(res).To(BeTrue())
 		Expect(msg).To(Equal(fmt.Sprintf(VerificationStatusReasonVerified, "build compiles")))
-
 	})
 
 	It("sync not completed yet", func() {
 		mod.Spec.ModuleLoader.Container.Build = &kmmv1beta1.Build{}
 		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
-		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion,
-			mapping.ContainerImage, false).Return(build.Result{Status: build.StatusInProgress}, nil)
+
+		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, pv.Spec.PushBuiltImage, pv).
+			Return(build.Result{Status: build.StatusInProgress}, nil)
 
 		res, msg := ph.verifyBuild(context.Background(), pv, &mapping, mod)
 		Expect(res).To(BeFalse())
 		Expect(msg).To(Equal("Waiting for build verification"))
-
 	})
 })

--- a/internal/sign/helper.go
+++ b/internal/sign/helper.go
@@ -7,7 +7,7 @@ import (
 //go:generate mockgen -source=helper.go -package=sign -destination=mock_helper.go
 
 type Helper interface {
-	GetRelevantSign(mod kmmv1beta1.Module, km kmmv1beta1.KernelMapping) *kmmv1beta1.Sign
+	GetRelevantSign(modSpec kmmv1beta1.ModuleSpec, km kmmv1beta1.KernelMapping) *kmmv1beta1.Sign
 }
 
 type helper struct{}
@@ -16,18 +16,17 @@ func NewSignerHelper() Helper {
 	return &helper{}
 }
 
-func (m *helper) GetRelevantSign(mod kmmv1beta1.Module, km kmmv1beta1.KernelMapping) *kmmv1beta1.Sign {
-
-	if mod.Spec.ModuleLoader.Container.Sign == nil {
+func (m *helper) GetRelevantSign(modSpec kmmv1beta1.ModuleSpec, km kmmv1beta1.KernelMapping) *kmmv1beta1.Sign {
+	if modSpec.ModuleLoader.Container.Sign == nil {
 		// km.Sign cannot be nil in case mod.Sign is nil, checked above
 		return km.Sign.DeepCopy()
 	}
 
 	if km.Sign == nil {
-		return mod.Spec.ModuleLoader.Container.Sign.DeepCopy()
+		return modSpec.ModuleLoader.Container.Sign.DeepCopy()
 	}
 
-	signConfig := mod.Spec.ModuleLoader.Container.Sign.DeepCopy()
+	signConfig := modSpec.ModuleLoader.Container.Sign.DeepCopy()
 
 	if km.Sign.UnsignedImage != "" {
 		signConfig.UnsignedImage = km.Sign.UnsignedImage

--- a/internal/sign/helper_test.go
+++ b/internal/sign/helper_test.go
@@ -1,12 +1,13 @@
 package sign
 
 import (
+	"strings"
+
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	v1 "k8s.io/api/core/v1"
-	"strings"
 )
 
 var _ = Describe("GetRelevantSign", func() {
@@ -35,7 +36,7 @@ var _ = Describe("GetRelevantSign", func() {
 
 	DescribeTable("should set fields correctly", func(mod kmmv1beta1.Module, km kmmv1beta1.KernelMapping) {
 
-		actual := h.GetRelevantSign(mod, km)
+		actual := h.GetRelevantSign(mod.Spec, km)
 		Expect(
 			cmp.Diff(expected, actual),
 		).To(

--- a/internal/sign/job/manager.go
+++ b/internal/sign/job/manager.go
@@ -5,40 +5,75 @@ import (
 	"errors"
 	"fmt"
 
-	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/sign"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/auth"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/module"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/registry"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 )
 
 type signJobManager struct {
-	signer    Signer
-	helper    sign.Helper
-	jobHelper utils.JobHelper
+	signer      Signer
+	jobHelper   utils.JobHelper
+	authFactory auth.RegistryAuthGetterFactory
+	registry    registry.Registry
 }
 
-func NewSignJobManager(signer Signer, helper sign.Helper, jobHelper utils.JobHelper) *signJobManager {
+func NewSignJobManager(
+	signer Signer,
+	jobHelper utils.JobHelper,
+	authFactory auth.RegistryAuthGetterFactory,
+	registry registry.Registry) *signJobManager {
 	return &signJobManager{
-		signer:    signer,
-		helper:    helper,
-		jobHelper: jobHelper,
+		signer:      signer,
+		jobHelper:   jobHelper,
+		authFactory: authFactory,
+		registry:    registry,
 	}
 }
 
-func (jbm *signJobManager) Sync(ctx context.Context, mod kmmv1beta1.Module, m kmmv1beta1.KernelMapping, targetKernel string, imageToSign string, targetImage string, pushImage bool) (utils.Result, error) {
+func (jbm *signJobManager) ShouldSync(
+	ctx context.Context,
+	mod kmmv1beta1.Module,
+	m kmmv1beta1.KernelMapping) (bool, error) {
+
+	// if there is no sign specified skip
+	if !module.ShouldBeSigned(mod.Spec, m) {
+		return false, nil
+	}
+
+	exists, err := module.ImageExists(ctx, jbm.authFactory, jbm.registry, mod, m, m.ContainerImage)
+	if err != nil {
+		return false, fmt.Errorf("failed to check existence of image %s: %w", m.ContainerImage, err)
+	}
+
+	return !exists, nil
+}
+
+func (jbm *signJobManager) Sync(
+	ctx context.Context,
+	mod kmmv1beta1.Module,
+	m kmmv1beta1.KernelMapping,
+	targetKernel string,
+	imageToSign string,
+	pushImage bool,
+	owner metav1.Object) (utils.Result, error) {
+
 	logger := log.FromContext(ctx)
 
 	logger.Info("Signing in-cluster")
 
-	signConfig := jbm.helper.GetRelevantSign(mod, m)
-	jobLabels := jbm.jobHelper.JobLabels(mod, targetKernel, "sign")
+	labels := jbm.jobHelper.JobLabels(mod.Name, targetKernel, "sign")
 
-	jobTemplate, err := jbm.signer.MakeJobTemplate(mod, signConfig, targetKernel, imageToSign, targetImage, jobLabels, pushImage)
+	jobTemplate, err := jbm.signer.MakeJobTemplate(mod, m, targetKernel, labels, imageToSign, pushImage, owner)
 	if err != nil {
 		return utils.Result{}, fmt.Errorf("could not make Job template: %v", err)
 	}
 
-	job, err := jbm.jobHelper.GetModuleJobByKernel(ctx, mod, targetKernel, utils.JobTypeSign)
+	job, err := jbm.jobHelper.GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, targetKernel, utils.JobTypeSign)
 	if err != nil {
 		if !errors.Is(err, utils.ErrNoMatchingJob) {
 			return utils.Result{}, fmt.Errorf("error getting the signing job: %v", err)
@@ -73,6 +108,6 @@ func (jbm *signJobManager) Sync(ctx context.Context, mod kmmv1beta1.Module, m km
 	if err != nil {
 		return utils.Result{}, err
 	}
-	return utils.Result{Status: statusmsg, Requeue: inprogress}, nil
 
+	return utils.Result{Status: statusmsg, Requeue: inprogress}, nil
 }

--- a/internal/sign/job/manager_test.go
+++ b/internal/sign/job/manager_test.go
@@ -4,24 +4,155 @@ import (
 	"context"
 	"errors"
 
-	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/sign"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
+
+	"github.com/golang/mock/gomock"
 	batchv1 "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/auth"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/registry"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 )
 
 var _ = Describe("JobManager", func() {
-	Describe("Sync", func() {
+	Describe("ShouldSync", func() {
+		var (
+			ctrl        *gomock.Controller
+			authFactory *auth.MockRegistryAuthGetterFactory
+			reg         *registry.MockRegistry
+		)
 
+		const (
+			moduleName    = "module-name"
+			imageName     = "image-name"
+			namespace     = "some-namespace"
+			kernelVersion = "1.2.3"
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			authFactory = auth.NewMockRegistryAuthGetterFactory(ctrl)
+			reg = registry.NewMockRegistry(ctrl)
+		})
+
+		It("should return false if there was not sign section", func() {
+			ctx := context.Background()
+
+			mod := kmmv1beta1.Module{}
+			km := kmmv1beta1.KernelMapping{}
+
+			mgr := NewSignJobManager(nil, nil, authFactory, reg)
+
+			shouldSync, err := mgr.ShouldSync(ctx, mod, km)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(shouldSync).To(BeFalse())
+		})
+
+		It("should return false if image already exists", func() {
+			ctx := context.Background()
+
+			km := kmmv1beta1.KernelMapping{
+				Sign:           &kmmv1beta1.Sign{},
+				ContainerImage: imageName,
+			}
+
+			mod := kmmv1beta1.Module{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      moduleName,
+					Namespace: namespace,
+				},
+				Spec: kmmv1beta1.ModuleSpec{
+					ImageRepoSecret: &v1.LocalObjectReference{Name: "pull-push-secret"},
+				},
+			}
+
+			gomock.InOrder(
+				authFactory.EXPECT().NewRegistryAuthGetterFrom(&mod),
+				reg.EXPECT().ImageExists(ctx, imageName, nil, gomock.Any()).Return(true, nil),
+			)
+
+			mgr := NewSignJobManager(nil, nil, authFactory, reg)
+
+			shouldSync, err := mgr.ShouldSync(ctx, mod, km)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(shouldSync).To(BeFalse())
+		})
+
+		It("should return false and an error if image check fails", func() {
+			ctx := context.Background()
+
+			km := kmmv1beta1.KernelMapping{
+				Sign:           &kmmv1beta1.Sign{},
+				ContainerImage: imageName,
+			}
+
+			mod := kmmv1beta1.Module{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      moduleName,
+					Namespace: namespace,
+				},
+				Spec: kmmv1beta1.ModuleSpec{
+					ImageRepoSecret: &v1.LocalObjectReference{Name: "pull-push-secret"},
+				},
+			}
+
+			gomock.InOrder(
+				authFactory.EXPECT().NewRegistryAuthGetterFrom(&mod),
+				reg.EXPECT().ImageExists(ctx, imageName, nil, gomock.Any()).Return(false, errors.New("generic-registry-error")),
+			)
+
+			mgr := NewSignJobManager(nil, nil, authFactory, reg)
+
+			shouldSync, err := mgr.ShouldSync(ctx, mod, km)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("generic-registry-error"))
+			Expect(shouldSync).To(BeFalse())
+		})
+
+		It("should return true if image does not exist", func() {
+			ctx := context.Background()
+
+			km := kmmv1beta1.KernelMapping{
+				Sign:           &kmmv1beta1.Sign{},
+				ContainerImage: imageName,
+			}
+
+			mod := kmmv1beta1.Module{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      moduleName,
+					Namespace: namespace,
+				},
+				Spec: kmmv1beta1.ModuleSpec{
+					ImageRepoSecret: &v1.LocalObjectReference{Name: "pull-push-secret"},
+				},
+			}
+
+			gomock.InOrder(
+				authFactory.EXPECT().NewRegistryAuthGetterFrom(&mod),
+				reg.EXPECT().ImageExists(ctx, imageName, nil, gomock.Any()).Return(false, nil),
+			)
+
+			mgr := NewSignJobManager(nil, nil, authFactory, reg)
+
+			shouldSync, err := mgr.ShouldSync(ctx, mod, km)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(shouldSync).To(BeTrue())
+		})
+	})
+
+	Describe("Sync", func() {
 		var (
 			ctrl      *gomock.Controller
 			maker     *MockSigner
-			helper    *sign.MockHelper
 			jobhelper *utils.MockJobHelper
 		)
 
@@ -38,7 +169,6 @@ var _ = Describe("JobManager", func() {
 		BeforeEach(func() {
 			ctrl = gomock.NewController(GinkgoT())
 			maker = NewMockSigner(ctrl)
-			helper = sign.NewMockHelper(ctrl)
 			jobhelper = utils.NewMockJobHelper(ctrl)
 		})
 
@@ -87,18 +217,16 @@ var _ = Describe("JobManager", func() {
 				}
 
 				gomock.InOrder(
-					helper.EXPECT().GetRelevantSign(mod, km).Return(km.Sign),
-
-					jobhelper.EXPECT().JobLabels(mod, kernelVersion, "sign").Return(labels),
-					maker.EXPECT().MakeJobTemplate(mod, km.Sign, kernelVersion, previousImageName, km.ContainerImage, labels, true).Return(&j, nil),
-					jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod, kernelVersion, utils.JobTypeSign).Return(&newJob, nil),
+					jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
+					maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
+					jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign).Return(&newJob, nil),
 					jobhelper.EXPECT().IsJobChanged(&j, &newJob).Return(false, nil),
 					jobhelper.EXPECT().GetJobStatus(&newJob).Return(r.Status, r.Requeue, joberr),
 				)
 
-				mgr := NewSignJobManager(maker, helper, jobhelper)
+				mgr := NewSignJobManager(maker, jobhelper, nil, nil)
 
-				res, err := mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, imageName, true)
+				res, err := mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod)
 
 				if expectsErr {
 					Expect(err).To(HaveOccurred())
@@ -117,15 +245,15 @@ var _ = Describe("JobManager", func() {
 			ctx := context.Background()
 
 			gomock.InOrder(
-				helper.EXPECT().GetRelevantSign(mod, km).Return(km.Sign),
-				jobhelper.EXPECT().JobLabels(mod, kernelVersion, "sign").Return(labels),
-				maker.EXPECT().MakeJobTemplate(mod, km.Sign, kernelVersion, previousImageName, km.ContainerImage, labels, true).Return(nil, errors.New("random error")),
+				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
+				maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).
+					Return(nil, errors.New("random error")),
 			)
 
-			mgr := NewSignJobManager(maker, helper, jobhelper)
+			mgr := NewSignJobManager(maker, jobhelper, nil, nil)
 
 			Expect(
-				mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, imageName, true),
+				mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod),
 			).Error().To(
 				HaveOccurred(),
 			)
@@ -145,16 +273,15 @@ var _ = Describe("JobManager", func() {
 			}
 
 			gomock.InOrder(
-				helper.EXPECT().GetRelevantSign(mod, km).Return(km.Sign),
-				jobhelper.EXPECT().JobLabels(mod, kernelVersion, "sign").Return(labels),
-				maker.EXPECT().MakeJobTemplate(mod, km.Sign, kernelVersion, previousImageName, km.ContainerImage, labels, true).Return(&j, nil),
-				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod, kernelVersion, utils.JobTypeSign).Return(nil, errors.New("random error")),
+				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
+				maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
+				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign).Return(nil, errors.New("random error")),
 			)
 
-			mgr := NewSignJobManager(maker, helper, jobhelper)
+			mgr := NewSignJobManager(maker, jobhelper, nil, nil)
 
 			Expect(
-				mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, imageName, true),
+				mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod),
 			).Error().To(
 				HaveOccurred(),
 			)
@@ -174,17 +301,16 @@ var _ = Describe("JobManager", func() {
 			}
 
 			gomock.InOrder(
-				helper.EXPECT().GetRelevantSign(mod, km).Return(km.Sign),
-				jobhelper.EXPECT().JobLabels(mod, kernelVersion, "sign").Return(labels),
-				maker.EXPECT().MakeJobTemplate(mod, km.Sign, kernelVersion, previousImageName, km.ContainerImage, labels, true).Return(&j, nil),
-				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod, kernelVersion, utils.JobTypeSign).Return(nil, utils.ErrNoMatchingJob),
+				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
+				maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
+				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign).Return(nil, utils.ErrNoMatchingJob),
 				jobhelper.EXPECT().CreateJob(ctx, &j).Return(errors.New("unable to create job")),
 			)
 
-			mgr := NewSignJobManager(maker, helper, jobhelper)
+			mgr := NewSignJobManager(maker, jobhelper, nil, nil)
 
 			Expect(
-				mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, imageName, true),
+				mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod),
 			).Error().To(
 				HaveOccurred(),
 			)
@@ -205,17 +331,16 @@ var _ = Describe("JobManager", func() {
 			}
 
 			gomock.InOrder(
-				helper.EXPECT().GetRelevantSign(mod, km).Return(km.Sign),
-				jobhelper.EXPECT().JobLabels(mod, kernelVersion, "sign").Return(labels),
-				maker.EXPECT().MakeJobTemplate(mod, km.Sign, kernelVersion, previousImageName, km.ContainerImage, labels, true).Return(&j, nil),
-				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod, kernelVersion, utils.JobTypeSign).Return(nil, utils.ErrNoMatchingJob),
+				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
+				maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
+				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign).Return(nil, utils.ErrNoMatchingJob),
 				jobhelper.EXPECT().CreateJob(ctx, &j).Return(nil),
 			)
 
-			mgr := NewSignJobManager(maker, helper, jobhelper)
+			mgr := NewSignJobManager(maker, jobhelper, nil, nil)
 
 			Expect(
-				mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, imageName, true),
+				mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod),
 			).To(
 				Equal(utils.Result{Requeue: true, Status: utils.StatusCreated}),
 			)
@@ -237,18 +362,17 @@ var _ = Describe("JobManager", func() {
 			}
 
 			gomock.InOrder(
-				helper.EXPECT().GetRelevantSign(mod, km).Return(km.Sign),
-				jobhelper.EXPECT().JobLabels(mod, kernelVersion, "sign").Return(labels),
-				maker.EXPECT().MakeJobTemplate(mod, km.Sign, kernelVersion, previousImageName, km.ContainerImage, labels, true).Return(&newJob, nil),
-				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod, kernelVersion, utils.JobTypeSign).Return(&newJob, nil),
+				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
+				maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&newJob, nil),
+				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign).Return(&newJob, nil),
 				jobhelper.EXPECT().IsJobChanged(&newJob, &newJob).Return(true, nil),
 				jobhelper.EXPECT().DeleteJob(ctx, &newJob).Return(nil),
 			)
 
-			mgr := NewSignJobManager(maker, helper, jobhelper)
+			mgr := NewSignJobManager(maker, jobhelper, nil, nil)
 
 			Expect(
-				mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, imageName, true),
+				mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod),
 			).To(
 				Equal(utils.Result{Requeue: true, Status: utils.StatusInProgress}),
 			)

--- a/internal/sign/job/mock_signer.go
+++ b/internal/sign/job/mock_signer.go
@@ -10,6 +10,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	v1 "k8s.io/api/batch/v1"
+	v10 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // MockSigner is a mock of Signer interface.
@@ -36,16 +37,16 @@ func (m *MockSigner) EXPECT() *MockSignerMockRecorder {
 }
 
 // MakeJobTemplate mocks base method.
-func (m *MockSigner) MakeJobTemplate(mod v1beta1.Module, signConfig *v1beta1.Sign, targetKernel, imageToSign, targetImage string, labels map[string]string, pushImage bool) (*v1.Job, error) {
+func (m *MockSigner) MakeJobTemplate(mod v1beta1.Module, km v1beta1.KernelMapping, targetKernel string, labels map[string]string, imageToSign string, pushImage bool, owner v10.Object) (*v1.Job, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MakeJobTemplate", mod, signConfig, targetKernel, imageToSign, targetImage, labels, pushImage)
+	ret := m.ctrl.Call(m, "MakeJobTemplate", mod, km, targetKernel, labels, imageToSign, pushImage, owner)
 	ret0, _ := ret[0].(*v1.Job)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MakeJobTemplate indicates an expected call of MakeJobTemplate.
-func (mr *MockSignerMockRecorder) MakeJobTemplate(mod, signConfig, targetKernel, imageToSign, targetImage, labels, pushImage interface{}) *gomock.Call {
+func (mr *MockSignerMockRecorder) MakeJobTemplate(mod, km, targetKernel, labels, imageToSign, pushImage, owner interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeJobTemplate", reflect.TypeOf((*MockSigner)(nil).MakeJobTemplate), mod, signConfig, targetKernel, imageToSign, targetImage, labels, pushImage)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeJobTemplate", reflect.TypeOf((*MockSigner)(nil).MakeJobTemplate), mod, km, targetKernel, labels, imageToSign, pushImage, owner)
 }

--- a/internal/sign/job/signer.go
+++ b/internal/sign/job/signer.go
@@ -4,35 +4,64 @@ import (
 	"fmt"
 	"strings"
 
-	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/sign"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 )
 
 //go:generate mockgen -source=signer.go -package=signjob -destination=mock_signer.go
 
 type Signer interface {
-	MakeJobTemplate(mod kmmv1beta1.Module, signConfig *kmmv1beta1.Sign, targetKernel string, imageToSign string, targetImage string, labels map[string]string, pushImage bool) (*batchv1.Job, error)
+	MakeJobTemplate(
+		mod kmmv1beta1.Module,
+		km kmmv1beta1.KernelMapping,
+		targetKernel string,
+		labels map[string]string,
+		imageToSign string,
+		pushImage bool,
+		owner metav1.Object,
+	) (*batchv1.Job, error)
 }
 
 type signer struct {
-	scheme *runtime.Scheme
+	scheme    *runtime.Scheme
+	helper    sign.Helper
+	jobHelper utils.JobHelper
 }
 
-func NewSigner(scheme *runtime.Scheme) Signer {
-	return &signer{scheme: scheme}
+func NewSigner(
+	scheme *runtime.Scheme,
+	helper sign.Helper,
+	jobHelper utils.JobHelper) Signer {
+	return &signer{
+		scheme:    scheme,
+		helper:    helper,
+		jobHelper: jobHelper,
+	}
 }
 
-func (m *signer) MakeJobTemplate(mod kmmv1beta1.Module, signConfig *kmmv1beta1.Sign, targetKernel string, imageToSign string, targetImage string, labels map[string]string, pushImage bool) (*batchv1.Job, error) {
-	var args []string
+func (m *signer) MakeJobTemplate(
+	mod kmmv1beta1.Module,
+	km kmmv1beta1.KernelMapping,
+	targetKernel string,
+	labels map[string]string,
+	imageToSign string,
+	pushImage bool,
+	owner metav1.Object) (*batchv1.Job, error) {
+
+	signConfig := m.helper.GetRelevantSign(mod.Spec, km)
+
+	args := make([]string, 0)
 
 	if pushImage {
-		args = []string{"-signedimage", targetImage}
+		args = append(args, "-signedimage", km.ContainerImage)
 	} else {
 		args = append(args, "-no-push")
 	}
@@ -92,7 +121,7 @@ func (m *signer) MakeJobTemplate(mod kmmv1beta1.Module, signConfig *kmmv1beta1.S
 		},
 	}
 
-	if err := controllerutil.SetControllerReference(&mod, job, m.scheme); err != nil {
+	if err := controllerutil.SetControllerReference(owner, job, m.scheme); err != nil {
 		return nil, fmt.Errorf("could not set the owner reference: %v", err)
 	}
 

--- a/internal/sign/job/signer_test.go
+++ b/internal/sign/job/signer_test.go
@@ -9,6 +9,8 @@ import (
 	. "github.com/onsi/gomega"
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/sign"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,7 +18,6 @@ import (
 )
 
 var _ = Describe("MakeJobTemplate", func() {
-
 	const (
 		unsignedImage = "my.registry/my/image"
 		signedImage   = "my.registry/my/image-signed"
@@ -27,14 +28,18 @@ var _ = Describe("MakeJobTemplate", func() {
 	)
 
 	var (
-		ctrl *gomock.Controller
-		m    Signer
-		mod  kmmv1beta1.Module
+		ctrl      *gomock.Controller
+		m         Signer
+		mod       kmmv1beta1.Module
+		helper    *sign.MockHelper
+		jobhelper *utils.MockJobHelper
 	)
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
-		m = NewSigner(scheme)
+		helper = sign.NewMockHelper(ctrl)
+		jobhelper = utils.NewMockJobHelper(ctrl)
+		m = NewSigner(scheme, helper, jobhelper)
 		mod = kmmv1beta1.Module{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      moduleName,
@@ -185,7 +190,11 @@ var _ = Describe("MakeJobTemplate", func() {
 		mod := mod.DeepCopy()
 		mod.Spec.Selector = nodeSelector
 
-		actual, err := m.MakeJobTemplate(*mod, km.Sign, kernelVersion, unsignedImage, signedImage, labels, true)
+		gomock.InOrder(
+			helper.EXPECT().GetRelevantSign(mod.Spec, km).Return(km.Sign),
+		)
+
+		actual, err := m.MakeJobTemplate(*mod, km, kernelVersion, labels, unsignedImage, true, mod)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(
@@ -204,21 +213,30 @@ var _ = Describe("MakeJobTemplate", func() {
 		),
 	)
 
-	DescribeTable("should set correct kmod-signer flags", func(filelist []string, pushFlag bool) {
+	DescribeTable("should set correct kmod-signer flags", func(filelist []string, pushImage bool) {
 
-		signConfig := &kmmv1beta1.Sign{
-			UnsignedImage: signedImage,
-			KeySecret:     &v1.LocalObjectReference{Name: "securebootkey"},
-			CertSecret:    &v1.LocalObjectReference{Name: "securebootcert"},
-			FilesToSign:   filelist,
+		km := kmmv1beta1.KernelMapping{
+			Sign: &kmmv1beta1.Sign{
+				UnsignedImage: signedImage,
+				KeySecret:     &v1.LocalObjectReference{Name: "securebootkey"},
+				CertSecret:    &v1.LocalObjectReference{Name: "securebootcert"},
+				FilesToSign:   filelist,
+			},
+			ContainerImage: unsignedImage,
 		}
 
-		actual, err := m.MakeJobTemplate(mod, signConfig, kernelVersion, "", signedImage, labels, pushFlag)
+		gomock.InOrder(
+			helper.EXPECT().GetRelevantSign(mod.Spec, km).Return(km.Sign),
+		)
+
+		actual, err := m.MakeJobTemplate(mod, km, kernelVersion, labels, "", pushImage, &mod)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(actual.Spec.Template.Spec.Containers[0].Args).To(ContainElement("-unsignedimage"))
 		Expect(actual.Spec.Template.Spec.Containers[0].Args).To(ContainElement("-key"))
 		Expect(actual.Spec.Template.Spec.Containers[0].Args).To(ContainElement("-cert"))
-		if pushFlag {
+
+		if pushImage {
 			Expect(actual.Spec.Template.Spec.Containers[0].Args).To(ContainElement("-signedimage"))
 		} else {
 			Expect(actual.Spec.Template.Spec.Containers[0].Args).To(ContainElement("-no-push"))

--- a/internal/sign/manager.go
+++ b/internal/sign/manager.go
@@ -3,10 +3,26 @@ package sign
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 )
 
+//go:generate mockgen -source=manager.go -package=sign -destination=mock_manager.go
+
 type SignManager interface {
-	Sync(ctx context.Context, mod kmmv1beta1.Module, m kmmv1beta1.KernelMapping, targetKernel string, imageToSign string, targetImage string, pushImage bool) (utils.Result, error)
+	ShouldSync(
+		ctx context.Context,
+		mod kmmv1beta1.Module,
+		m kmmv1beta1.KernelMapping) (bool, error)
+
+	Sync(
+		ctx context.Context,
+		mod kmmv1beta1.Module,
+		m kmmv1beta1.KernelMapping,
+		targetKernel string,
+		imageToSign string,
+		pushImage bool,
+		owner metav1.Object) (utils.Result, error)
 }

--- a/internal/sign/mock_helper.go
+++ b/internal/sign/mock_helper.go
@@ -35,15 +35,15 @@ func (m *MockHelper) EXPECT() *MockHelperMockRecorder {
 }
 
 // GetRelevantSign mocks base method.
-func (m *MockHelper) GetRelevantSign(mod v1beta1.Module, km v1beta1.KernelMapping) *v1beta1.Sign {
+func (m *MockHelper) GetRelevantSign(modSpec v1beta1.ModuleSpec, km v1beta1.KernelMapping) *v1beta1.Sign {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRelevantSign", mod, km)
+	ret := m.ctrl.Call(m, "GetRelevantSign", modSpec, km)
 	ret0, _ := ret[0].(*v1beta1.Sign)
 	return ret0
 }
 
 // GetRelevantSign indicates an expected call of GetRelevantSign.
-func (mr *MockHelperMockRecorder) GetRelevantSign(mod, km interface{}) *gomock.Call {
+func (mr *MockHelperMockRecorder) GetRelevantSign(modSpec, km interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelevantSign", reflect.TypeOf((*MockHelper)(nil).GetRelevantSign), mod, km)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelevantSign", reflect.TypeOf((*MockHelper)(nil).GetRelevantSign), modSpec, km)
 }

--- a/internal/sign/mock_manager.go
+++ b/internal/sign/mock_manager.go
@@ -10,7 +10,8 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
-	jobHelper "github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
+	utils "github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // MockSignManager is a mock of SignManager interface.
@@ -36,17 +37,32 @@ func (m *MockSignManager) EXPECT() *MockSignManagerMockRecorder {
 	return m.recorder
 }
 
-// Sync mocks base method.
-func (m_2 *MockSignManager) Sync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping, targetKernel, imageToSign, targetImage string, pushImage bool) (jobHelper.Result, error) {
+// ShouldSync mocks base method.
+func (m_2 *MockSignManager) ShouldSync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping) (bool, error) {
 	m_2.ctrl.T.Helper()
-	ret := m_2.ctrl.Call(m_2, "Sync", ctx, mod, m, targetKernel, imageToSign, targetImage, pushImage)
-	ret0, _ := ret[0].(jobHelper.Result)
+	ret := m_2.ctrl.Call(m_2, "ShouldSync", ctx, mod, m)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ShouldSync indicates an expected call of ShouldSync.
+func (mr *MockSignManagerMockRecorder) ShouldSync(ctx, mod, m interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldSync", reflect.TypeOf((*MockSignManager)(nil).ShouldSync), ctx, mod, m)
+}
+
+// Sync mocks base method.
+func (m_2 *MockSignManager) Sync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping, targetKernel, imageToSign string, pushImage bool, owner v1.Object) (utils.Result, error) {
+	m_2.ctrl.T.Helper()
+	ret := m_2.ctrl.Call(m_2, "Sync", ctx, mod, m, targetKernel, imageToSign, pushImage, owner)
+	ret0, _ := ret[0].(utils.Result)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Sync indicates an expected call of Sync.
-func (mr *MockSignManagerMockRecorder) Sync(ctx, mod, m, targetKernel, imageToSign, targetImage, pushImage interface{}) *gomock.Call {
+func (mr *MockSignManagerMockRecorder) Sync(ctx, mod, m, targetKernel, imageToSign, pushImage, owner interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockSignManager)(nil).Sync), ctx, mod, m, targetKernel, imageToSign, targetImage, pushImage)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockSignManager)(nil).Sync), ctx, mod, m, targetKernel, imageToSign, pushImage, owner)
 }

--- a/internal/utils/jobhelper.go
+++ b/internal/utils/jobhelper.go
@@ -1,17 +1,15 @@
 package utils
 
-//go:generate mockgen -source=jobhelper.go -package=utils -destination=mock_jobhelper.go
-
 import (
 	"context"
 	"errors"
 	"fmt"
 
-	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 )
 
 type Status string
@@ -33,11 +31,13 @@ type Result struct {
 	Status  Status
 }
 
+//go:generate mockgen -source=jobhelper.go -package=utils -destination=mock_jobhelper.go
+
 type JobHelper interface {
 	IsJobChanged(existingJob *batchv1.Job, newJob *batchv1.Job) (bool, error)
-	JobLabels(mod kmmv1beta1.Module, targetKernel string, jobType string) map[string]string
-	GetModuleJobByKernel(ctx context.Context, mod kmmv1beta1.Module, targetKernel, jobType string) (*batchv1.Job, error)
-	GetModuleJobs(ctx context.Context, mod kmmv1beta1.Module, jobType string) ([]batchv1.Job, error)
+	JobLabels(modName string, targetKernel string, jobType string) map[string]string
+	GetModuleJobByKernel(ctx context.Context, modName, namespace, targetKernel, jobType string) (*batchv1.Job, error)
+	GetModuleJobs(ctx context.Context, modName, namespace, jobType string) ([]batchv1.Job, error)
 	DeleteJob(ctx context.Context, job *batchv1.Job) error
 	CreateJob(ctx context.Context, jobTemplate *batchv1.Job) error
 	GetJobStatus(job *batchv1.Job) (Status, bool, error)
@@ -65,15 +65,15 @@ func (jh *jobHelper) IsJobChanged(existingJob *batchv1.Job, newJob *batchv1.Job)
 	return true, nil
 }
 
-func (jh *jobHelper) JobLabels(mod kmmv1beta1.Module, targetKernel string, jobType string) map[string]string {
-	return moduleKernelLabels(mod.Name, targetKernel, jobType)
+func (jh *jobHelper) JobLabels(modName string, targetKernel string, jobType string) map[string]string {
+	return moduleKernelLabels(modName, targetKernel, jobType)
 }
 
-func (jh *jobHelper) GetModuleJobByKernel(ctx context.Context, mod kmmv1beta1.Module, targetKernel, jobType string) (*batchv1.Job, error) {
-	matchLabels := moduleKernelLabels(mod.Name, targetKernel, jobType)
-	jobs, err := jh.getJobs(ctx, mod.Namespace, matchLabels)
+func (jh *jobHelper) GetModuleJobByKernel(ctx context.Context, modName, namespace, targetKernel, jobType string) (*batchv1.Job, error) {
+	matchLabels := moduleKernelLabels(modName, targetKernel, jobType)
+	jobs, err := jh.getJobs(ctx, namespace, matchLabels)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get module %s, jobs by kernel %s: %v", mod.Name, targetKernel, err)
+		return nil, fmt.Errorf("failed to get module %s, jobs by kernel %s: %v", modName, targetKernel, err)
 	}
 
 	numFoundJobs := len(jobs)
@@ -86,13 +86,12 @@ func (jh *jobHelper) GetModuleJobByKernel(ctx context.Context, mod kmmv1beta1.Mo
 	return &jobs[0], nil
 }
 
-func (jh *jobHelper) GetModuleJobs(ctx context.Context, mod kmmv1beta1.Module, jobType string) ([]batchv1.Job, error) {
-	matchLabels := moduleLabels(mod.Name, jobType)
-	return jh.getJobs(ctx, mod.Namespace, matchLabels)
+func (jh *jobHelper) GetModuleJobs(ctx context.Context, modName, namespace, jobType string) ([]batchv1.Job, error) {
+	matchLabels := moduleLabels(modName, jobType)
+	return jh.getJobs(ctx, namespace, matchLabels)
 }
 
 func (jh *jobHelper) DeleteJob(ctx context.Context, job *batchv1.Job) error {
-
 	opts := []client.DeleteOption{
 		client.PropagationPolicy(metav1.DeletePropagationBackground),
 	}
@@ -111,12 +110,8 @@ func (jh *jobHelper) CreateJob(ctx context.Context, jobTemplate *batchv1.Job) er
 	return nil
 }
 
-/* get the status of a job
-** returns:
-**	status - string representation of the status
-**	inprogress - bool, is the job still in progress?
-**	error - an error reporting failure state
- */
+// GetJobStatus returns the status of a Job, whether the latter is in progress or not and
+// whether there was an error or not
 func (jh *jobHelper) GetJobStatus(job *batchv1.Job) (Status, bool, error) {
 	switch {
 	case job.Status.Succeeded == 1:

--- a/internal/utils/mock_jobhelper.go
+++ b/internal/utils/mock_jobhelper.go
@@ -9,7 +9,6 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	v1 "k8s.io/api/batch/v1"
 )
 
@@ -81,33 +80,33 @@ func (mr *MockJobHelperMockRecorder) GetJobStatus(job interface{}) *gomock.Call 
 }
 
 // GetModuleJobByKernel mocks base method.
-func (m *MockJobHelper) GetModuleJobByKernel(ctx context.Context, mod v1beta1.Module, targetKernel, jobType string) (*v1.Job, error) {
+func (m *MockJobHelper) GetModuleJobByKernel(ctx context.Context, modName, namespace, targetKernel, jobType string) (*v1.Job, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetModuleJobByKernel", ctx, mod, targetKernel, jobType)
+	ret := m.ctrl.Call(m, "GetModuleJobByKernel", ctx, modName, namespace, targetKernel, jobType)
 	ret0, _ := ret[0].(*v1.Job)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetModuleJobByKernel indicates an expected call of GetModuleJobByKernel.
-func (mr *MockJobHelperMockRecorder) GetModuleJobByKernel(ctx, mod, targetKernel, jobType interface{}) *gomock.Call {
+func (mr *MockJobHelperMockRecorder) GetModuleJobByKernel(ctx, modName, namespace, targetKernel, jobType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleJobByKernel", reflect.TypeOf((*MockJobHelper)(nil).GetModuleJobByKernel), ctx, mod, targetKernel, jobType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleJobByKernel", reflect.TypeOf((*MockJobHelper)(nil).GetModuleJobByKernel), ctx, modName, namespace, targetKernel, jobType)
 }
 
 // GetModuleJobs mocks base method.
-func (m *MockJobHelper) GetModuleJobs(ctx context.Context, mod v1beta1.Module, jobType string) ([]v1.Job, error) {
+func (m *MockJobHelper) GetModuleJobs(ctx context.Context, modName, namespace, jobType string) ([]v1.Job, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetModuleJobs", ctx, mod, jobType)
+	ret := m.ctrl.Call(m, "GetModuleJobs", ctx, modName, namespace, jobType)
 	ret0, _ := ret[0].([]v1.Job)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetModuleJobs indicates an expected call of GetModuleJobs.
-func (mr *MockJobHelperMockRecorder) GetModuleJobs(ctx, mod, jobType interface{}) *gomock.Call {
+func (mr *MockJobHelperMockRecorder) GetModuleJobs(ctx, modName, namespace, jobType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleJobs", reflect.TypeOf((*MockJobHelper)(nil).GetModuleJobs), ctx, mod, jobType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleJobs", reflect.TypeOf((*MockJobHelper)(nil).GetModuleJobs), ctx, modName, namespace, jobType)
 }
 
 // IsJobChanged mocks base method.
@@ -126,15 +125,15 @@ func (mr *MockJobHelperMockRecorder) IsJobChanged(existingJob, newJob interface{
 }
 
 // JobLabels mocks base method.
-func (m *MockJobHelper) JobLabels(mod v1beta1.Module, targetKernel, jobType string) map[string]string {
+func (m *MockJobHelper) JobLabels(modName, targetKernel, jobType string) map[string]string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JobLabels", mod, targetKernel, jobType)
+	ret := m.ctrl.Call(m, "JobLabels", modName, targetKernel, jobType)
 	ret0, _ := ret[0].(map[string]string)
 	return ret0
 }
 
 // JobLabels indicates an expected call of JobLabels.
-func (mr *MockJobHelperMockRecorder) JobLabels(mod, targetKernel, jobType interface{}) *gomock.Call {
+func (mr *MockJobHelperMockRecorder) JobLabels(modName, targetKernel, jobType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JobLabels", reflect.TypeOf((*MockJobHelper)(nil).JobLabels), mod, targetKernel, jobType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JobLabels", reflect.TypeOf((*MockJobHelper)(nil).JobLabels), modName, targetKernel, jobType)
 }


### PR DESCRIPTION
This change refactors the internal build and sign APIs, in order to facilitate their use by the `ManagedClusterModuleReconciler` as well.

Signed-off-by: Michail Resvanis <mresvani@redhat.com>

Upstream-Commit: 9401c987f497c5757d0384406be3048c527a1799

Fixes #264 