### PR TITLE
Build signer images in CI (#165)

### DIFF
--- a/Dockerfile.signimage
+++ b/Dockerfile.signimage
@@ -1,24 +1,25 @@
-FROM registry.fedoraproject.org/fedora as ksource
-RUN yum install -y kernel-devel
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11 as ksource
 
-FROM golang:1.19 as builder
+RUN dnf install -y kernel-devel
+
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11 as builder
 
 WORKDIR /workspace
 
+COPY go.mod go.mod
+COPY go.sum go.sum
 COPY cmd cmd
 COPY api api
 COPY internal internal
 COPY Makefile Makefile
-COPY docs.mk docs.mk
-COPY go.mod go.mod
-COPY go.sum go.sum
-RUN go mod download
+COPY vendor vendor
+
 # Build
 RUN make signimage
 
-FROM registry.fedoraproject.org/fedora
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11
 
-COPY --from=builder /workspace/cmd/signimage/signimage /
+COPY --from=builder /workspace/signimage /
 COPY --from=ksource /usr/src/kernels/*/scripts/sign-file /sign-file
 
 ENTRYPOINT ["/signimage"]

--- a/Makefile
+++ b/Makefile
@@ -267,9 +267,9 @@ catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
 
 .PHONY: signimage
-signimage: ## Build manager binary.
-	go build -o cmd/signimage/signimage cmd/signimage/signimage.go
+signimage: ## Build signer binary.
+	go build -o $@ cmd/signimage/signimage.go
 
 .PHONY: signimage-build
-signimage-build: ## Build docker image with the manager.
+signimage-build: ## Build docker image with the signer.
 	$(PODMAN) build -f Dockerfile.signimage -t $(SIGNER_IMG)


### PR DESCRIPTION
Use UBI base images for a smaller footprint.
Rework the Dockerfile for better caching.

Co-authored-by: Yoni Bettan <yonibettan@gmail.com>

---

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/257