### PR TITLE
Fixes call to check_kmm_mod function

### DIFF
--- a/ci/prow/e2e-crd-variable
+++ b/ci/prow/e2e-crd-variable
@@ -2,10 +2,11 @@
 
 set -euxo pipefail
 
-echo "Get first node..."
-NODE=$(oc get nodes -o jsonpath='{.items..metadata.name}' | awk {'print $1'})
-
 source ci/prow/check-kmm-kmod
+export -f check_kmm_kmod
+
+echo "Get first node..."
+export NODE=$(oc get nodes -o jsonpath='{.items..metadata.name}' | awk {'print $1'})
 
 echo "Label a node to match selector in Module afterwards..."
 oc label node $NODE task=kmm-ci

--- a/ci/prow/e2e-incluster-build
+++ b/ci/prow/e2e-incluster-build
@@ -2,16 +2,17 @@
 
 set -euxo pipefail
 
-echo "Deploy KMMO..."
-make deploy
+source ci/prow/check-kmm-kmod
+export -f check_kmm_kmod
 
 echo "Get first node..."
-NODE=$(oc get nodes -o jsonpath='{.items..metadata.name}' | awk {'print $1'})
-
-source ci/prow/check-kmm-kmod
+export NODE=$(oc get nodes -o jsonpath='{.items..metadata.name}' | awk {'print $1'})
 
 echo "Label a node to match selector in Module afterwards..."
 oc label node $NODE task=kmm-ci
+
+echo "Deploy KMMO..."
+make deploy
 
 echo "Wait until the KMMO Deployment is Available"
 oc wait --for condition=Available --timeout 1m deployments.apps -n kmm-operator-system kmm-operator-controller-manager

--- a/ci/prow/e2e-prebuilt-kernel-module
+++ b/ci/prow/e2e-prebuilt-kernel-module
@@ -2,10 +2,11 @@
 
 set -euxo pipefail
 
-echo "Get first node..."
-NODE=$(oc get nodes -o jsonpath='{.items..metadata.name}' | awk {'print $1'})
-
 source ci/prow/check-kmm-kmod
+export -f check_kmm_kmod
+
+echo "Get first node..."
+export NODE=$(oc get nodes -o jsonpath='{.items..metadata.name}' | awk {'print $1'})
 
 echo "Label a node to match selector in Module afterwards..."
 oc label node $NODE task=kmm-ci


### PR DESCRIPTION
Function check\_kmm\_kmod is exported in order to be used by e2e test scripts. This function checks in cluster nodes if kmm-kmod module is loaded or not.