### PR TITLE
Build/Sign job selection should be done based on owner field also

### DIFF
--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -408,7 +408,7 @@ func (r *ModuleReconciler) garbageCollect(ctx context.Context,
 	logger.Info("Garbage-collected DaemonSets", "names", deleted)
 
 	// Garbage collect for successfully finished build jobs
-	deleted, err = r.buildAPI.GarbageCollect(ctx, mod.Name, mod.Namespace)
+	deleted, err = r.buildAPI.GarbageCollect(ctx, mod.Name, mod.Namespace, mod)
 	if err != nil {
 		return fmt.Errorf("could not garbage collect build objects: %v", err)
 	}

--- a/controllers/module_reconciler_test.go
+++ b/controllers/module_reconciler_test.go
@@ -164,7 +164,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		gomock.InOrder(
 			mockDC.EXPECT().ModuleDaemonSetsByKernelVersion(ctx, moduleName, namespace).Return(dsByKernelVersion, nil),
 			mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString()),
-			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace),
+			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace, &mod),
 			mockSU.EXPECT().ModuleUpdateStatus(ctx, &mod, []v1.Node{}, []v1.Node{}, dsByKernelVersion).Return(nil),
 		)
 
@@ -229,7 +229,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		gomock.InOrder(
 			mockDC.EXPECT().ModuleDaemonSetsByKernelVersion(ctx, moduleName, namespace).Return(dsByKernelVersion, nil),
 			mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString()),
-			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace),
+			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace, &mod),
 			mockSU.EXPECT().ModuleUpdateStatus(ctx, &mod, []v1.Node{}, []v1.Node{}, dsByKernelVersion).Return(nil),
 		)
 
@@ -304,7 +304,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		gomock.InOrder(
 			mockDC.EXPECT().ModuleDaemonSetsByKernelVersion(ctx, moduleName, namespace).Return(dsByKernelVersion, nil),
 			mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString()),
-			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace),
+			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace, &mod),
 			mockSU.EXPECT().ModuleUpdateStatus(ctx, &mod, []v1.Node{}, []v1.Node{}, dsByKernelVersion).Return(nil),
 		)
 
@@ -413,7 +413,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			clnt.EXPECT().Create(ctx, gomock.Any()).Return(nil),
 			mockMetrics.EXPECT().SetCompletedStage(moduleName, namespace, kernelVersion, metrics.ModuleLoaderStage, false),
 			mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString(kernelVersion)),
-			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace),
+			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace, &mod),
 			mockSU.EXPECT().ModuleUpdateStatus(ctx, &mod, nodeList.Items, nodeList.Items, dsByKernelVersion).Return(nil),
 		)
 
@@ -535,7 +535,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 					d.SetLabels(map[string]string{"test": "test"})
 				}),
 			mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString(kernelVersion)),
-			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace),
+			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace, &mod),
 			mockSU.EXPECT().ModuleUpdateStatus(ctx, &mod, nodeList.Items, nodeList.Items, dsByKernelVersion).Return(nil),
 		)
 
@@ -625,7 +625,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			clnt.EXPECT().Create(ctx, gomock.Any()).Return(nil),
 			mockMetrics.EXPECT().SetCompletedStage(moduleName, namespace, "", metrics.DevicePluginStage, false),
 			mockDC.EXPECT().GarbageCollect(ctx, nil, sets.NewString()),
-			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace),
+			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace, &mod),
 			mockSU.EXPECT().ModuleUpdateStatus(ctx, &mod, []v1.Node{}, []v1.Node{}, nil).Return(nil),
 		)
 

--- a/internal/build/buildconfig/manager.go
+++ b/internal/build/buildconfig/manager.go
@@ -47,7 +47,7 @@ func NewManager(
 	}
 }
 
