### PR TITLE
Installing `operator-skd` via Makefile. (#219)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,12 +210,21 @@ GOBIN=$(PROJECT_DIR)/bin go install $(2) ;\
 }
 endef
 
+OPERATOR_SDK = $(shell pwd)/bin/operator-sdk
+.PHONY: operator-sdk
+operator-sdk:
+	@if [ ! -f ${OPERATOR_SDK} ]; then \
+		echo "Downloading ${OPERATOR_SDK}"; \
+		curl -Lo ${OPERATOR_SDK} 'https://github.com/operator-framework/operator-sdk/releases/download/v1.25.2/operator-sdk_linux_amd64'; \
+		chmod +x ${OPERATOR_SDK}; \
+	fi
+
 .PHONY: bundle
-bundle: manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
-	operator-sdk generate kustomize manifests -q
+bundle: operator-sdk manifests kustomize ## Generate bundle manifests and metadata, then validate generated files.
+	${OPERATOR_SDK} generate kustomize manifests -q
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
-	oc kustomize config/manifests | operator-sdk generate bundle $(BUNDLE_GEN_FLAGS)
-	operator-sdk bundle validate ./bundle
+	oc kustomize config/manifests | ${OPERATOR_SDK} generate bundle $(BUNDLE_GEN_FLAGS)
+	${OPERATOR_SDK} bundle validate ./bundle
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -6,7 +6,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=kernel-module-management
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.26.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.25.2
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -14,8 +14,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2022-12-19T10:49:04Z"
-    operators.operatorframework.io/builder: operator-sdk-v1.26.0
+    operators.operatorframework.io/builder: operator-sdk-v1.25.2
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: kernel-module-management.v0.0.1
   namespace: placeholder

--- a/bundle/manifests/kmm.sigs.x-k8s.io_managedclustermodules.yaml
+++ b/bundle/manifests/kmm.sigs.x-k8s.io_managedclustermodules.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: managedclustermodules.kmm.sigs.x-k8s.io
 spec:

--- a/bundle/manifests/kmm.sigs.x-k8s.io_modules.yaml
+++ b/bundle/manifests/kmm.sigs.x-k8s.io_modules.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: modules.kmm.sigs.x-k8s.io
 spec:

--- a/bundle/manifests/kmm.sigs.x-k8s.io_preflightvalidations.yaml
+++ b/bundle/manifests/kmm.sigs.x-k8s.io_preflightvalidations.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: preflightvalidations.kmm.sigs.x-k8s.io
 spec:

--- a/bundle/manifests/kmm.sigs.x-k8s.io_preflightvalidationsocp.yaml
+++ b/bundle/manifests/kmm.sigs.x-k8s.io_preflightvalidationsocp.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: preflightvalidationsocp.kmm.sigs.x-k8s.io
 spec:

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: kernel-module-management
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.26.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.25.2
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/crd/bases/kmm.sigs.x-k8s.io_managedclustermodules.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_managedclustermodules.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: managedclustermodules.kmm.sigs.x-k8s.io
 spec:

--- a/config/crd/bases/kmm.sigs.x-k8s.io_modules.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_modules.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: modules.kmm.sigs.x-k8s.io
 spec:

--- a/config/crd/bases/kmm.sigs.x-k8s.io_preflightvalidations.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_preflightvalidations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: preflightvalidations.kmm.sigs.x-k8s.io
 spec:

--- a/config/crd/bases/kmm.sigs.x-k8s.io_preflightvalidationsocp.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_preflightvalidationsocp.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.10.0
+    controller-gen.kubebuilder.io/version: v0.9.2
   creationTimestamp: null
   name: preflightvalidationsocp.kmm.sigs.x-k8s.io
 spec:


### PR DESCRIPTION
To make sure u/s and m/s are always using the same version without the need of manually installing and maintaining `operator-sdk` with the same version on u/s infra and on m/s infra.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>

---

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/315