### PR TITLE
Adding sign verification to the preflight flow

### DIFF
--- a/api/v1beta1/preflightvalidation_types.go
+++ b/api/v1beta1/preflightvalidation_types.go
@@ -25,6 +25,7 @@ const (
 	VerificationFalse         string = "False"
 	VerificationStageImage    string = "Image"
 	VerificationStageBuild    string = "Build"
+	VerificationStageSign     string = "Sign"
 	VerificationStageRequeued string = "Requeued"
 	VerificationStageDone     string = "Done"
 )
@@ -60,7 +61,7 @@ type CRStatus struct {
 	// image (image existence verification), build(build process verification)
 	// +required
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:Enum=Image;Build;Requeued;Done
+	// +kubebuilder:validation:Enum=Image;Build;Sign;Requeued;Done
 	VerificationStage string `json:"verificationStage"`
 
 	// LastTransitionTime is the last time the CR status transitioned from one status to another.

--- a/config/crd/bases/kmm.sigs.k8s.io_preflightvalidations.yaml
+++ b/config/crd/bases/kmm.sigs.k8s.io_preflightvalidations.yaml
@@ -76,6 +76,7 @@ spec:
                       enum:
                       - Image
                       - Build
+                      - Sign
                       - Requeued
                       - Done
                       type: string

--- a/internal/module/helper.go
+++ b/internal/module/helper.go
@@ -38,7 +38,7 @@ func ShouldBeBuilt(modSpec kmmv1beta1.ModuleSpec, km kmmv1beta1.KernelMapping) b
 	return modSpec.ModuleLoader.Container.Build != nil || km.Build != nil
 }
 
-// ShouldBeBuilt indicates whether the specified KernelMapping of the
+// ShouldBeSigned indicates whether the specified KernelMapping of the
 // Module should be signed or not.
 func ShouldBeSigned(modSpec kmmv1beta1.ModuleSpec, km kmmv1beta1.KernelMapping) bool {
 	return modSpec.ModuleLoader.Container.Sign != nil || km.Sign != nil

--- a/internal/preflight/mock_preflight_api.go
+++ b/internal/preflight/mock_preflight_api.go
@@ -102,3 +102,18 @@ func (mr *MockpreflightHelperAPIMockRecorder) verifyImage(ctx, mapping, mod, ker
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "verifyImage", reflect.TypeOf((*MockpreflightHelperAPI)(nil).verifyImage), ctx, mapping, mod, kernelVersion)
 }
