### PR TITLE
Fixing sign job hash annotation.

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -10,4 +10,6 @@ const (
 
 	ManagedClusterModuleNameLabel = "kmm.node.kubernetes.io/managedclustermodule.name"
 	DockerfileCMKey               = "dockerfile"
+	PublicSignDataKey             = "cert"
+	PrivateSignDataKey            = "key"
 )

--- a/internal/sign/job/manager.go
+++ b/internal/sign/job/manager.go
@@ -68,7 +68,7 @@ func (jbm *signJobManager) Sync(
 
 	labels := jbm.jobHelper.JobLabels(mod.Name, targetKernel, "sign")
 
-	jobTemplate, err := jbm.signer.MakeJobTemplate(mod, m, targetKernel, labels, imageToSign, pushImage, owner)
+	jobTemplate, err := jbm.signer.MakeJobTemplate(ctx, mod, m, targetKernel, labels, imageToSign, pushImage, owner)
 	if err != nil {
 		return utils.Result{}, fmt.Errorf("could not make Job template: %v", err)
 	}

--- a/internal/sign/job/manager_test.go
+++ b/internal/sign/job/manager_test.go
@@ -218,7 +218,7 @@ var _ = Describe("JobManager", func() {
 
 				gomock.InOrder(
 					jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
-					maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
+					maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
 					jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(&newJob, nil),
 					jobhelper.EXPECT().IsJobChanged(&j, &newJob).Return(false, nil),
 					jobhelper.EXPECT().GetJobStatus(&newJob).Return(r.Status, r.Requeue, joberr),
@@ -246,7 +246,7 @@ var _ = Describe("JobManager", func() {
 
 			gomock.InOrder(
 				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
-				maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).
+				maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).
 					Return(nil, errors.New("random error")),
 			)
 
@@ -274,7 +274,7 @@ var _ = Describe("JobManager", func() {
 
 			gomock.InOrder(
 				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
-				maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
+				maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
 				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(nil, errors.New("random error")),
 			)
 
@@ -302,7 +302,7 @@ var _ = Describe("JobManager", func() {
 
 			gomock.InOrder(
 				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
-				maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
+				maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
 				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(nil, utils.ErrNoMatchingJob),
 				jobhelper.EXPECT().CreateJob(ctx, &j).Return(errors.New("unable to create job")),
 			)
@@ -332,7 +332,7 @@ var _ = Describe("JobManager", func() {
 
 			gomock.InOrder(
 				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
-				maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
+				maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
 				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(nil, utils.ErrNoMatchingJob),
 				jobhelper.EXPECT().CreateJob(ctx, &j).Return(nil),
 			)
@@ -363,7 +363,7 @@ var _ = Describe("JobManager", func() {
 
 			gomock.InOrder(
 				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
-				maker.EXPECT().MakeJobTemplate(mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&newJob, nil),
+				maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&newJob, nil),
 				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(&newJob, nil),
 				jobhelper.EXPECT().IsJobChanged(&newJob, &newJob).Return(true, nil),
 				jobhelper.EXPECT().DeleteJob(ctx, &newJob).Return(nil),

--- a/internal/sign/job/mock_signer.go
+++ b/internal/sign/job/mock_signer.go
@@ -5,6 +5,7 @@
 package signjob
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -37,16 +38,16 @@ func (m *MockSigner) EXPECT() *MockSignerMockRecorder {
 }
 
 // MakeJobTemplate mocks base method.
-func (m *MockSigner) MakeJobTemplate(mod v1beta1.Module, km v1beta1.KernelMapping, targetKernel string, labels map[string]string, imageToSign string, pushImage bool, owner v10.Object) (*v1.Job, error) {
+func (m *MockSigner) MakeJobTemplate(ctx context.Context, mod v1beta1.Module, km v1beta1.KernelMapping, targetKernel string, labels map[string]string, imageToSign string, pushImage bool, owner v10.Object) (*v1.Job, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MakeJobTemplate", mod, km, targetKernel, labels, imageToSign, pushImage, owner)
+	ret := m.ctrl.Call(m, "MakeJobTemplate", ctx, mod, km, targetKernel, labels, imageToSign, pushImage, owner)
 	ret0, _ := ret[0].(*v1.Job)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MakeJobTemplate indicates an expected call of MakeJobTemplate.
-func (mr *MockSignerMockRecorder) MakeJobTemplate(mod, km, targetKernel, labels, imageToSign, pushImage, owner interface{}) *gomock.Call {
+func (mr *MockSignerMockRecorder) MakeJobTemplate(ctx, mod, km, targetKernel, labels, imageToSign, pushImage, owner interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeJobTemplate", reflect.TypeOf((*MockSigner)(nil).MakeJobTemplate), mod, km, targetKernel, labels, imageToSign, pushImage, owner)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeJobTemplate", reflect.TypeOf((*MockSigner)(nil).MakeJobTemplate), ctx, mod, km, targetKernel, labels, imageToSign, pushImage, owner)
 }

--- a/internal/sign/job/signer.go
+++ b/internal/sign/job/signer.go
@@ -1,17 +1,22 @@
 package signjob
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
+	"github.com/mitchellh/hashstructure"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/module"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/sign"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
@@ -21,6 +26,7 @@ import (
 
 type Signer interface {
 	MakeJobTemplate(
+		ctx context.Context,
 		mod kmmv1beta1.Module,
 		km kmmv1beta1.KernelMapping,
 		targetKernel string,
@@ -31,17 +37,26 @@ type Signer interface {
 	) (*batchv1.Job, error)
 }
 
+type hashData struct {
+	PrivateKeyData []byte
+	PublicKeyData  []byte
+	PodTemplate    *v1.PodTemplateSpec
+}
+
 type signer struct {
+	client    client.Client
 	scheme    *runtime.Scheme
 	helper    sign.Helper
 	jobHelper utils.JobHelper
 }
 
 func NewSigner(
+	client client.Client,
 	scheme *runtime.Scheme,
 	helper sign.Helper,
 	jobHelper utils.JobHelper) Signer {
 	return &signer{
+		client:    client,
 		scheme:    scheme,
 		helper:    helper,
 		jobHelper: jobHelper,
@@ -49,6 +64,7 @@ func NewSigner(
 }
 
 func (m *signer) MakeJobTemplate(
+	ctx context.Context,
 	mod kmmv1beta1.Module,
 	km kmmv1beta1.KernelMapping,
 	targetKernel string,
@@ -112,29 +128,37 @@ func (m *signer) MakeJobTemplate(
 		volumeMounts = append(volumeMounts, utils.MakeSecretVolumeMount(mod.Spec.ImageRepoSecret, "/docker_config"))
 	}
 
+	specTemplate := v1.PodTemplateSpec{
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:         "signimage",
+					Image:        "quay.io/chrisp262/kmod-signer:latest",
+					Args:         args,
+					VolumeMounts: volumeMounts,
+				},
+			},
+			RestartPolicy: v1.RestartPolicyOnFailure,
+			Volumes:       volumes,
+			NodeSelector:  mod.Spec.Selector,
+		},
+	}
+
+	specTemplateHash, err := m.getHashAnnotationValue(ctx, signConfig.KeySecret.Name, signConfig.CertSecret.Name, mod.Namespace, &specTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("could not hash job's definitions: %v", err)
+	}
+
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: mod.Name + "-sign-",
 			Namespace:    mod.Namespace,
 			Labels:       labels,
+			Annotations:  map[string]string{constants.JobHashAnnotation: fmt.Sprintf("%d", specTemplateHash)},
 		},
 		Spec: batchv1.JobSpec{
 			Completions: pointer.Int32(1),
-			Template: v1.PodTemplateSpec{
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
-						{
-							Name:         "signimage",
-							Image:        "quay.io/chrisp262/kmod-signer:latest",
-							Args:         args,
-							VolumeMounts: volumeMounts,
-						},
-					},
-					RestartPolicy: v1.RestartPolicyOnFailure,
-					Volumes:       volumes,
-					NodeSelector:  mod.Spec.Selector,
-				},
-			},
+			Template:    specTemplate,
 		},
 	}
 
@@ -143,4 +167,44 @@ func (m *signer) MakeJobTemplate(
 	}
 
 	return job, nil
+}
+
+func (s *signer) getHashAnnotationValue(ctx context.Context, privateSecret, publicSecret, namespace string, podTemplate *v1.PodTemplateSpec) (uint64, error) {
+	privateKeyData, err := s.getSecretData(ctx, privateSecret, constants.PrivateSignDataKey, namespace)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get private secret %s for signing: %v", privateSecret, err)
+	}
+	publicKeyData, err := s.getSecretData(ctx, publicSecret, constants.PublicSignDataKey, namespace)
+	if err != nil {
+		return 0, fmt.Errorf("failed to get public secret %s for signing: %v", publicSecret, err)
+	}
+
+	return getHashValue(podTemplate, publicKeyData, privateKeyData)
+}
+
+func (s *signer) getSecretData(ctx context.Context, secretName, secretDataKey, namespace string) ([]byte, error) {
+	secret := v1.Secret{}
+	namespacedName := types.NamespacedName{Name: secretName, Namespace: namespace}
+	err := s.client.Get(ctx, namespacedName, &secret)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Secret %s: %v", namespacedName, err)
+	}
+	data, ok := secret.Data[secretDataKey]
+	if !ok {
+		return nil, fmt.Errorf("invalid Secret %s format, %s key is missing", namespacedName, secretDataKey)
+	}
+	return data, nil
+}
+
+func getHashValue(podTemplate *v1.PodTemplateSpec, publicKeyData, privateKeyData []byte) (uint64, error) {
+	dataToHash := hashData{
+		PrivateKeyData: privateKeyData,
+		PublicKeyData:  publicKeyData,
+		PodTemplate:    podTemplate,
+	}
+	hashValue, err := hashstructure.Hash(dataToHash, nil)
+	if err != nil {
+		return 0, fmt.Errorf("could not hash job's spec template and dockefile: %v", err)
+	}
+	return hashValue, nil
 }

--- a/main.go
+++ b/main.go
@@ -192,7 +192,7 @@ func main() {
 	signHelperAPI := sign.NewSignerHelper()
 	jobHelperAPI := utils.NewJobHelper(client)
 	signAPI := signjob.NewSignJobManager(
-		signjob.NewSigner(scheme, signHelperAPI, jobHelperAPI),
+		signjob.NewSigner(client, scheme, signHelperAPI, jobHelperAPI),
 		jobHelperAPI,
 		authFactory,
 		registryAPI,


### PR DESCRIPTION
Sign job annotation is used for deciding whether update flow should
be executed on the job ( deletion and creation anew with new parameters).
Currently the code includes verification of currently running job hash
versus the new parameters hash, but the actual code that sets
the hash annotation during job template is missing.

This PR does the following:
1) add hash annotation calculation during job template creation
2) unit test

Upstream-Commit: 1c6cdf380b22c6bd4be0c2667860b42a51b6fb8c

Fixes #279 