### PR TITLE
Produce a slimmer sign image

### DIFF
--- a/Dockerfile.signimage
+++ b/Dockerfile.signimage
@@ -1,7 +1,3 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11 as ksource
-
-RUN dnf install -y kernel-devel
-
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11 as builder
 
 WORKDIR /workspace
@@ -17,9 +13,11 @@ COPY vendor vendor
 # Build
 RUN make signimage
 
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11
+RUN dnf install -y kernel-devel
 
-COPY --from=builder /workspace/signimage /
-COPY --from=ksource /usr/src/kernels/*/scripts/sign-file /sign-file
+FROM registry.redhat.io/ubi8/ubi-micro:8.7
 
-ENTRYPOINT ["/signimage"]
+COPY --from=builder /workspace/signimage /usr/src/kernels/*/scripts/sign-file /usr/local/bin
+USER 65534:65534
+
+ENTRYPOINT ["/usr/local/bin/signimage"]

--- a/cmd/signimage/signimage.go
+++ b/cmd/signimage/signimage.go
@@ -5,17 +5,19 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"github.com/docker/cli/cli/config"
-	dockertypes "github.com/docker/cli/cli/config/types"
-	"github.com/go-logr/logr"
-	"github.com/google/go-containerregistry/pkg/authn"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/registry"
 	"io"
-	"k8s.io/klog/v2/klogr"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/docker/cli/cli/config"
+	dockertypes "github.com/docker/cli/cli/config/types"
+	"github.com/go-logr/logr"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"k8s.io/klog/v2/klogr"
+
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/registry"
 )
 
 func checkArg(arg *string, varname string, fallback string) {
@@ -43,8 +45,10 @@ func canonicalisePath(path string) string {
 }
 
 func signFile(filename string, publickey string, privatekey string) error {
-	logger.Info("running /sign-file", "algo", "sha256", "privatekey", privatekey, "publickey", publickey, "filename", filepath.Base(filename))
-	out, err := exec.Command("/sign-file", "sha256", privatekey, publickey, filename).Output()
+	cmd := exec.Command("/usr/local/bin/sign-file", "sha256", privatekey, publickey, filename)
+
+	logger.Info("running sign-file", "cmd", cmd.String())
+	out, err := cmd.Output()
 	if err != nil {
 		return fmt.Errorf("signing %s returned: %s\n error: %v\n", filename, out, err)
 	}


### PR DESCRIPTION
Get the sign-fiel binary from the builder image.
Place binaries in a well-known location.

/cc @chr15p @ybettan