+
+// verifySign mocks base method.
+func (m *MockpreflightHelperAPI) verifySign(ctx context.Context, pv *v1beta1.PreflightValidation, mapping *v1beta1.KernelMapping, mod *v1beta1.Module) (bool, string) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "verifySign", ctx, pv, mapping, mod)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(string)
+	return ret0, ret1
+}
+
+// verifySign indicates an expected call of verifySign.
+func (mr *MockpreflightHelperAPIMockRecorder) verifySign(ctx, pv, mapping, mod interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "verifySign", reflect.TypeOf((*MockpreflightHelperAPI)(nil).verifySign), ctx, pv, mapping, mod)
+}

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/build"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/module"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/registry"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/sign"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/statusupdater"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 
@@ -32,12 +33,12 @@ type PreflightAPI interface {
 func NewPreflightAPI(
 	client client.Client,
 	buildAPI build.Manager,
+	signAPI sign.SignManager,
 	registryAPI registry.Registry,
 	kernelAPI module.KernelMapper,
 	statusUpdater statusupdater.PreflightStatusUpdater,
-	authFactory auth.RegistryAuthGetterFactory,
-) PreflightAPI {
-	helper := newPreflightHelper(client, buildAPI, registryAPI, authFactory)
+	authFactory auth.RegistryAuthGetterFactory) PreflightAPI {
+	helper := newPreflightHelper(client, buildAPI, signAPI, registryAPI, authFactory)
 	return &preflight{
 		kernelAPI:     kernelAPI,
 		statusUpdater: statusUpdater,
@@ -70,35 +71,58 @@ func (p *preflight) PreflightUpgradeCheck(ctx context.Context, pv *kmmv1beta1.Pr
 		log.Info(utils.WarnString("failed to update the stage of Module CR in preflight to image stage"), "module", mod.Name, "error", err)
 	}
 
-	imageVerified, msg := p.helper.verifyImage(ctx, mapping, mod, kernelVersion)
-	if imageVerified || (mapping.Build == nil && mod.Spec.ModuleLoader.Container.Build == nil) {
-		return imageVerified, msg
+	verified, msg := p.helper.verifyImage(ctx, mapping, mod, kernelVersion)
+	if verified {
+		return true, msg
 	}
 
-	err = p.statusUpdater.PreflightSetVerificationStage(ctx, pv, mod.Name, kmmv1beta1.VerificationStageBuild)
-	if err != nil {
-		log.Info(utils.WarnString("failed to update the stage of Module CR in preflight to build stage"), "module", mod.Name, "error", err)
+	shouldBuild := module.ShouldBeBuilt(mod.Spec, *mapping)
+	shouldSign := module.ShouldBeSigned(mod.Spec, *mapping)
+
+	if shouldBuild {
+		err = p.statusUpdater.PreflightSetVerificationStage(ctx, pv, mod.Name, kmmv1beta1.VerificationStageBuild)
+		if err != nil {
+			log.Info(utils.WarnString("failed to update the stage of Module CR in preflight to build stage"), "module", mod.Name, "error", err)
+		}
+
+		verified, msg = p.helper.verifyBuild(ctx, pv, mapping, mod)
+		if !verified {
+			return false, msg
+		}
 	}
 
-	return p.helper.verifyBuild(ctx, pv, mapping, mod)
+	if shouldSign {
+		err = p.statusUpdater.PreflightSetVerificationStage(ctx, pv, mod.Name, kmmv1beta1.VerificationStageSign)
+		if err != nil {
+			log.Info(utils.WarnString("failed to update the stage of Module CR in preflight to sign stage"), "module", mod.Name, "error", err)
+		}
+		verified, msg = p.helper.verifySign(ctx, pv, mapping, mod)
+		if !verified {
+			return false, msg
+		}
+	}
+	return verified, msg
 }
 
 type preflightHelperAPI interface {
 	verifyImage(ctx context.Context, mapping *kmmv1beta1.KernelMapping, mod *kmmv1beta1.Module, kernelVersion string) (bool, string)
 	verifyBuild(ctx context.Context, pv *kmmv1beta1.PreflightValidation, mapping *kmmv1beta1.KernelMapping, mod *kmmv1beta1.Module) (bool, string)
+	verifySign(ctx context.Context, pv *kmmv1beta1.PreflightValidation, mapping *kmmv1beta1.KernelMapping, mod *kmmv1beta1.Module) (bool, string)
 }
 
 type preflightHelper struct {
 	client      client.Client
 	registryAPI registry.Registry
 	buildAPI    build.Manager
+	signAPI     sign.SignManager
 	authFactory auth.RegistryAuthGetterFactory
 }
 
-func newPreflightHelper(client client.Client, buildAPI build.Manager, registryAPI registry.Registry, authFactory auth.RegistryAuthGetterFactory) preflightHelperAPI {
+func newPreflightHelper(client client.Client, buildAPI build.Manager, signAPI sign.SignManager, registryAPI registry.Registry, authFactory auth.RegistryAuthGetterFactory) preflightHelperAPI {
 	return &preflightHelper{
 		client:      client,
 		buildAPI:    buildAPI,
+		signAPI:     signAPI,
 		registryAPI: registryAPI,
 		authFactory: authFactory,
 	}
@@ -156,4 +180,32 @@ func (p *preflightHelper) verifyBuild(ctx context.Context,
 		return true, fmt.Sprintf(VerificationStatusReasonVerified, msg)
 	}
 	return false, "Waiting for build verification"
+}
+
+func (p *preflightHelper) verifySign(ctx context.Context,
+	pv *kmmv1beta1.PreflightValidation,
+	mapping *kmmv1beta1.KernelMapping,
+	mod *kmmv1beta1.Module) (bool, string) {
+	log := ctrlruntime.LoggerFrom(ctx)
+
+	previousImage := ""
+	if module.ShouldBeBuilt(mod.Spec, *mapping) {
+		previousImage = module.IntermediateImageName(mod.Name, mod.Namespace, mapping.ContainerImage)
+	}
+
+	// at this stage we know that eiher mapping Sign or Container sign are defined
+	signRes, err := p.signAPI.Sync(ctx, *mod, *mapping, pv.Spec.KernelVersion, previousImage, pv.Spec.PushBuiltImage, pv)
+	if err != nil {
+		return false, fmt.Sprintf("Failed to verify signing for module %s, kernel version %s, error %s", mod.Name, pv.Spec.KernelVersion, err)
+	}
+
+	if signRes.Status == utils.StatusCompleted {
+		msg := "sign completes"
+		if pv.Spec.PushBuiltImage {
+			msg += " and image pushed"
+		}
+		log.Info("build for module during preflight has been build successfully", "module", mod.Name)
+		return true, fmt.Sprintf(VerificationStatusReasonVerified, msg)
+	}
+	return false, "Waiting for sign verification"
 }

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -15,7 +15,9 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/module"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/registry"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/sign"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/statusupdater"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -64,6 +66,13 @@ func TestPreflight(t *testing.T) {
 }
 
 var _ = Describe("preflight_PreflightUpgradeCheck", func() {
+	const (
+		buildExistsFlag   = true
+		signExistsFlag    = true
+		imageVerifiedFlag = true
+		buildVerifiedFlag = true
+		signVerifiedFlag  = true
+	)
 	var (
 		ctrl              *gomock.Controller
 		mockKernelAPI     *module.MockKernelMapper
@@ -114,77 +123,88 @@ var _ = Describe("preflight_PreflightUpgradeCheck", func() {
 		Expect(message).To(Equal(fmt.Sprintf("Failed to substitute template in kernel mapping in the module %s for kernel version %s", mod.Name, kernelVersion)))
 	})
 
-	It("verify image success, no build", func() {
+	DescribeTable("correct flow of the image/build/sign verification", func(buildExists, signExists, imageVerified, buildVerified, signVerified,
+		returnedResult bool, returnedMessage string) {
+		ctx := context.Background()
 		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
 		mod.Spec.ModuleLoader.Container.KernelMappings = []kmmv1beta1.KernelMapping{mapping}
+		if buildExists {
+			mapping.Build = &kmmv1beta1.Build{}
+		}
+		if signExists {
+			mapping.Sign = &kmmv1beta1.Sign{}
+		}
 
-		gomock.InOrder(
-			mockKernelAPI.EXPECT().FindMappingForKernel(mod.Spec.ModuleLoader.Container.KernelMappings, kernelVersion).Return(&mapping, nil),
-			mockKernelAPI.EXPECT().PrepareKernelMapping(&mapping, gomock.Any()).Return(&mapping, nil),
-			mockStatusUpdater.EXPECT().PreflightSetVerificationStage(context.Background(), pv, mod.Name, kmmv1beta1.VerificationStageImage),
-			preflightHelper.EXPECT().verifyImage(context.Background(), &mapping, mod, kernelVersion).Return(true, "some message"),
-		)
+		mockKernelAPI.EXPECT().FindMappingForKernel(mod.Spec.ModuleLoader.Container.KernelMappings, kernelVersion).Return(&mapping, nil)
+		mockKernelAPI.EXPECT().PrepareKernelMapping(&mapping, gomock.Any()).Return(&mapping, nil)
+		mockStatusUpdater.EXPECT().PreflightSetVerificationStage(context.Background(), pv, mod.Name, kmmv1beta1.VerificationStageImage).Return(nil)
+		preflightHelper.EXPECT().verifyImage(ctx, &mapping, mod, kernelVersion).Return(imageVerified, "image message")
+		if !imageVerified {
+			if buildExists {
+				mockStatusUpdater.EXPECT().PreflightSetVerificationStage(context.Background(), pv, mod.Name, kmmv1beta1.VerificationStageBuild).Return(nil)
+				preflightHelper.EXPECT().verifyBuild(ctx, pv, &mapping, mod).Return(buildVerified, "build message")
+			}
+			if signExists {
+				if buildVerified || !buildExists {
+					mockStatusUpdater.EXPECT().PreflightSetVerificationStage(context.Background(), pv, mod.Name, kmmv1beta1.VerificationStageSign).Return(nil)
+					preflightHelper.EXPECT().verifySign(ctx, pv, &mapping, mod).Return(signVerified, "sign message")
+				}
+			}
+		}
 
-		res, message := p.PreflightUpgradeCheck(context.Background(), pv, mod)
-
-		Expect(res).To(BeTrue())
-		Expect(message).To(Equal("some message"))
-	})
-
-	It("verify image failed, no build", func() {
-		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
-		mod.Spec.ModuleLoader.Container.KernelMappings = []kmmv1beta1.KernelMapping{mapping}
-
-		gomock.InOrder(
-			mockKernelAPI.EXPECT().FindMappingForKernel(mod.Spec.ModuleLoader.Container.KernelMappings, kernelVersion).Return(&mapping, nil),
-			mockKernelAPI.EXPECT().PrepareKernelMapping(&mapping, gomock.Any()).Return(&mapping, nil),
-			mockStatusUpdater.EXPECT().PreflightSetVerificationStage(context.Background(), pv, mod.Name, kmmv1beta1.VerificationStageImage),
-			preflightHelper.EXPECT().verifyImage(context.Background(), &mapping, mod, kernelVersion).Return(false, "some error message"),
-		)
-
-		res, message := p.PreflightUpgradeCheck(context.Background(), pv, mod)
-
-		Expect(res).To(BeFalse())
-		Expect(message).To(Equal("some error message"))
-	})
-
-	It("verify image failed, build exists, successful", func() {
-		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage, Build: &kmmv1beta1.Build{}}
-		mod.Spec.ModuleLoader.Container.KernelMappings = []kmmv1beta1.KernelMapping{mapping}
-
-		gomock.InOrder(
-			mockKernelAPI.EXPECT().FindMappingForKernel(mod.Spec.ModuleLoader.Container.KernelMappings, kernelVersion).Return(&mapping, nil),
-			mockKernelAPI.EXPECT().PrepareKernelMapping(&mapping, gomock.Any()).Return(&mapping, nil),
-			mockStatusUpdater.EXPECT().PreflightSetVerificationStage(context.Background(), pv, mod.Name, kmmv1beta1.VerificationStageImage),
-			preflightHelper.EXPECT().verifyImage(context.Background(), &mapping, mod, kernelVersion).Return(false, "some error message"),
-			mockStatusUpdater.EXPECT().PreflightSetVerificationStage(context.Background(), pv, mod.Name, kmmv1beta1.VerificationStageBuild),
-			preflightHelper.EXPECT().verifyBuild(context.Background(), pv, &mapping, mod).Return(true, "some message"),
-		)
-
-		res, message := p.PreflightUpgradeCheck(context.Background(), pv, mod)
-
-		Expect(res).To(BeTrue())
-		Expect(message).To(Equal("some message"))
-	})
-
-	It("verify image failed, build exists, failed", func() {
-		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage, Build: &kmmv1beta1.Build{}}
-		mod.Spec.ModuleLoader.Container.KernelMappings = []kmmv1beta1.KernelMapping{mapping}
-
-		gomock.InOrder(
-			mockKernelAPI.EXPECT().FindMappingForKernel(mod.Spec.ModuleLoader.Container.KernelMappings, kernelVersion).Return(&mapping, nil),
-			mockKernelAPI.EXPECT().PrepareKernelMapping(&mapping, gomock.Any()).Return(&mapping, nil),
-			mockStatusUpdater.EXPECT().PreflightSetVerificationStage(context.Background(), pv, mod.Name, kmmv1beta1.VerificationStageImage),
-			preflightHelper.EXPECT().verifyImage(context.Background(), &mapping, mod, kernelVersion).Return(false, "some error message"),
-			mockStatusUpdater.EXPECT().PreflightSetVerificationStage(context.Background(), pv, mod.Name, kmmv1beta1.VerificationStageBuild),
-			preflightHelper.EXPECT().verifyBuild(context.Background(), pv, &mapping, mod).Return(false, "some error message"),
-		)
-
-		res, message := p.PreflightUpgradeCheck(context.Background(), pv, mod)
-
-		Expect(res).To(BeFalse())
-		Expect(message).To(Equal("some error message"))
-	})
+		res, msg := p.PreflightUpgradeCheck(context.Background(), pv, mod)
+		Expect(res).To(Equal(returnedResult))
+		Expect(msg).To(Equal(returnedMessage))
+	},
+		Entry(
+			"no build, no sign, image verified",
+			!buildExistsFlag, signExistsFlag, imageVerifiedFlag, !buildVerifiedFlag, !signVerifiedFlag, true, "image message",
+		),
+		Entry(
+			"no build, no sign, image not verified",
+			!buildExistsFlag, !signExistsFlag, !imageVerifiedFlag, !buildVerifiedFlag, !signVerifiedFlag, false, "image message",
+		),
+		Entry(
+			"build exists, no sign, image verified",
+			buildExistsFlag, !signExistsFlag, imageVerifiedFlag, !buildVerifiedFlag, !signVerifiedFlag, true, "image message",
+		),
+		Entry(
+			"build exists, no sign, image not verified, build verified",
+			buildExistsFlag, !signExistsFlag, !imageVerifiedFlag, buildVerifiedFlag, !signVerifiedFlag, true, "build message",
+		),
+		Entry(
+			"build exists, no sign, image not verified, build not verified",
+			buildExistsFlag, !signExistsFlag, !imageVerifiedFlag, !buildVerifiedFlag, !signVerifiedFlag, false, "build message",
+		),
+		Entry(
+			"build exists, sign exists , image verified",
+			buildExistsFlag, signExistsFlag, imageVerifiedFlag, !buildVerifiedFlag, !signVerifiedFlag, true, "image message",
+		),
+		Entry(
+			"build exists, sign exists , image not verified, build verified, sign not verified",
+			buildExistsFlag, signExistsFlag, !imageVerifiedFlag, buildVerifiedFlag, !signVerifiedFlag, false, "sign message",
+		),
+		Entry(
+			"build exists, sign exists , image not verified, build verified, sign verified",
+			buildExistsFlag, signExistsFlag, !imageVerifiedFlag, buildVerifiedFlag, signVerifiedFlag, true, "sign message",
+		),
+		Entry(
+			"build exists, sign exists , image not verified, build not verified",
+			buildExistsFlag, signExistsFlag, !imageVerifiedFlag, !buildVerifiedFlag, signVerifiedFlag, false, "build message",
+		),
+		Entry(
+			"build not exists, sign exists , image verified",
+			!buildExistsFlag, signExistsFlag, imageVerifiedFlag, !buildVerifiedFlag, signVerifiedFlag, true, "image message",
+		),
+		Entry(
+			"build not exists, sign exists , image not verified, sign not verified",
+			!buildExistsFlag, signExistsFlag, !imageVerifiedFlag, !buildVerifiedFlag, !signVerifiedFlag, false, "sign message",
+		),
+		Entry(
+			"build not exists, sign exists , image not verified, sign verified",
+			!buildExistsFlag, signExistsFlag, !imageVerifiedFlag, !buildVerifiedFlag, signVerifiedFlag, true, "sign message",
+		),
+	)
 })
 
 var _ = Describe("preflightHelper_verifyImage", func() {
@@ -340,5 +360,71 @@ var _ = Describe("preflightHelper_verifyBuild", func() {
 		res, msg := ph.verifyBuild(context.Background(), pv, &mapping, mod)
 		Expect(res).To(BeFalse())
 		Expect(msg).To(Equal("Waiting for build verification"))
+	})
+})
+
+var _ = Describe("preflightHelper_verifySign", func() {
+	var (
+		ctrl        *gomock.Controller
+		mockSignAPI *sign.MockSignManager
+		clnt        *client.MockClient
+		ph          *preflightHelper
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		mockSignAPI = sign.NewMockSignManager(ctrl)
+		ph = &preflightHelper{
+			client:  clnt,
+			signAPI: mockSignAPI,
+		}
+
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	It("sync failed", func() {
+		mod.Spec.ModuleLoader.Container.Sign = &kmmv1beta1.Sign{}
+		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
+
+		previousImage := ""
+
+		mockSignAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, previousImage, pv.Spec.PushBuiltImage, pv).
+			Return(utils.Result{}, fmt.Errorf("some error"))
+
+		res, msg := ph.verifySign(context.Background(), pv, &mapping, mod)
+		Expect(res).To(BeFalse())
+		Expect(msg).To(Equal(fmt.Sprintf("Failed to verify signing for module %s, kernel version %s, error %s", mod.Name, kernelVersion, fmt.Errorf("some error"))))
+	})
+
+	It("sync completed", func() {
+		mod.Spec.ModuleLoader.Container.Sign = &kmmv1beta1.Sign{}
+		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
+
+		previousImage := ""
+
+		mockSignAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, previousImage, pv.Spec.PushBuiltImage, pv).
+			Return(utils.Result{Status: utils.StatusCompleted}, nil)
+
+		res, msg := ph.verifySign(context.Background(), pv, &mapping, mod)
+		Expect(res).To(BeTrue())
+		Expect(msg).To(Equal(fmt.Sprintf(VerificationStatusReasonVerified, "sign completes")))
+	})
+
+	It("sync not completed yet", func() {
+		mod.Spec.ModuleLoader.Container.Sign = &kmmv1beta1.Sign{}
+		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
+
+		previousImage := ""
+
+		mockSignAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, previousImage, pv.Spec.PushBuiltImage, pv).
+			Return(utils.Result{Status: utils.StatusInProgress}, nil)
+
+		res, msg := ph.verifySign(context.Background(), pv, &mapping, mod)
+		Expect(res).To(BeFalse())
+		Expect(msg).To(Equal("Waiting for sign verification"))
 	})
 })

--- a/main.go
+++ b/main.go
@@ -204,7 +204,7 @@ func main() {
 	moduleStatusUpdaterAPI := statusupdater.NewModuleStatusUpdater(client, daemonAPI, metricsAPI)
 	preflightStatusUpdaterAPI := statusupdater.NewPreflightStatusUpdater(client)
 	preflightOCPStatusUpdaterAPI := statusupdater.NewPreflightOCPStatusUpdater(client)
-	preflightAPI := preflight.NewPreflightAPI(client, buildAPI, registryAPI, kernelAPI, preflightStatusUpdaterAPI, authFactory)
+	preflightAPI := preflight.NewPreflightAPI(client, buildAPI, signAPI, registryAPI, kernelAPI, preflightStatusUpdaterAPI, authFactory)
 
 	mc := controllers.NewModuleReconciler(
 		client,


### PR DESCRIPTION
This PR add the sign verification stage to the preflight: in case image verification has failed and either build section is not defined or build verification was successful, preflight will now verify sign , if it was defined in the Module

Upstream-Commit: f37a1c03e1becf47fc99a810dfe1fb43665405f7

Fixes #283 