-func (bcm *buildManager) GarbageCollect(ctx context.Context, modName, namespace string) ([]string, error) {
+func (bcm *buildManager) GarbageCollect(ctx context.Context, modName, namespace string, owner metav1.Object) ([]string, error) {
 
 	//Garbage Collection noti (yet) implemented for Build
 	return nil, nil

--- a/internal/build/manager.go
+++ b/internal/build/manager.go
@@ -24,7 +24,7 @@ type Result struct {
 //go:generate mockgen -source=manager.go -package=build -destination=mock_manager.go
 
 type Manager interface {
-	GarbageCollect(ctx context.Context, modName, namespace string) ([]string, error)
+	GarbageCollect(ctx context.Context, modName, namespace string, owner metav1.Object) ([]string, error)
 
 	ShouldSync(
 		ctx context.Context,

--- a/internal/build/mock_manager.go
+++ b/internal/build/mock_manager.go
@@ -37,18 +37,18 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 }
 
 // GarbageCollect mocks base method.
-func (m *MockManager) GarbageCollect(ctx context.Context, modName, namespace string) ([]string, error) {
+func (m *MockManager) GarbageCollect(ctx context.Context, modName, namespace string, owner v1.Object) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GarbageCollect", ctx, modName, namespace)
+	ret := m.ctrl.Call(m, "GarbageCollect", ctx, modName, namespace, owner)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GarbageCollect indicates an expected call of GarbageCollect.
-func (mr *MockManagerMockRecorder) GarbageCollect(ctx, modName, namespace interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) GarbageCollect(ctx, modName, namespace, owner interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockManager)(nil).GarbageCollect), ctx, modName, namespace)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockManager)(nil).GarbageCollect), ctx, modName, namespace, owner)
 }
 
 // ShouldSync mocks base method.

--- a/internal/sign/job/manager.go
+++ b/internal/sign/job/manager.go
@@ -73,7 +73,7 @@ func (jbm *signJobManager) Sync(
 		return utils.Result{}, fmt.Errorf("could not make Job template: %v", err)
 	}
 
