### PR TITLE
Preventing 'grep' to return an error in case there was no match.

### DIFF
--- a/ci/prow/check-kmm-kmod
+++ b/ci/prow/check-kmm-kmod
@@ -3,5 +3,7 @@
 set -euxo pipefail
 
 check_kmm_kmod () {
-  oc debug node/$NODE -T -- chroot /host sh -c "lsmod | grep kmm"
+  # `|| true` is required in order to prevent `grep` from returning an error
+  # code in case `kmm` wasn't found. Check `git blame` for additional info.
+  oc debug node/$NODE -T -- chroot /host sh -c "lsmod | { grep kmm || true; }"
 }


### PR DESCRIPTION
In older versions of `oc` (like 4.8), when running `oc debug node/$NODE -T -- chroot /host sh -c "<command>"`, the returned value of `oc debug node` was `0` even if the command failed.

For newer versions of `oc` (such as 4.11), which is used in CI, the returned value of `oc debug node` gets the value of the inner command, therefore, in case the module wasn't found, it will return an error code instead of just returning an empty string as expected by the e2e tests.

This commit is supposed to fix that issue.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>

---

This PR is currently blocking https://github.com/openshift/release/pull/34904