### PR TITLE
Revert "Preventing 'grep' to return an error in case there was no match."

### DIFF
--- a/ci/prow/check-kmm-kmod
+++ b/ci/prow/check-kmm-kmod
@@ -3,7 +3,5 @@
 set -euxo pipefail
 
 check_kmm_kmod () {
-  # `|| true` is required in order to prevent `grep` from returning an error
-  # code in case `kmm` wasn't found. Check `git blame` for additional info.
-  oc debug node/$NODE -T -- chroot /host sh -c "lsmod | { grep kmm || true; }"
+  oc debug node/$NODE -T -- chroot /host sh -c "lsmod | grep kmm"
 }


### PR DESCRIPTION
Reverts rh-ecosystem-edge/kernel-module-management#312