### PR TITLE
Increase preflight reconciliation timeout to 3 minutes

### DIFF
--- a/controllers/preflightvalidation_reconciler.go
+++ b/controllers/preflightvalidation_reconciler.go
@@ -39,7 +39,7 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 )
 
-const reconcileRequeueInSeconds = 60
+const reconcileRequeueInSeconds = 180
 
 // ClusterPreflightReconciler reconciles a PreflightValidation object
 type PreflightValidationReconciler struct {
@@ -107,6 +107,10 @@ func (r *PreflightValidationReconciler) Reconcile(ctx context.Context, req ctrl.
 		log.Info("PreflightValidation reconciliation success")
 		return ctrl.Result{}, nil
 	}
+	// if not all the modules has been reconciled, then maybe there is a problem with build
+	// configuration. Since build configuration is stored in the ConfigMap, and we cannot watch
+	// ConfigMap (since we don't know which ones to watch), then we need a requeue in order to run
+	// reconciliation again
 	log.Info("PreflightValidation reconciliation requeue")
 	return ctrl.Result{RequeueAfter: time.Second * reconcileRequeueInSeconds}, nil
 }

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -140,6 +140,7 @@ func (p *preflightHelper) verifyBuild(ctx context.Context,
 	pv *kmmv1beta1.PreflightValidation,
 	mapping *kmmv1beta1.KernelMapping,
 	mod *kmmv1beta1.Module) (bool, string) {
+	log := ctrlruntime.LoggerFrom(ctx)
 	// at this stage we know that eiher mapping Build or Container build are defined
 	buildRes, err := p.buildAPI.Sync(ctx, *mod, *mapping, pv.Spec.KernelVersion, pv.Spec.PushBuiltImage, pv)
 	if err != nil {
@@ -151,6 +152,7 @@ func (p *preflightHelper) verifyBuild(ctx context.Context,
 		if pv.Spec.PushBuiltImage {
 			msg += " and image pushed"
 		}
+		log.Info("build for module during preflight has been build successfully", "module", mod.Name)
 		return true, fmt.Sprintf(VerificationStatusReasonVerified, msg)
 	}
 	return false, "Waiting for build verification"


### PR DESCRIPTION
This PR increases the preflight reconciliation timeout to 3 minutes.

Upstream-Commit: b027816f3a46573c17b50197e0c27874d1357f17

Fixes #274 