### PR TITLE
Committing update to the PreflightOCP

### DIFF
--- a/config/crd/bases/kmm.sigs.k8s.io_preflightvalidationsocp.yaml
+++ b/config/crd/bases/kmm.sigs.k8s.io_preflightvalidationsocp.yaml
@@ -76,6 +76,7 @@ spec:
                       enum:
                       - Image
                       - Build
+                      - Sign
                       - Requeued
                       - Done
                       type: string


### PR DESCRIPTION
PreflightOCP status is actually a status of Preflight. In case Preflight status is updated, the PrelfightOCP is also updated and needs to be pushed