-	job, err := jbm.jobHelper.GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, targetKernel, utils.JobTypeSign)
+	job, err := jbm.jobHelper.GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, targetKernel, utils.JobTypeSign, owner)
 	if err != nil {
 		if !errors.Is(err, utils.ErrNoMatchingJob) {
 			return utils.Result{}, fmt.Errorf("error getting the signing job: %v", err)

--- a/internal/sign/job/manager_test.go
+++ b/internal/sign/job/manager_test.go
@@ -219,7 +219,7 @@ var _ = Describe("JobManager", func() {
 				gomock.InOrder(
 					jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
 					maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
-					jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign).Return(&newJob, nil),
+					jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(&newJob, nil),
 					jobhelper.EXPECT().IsJobChanged(&j, &newJob).Return(false, nil),
 					jobhelper.EXPECT().GetJobStatus(&newJob).Return(r.Status, r.Requeue, joberr),
 				)
@@ -275,7 +275,7 @@ var _ = Describe("JobManager", func() {
 			gomock.InOrder(
 				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
 				maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
-				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign).Return(nil, errors.New("random error")),
+				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(nil, errors.New("random error")),
 			)
 
 			mgr := NewSignJobManager(maker, jobhelper, nil, nil)
@@ -303,7 +303,7 @@ var _ = Describe("JobManager", func() {
 			gomock.InOrder(
 				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
 				maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
-				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign).Return(nil, utils.ErrNoMatchingJob),
+				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(nil, utils.ErrNoMatchingJob),
 				jobhelper.EXPECT().CreateJob(ctx, &j).Return(errors.New("unable to create job")),
 			)
 
@@ -333,7 +333,7 @@ var _ = Describe("JobManager", func() {
 			gomock.InOrder(
 				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
 				maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
-				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign).Return(nil, utils.ErrNoMatchingJob),
+				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(nil, utils.ErrNoMatchingJob),
 				jobhelper.EXPECT().CreateJob(ctx, &j).Return(nil),
 			)
 
@@ -364,7 +364,7 @@ var _ = Describe("JobManager", func() {
 			gomock.InOrder(
 				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
 				maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&newJob, nil),
-				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign).Return(&newJob, nil),
+				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(&newJob, nil),
 				jobhelper.EXPECT().IsJobChanged(&newJob, &newJob).Return(true, nil),
 				jobhelper.EXPECT().DeleteJob(ctx, &newJob).Return(nil),
 			)

--- a/internal/utils/mock_jobhelper.go
+++ b/internal/utils/mock_jobhelper.go
@@ -10,6 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/batch/v1"
+	v10 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // MockJobHelper is a mock of JobHelper interface.
@@ -80,33 +81,33 @@ func (mr *MockJobHelperMockRecorder) GetJobStatus(job interface{}) *gomock.Call 
 }
 
 // GetModuleJobByKernel mocks base method.
-func (m *MockJobHelper) GetModuleJobByKernel(ctx context.Context, modName, namespace, targetKernel, jobType string) (*v1.Job, error) {
+func (m *MockJobHelper) GetModuleJobByKernel(ctx context.Context, modName, namespace, targetKernel, jobType string, owner v10.Object) (*v1.Job, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetModuleJobByKernel", ctx, modName, namespace, targetKernel, jobType)
+	ret := m.ctrl.Call(m, "GetModuleJobByKernel", ctx, modName, namespace, targetKernel, jobType, owner)
 	ret0, _ := ret[0].(*v1.Job)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetModuleJobByKernel indicates an expected call of GetModuleJobByKernel.
-func (mr *MockJobHelperMockRecorder) GetModuleJobByKernel(ctx, modName, namespace, targetKernel, jobType interface{}) *gomock.Call {
+func (mr *MockJobHelperMockRecorder) GetModuleJobByKernel(ctx, modName, namespace, targetKernel, jobType, owner interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleJobByKernel", reflect.TypeOf((*MockJobHelper)(nil).GetModuleJobByKernel), ctx, modName, namespace, targetKernel, jobType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleJobByKernel", reflect.TypeOf((*MockJobHelper)(nil).GetModuleJobByKernel), ctx, modName, namespace, targetKernel, jobType, owner)
 }
 
 // GetModuleJobs mocks base method.
-func (m *MockJobHelper) GetModuleJobs(ctx context.Context, modName, namespace, jobType string) ([]v1.Job, error) {
+func (m *MockJobHelper) GetModuleJobs(ctx context.Context, modName, namespace, jobType string, owner v10.Object) ([]v1.Job, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetModuleJobs", ctx, modName, namespace, jobType)
+	ret := m.ctrl.Call(m, "GetModuleJobs", ctx, modName, namespace, jobType, owner)
 	ret0, _ := ret[0].([]v1.Job)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetModuleJobs indicates an expected call of GetModuleJobs.
-func (mr *MockJobHelperMockRecorder) GetModuleJobs(ctx, modName, namespace, jobType interface{}) *gomock.Call {
+func (mr *MockJobHelperMockRecorder) GetModuleJobs(ctx, modName, namespace, jobType, owner interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleJobs", reflect.TypeOf((*MockJobHelper)(nil).GetModuleJobs), ctx, modName, namespace, jobType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleJobs", reflect.TypeOf((*MockJobHelper)(nil).GetModuleJobs), ctx, modName, namespace, jobType, owner)
 }
 
 // IsJobChanged mocks base method.


### PR DESCRIPTION
Currently, our code queries for jobs in 2 scenarious: 1) check if there is a running kaniko build/sign job for specific module/kernel 2) get all the job of the module during garbage collection scenario

With introduction of preflight flow we need to deferentiate the jobs also by owner, since preflight flow also uses and garbage collects build/sign jobs

Upstream-Commit: 688015c3d5e6f42c535801a9b613fa33be7bf1f4

Fixes #277 