### PR TITLE
Remove insecure options from the labs

### DIFF
--- a/docs/labs/deviceplugin-kmm.yaml
+++ b/docs/labs/deviceplugin-kmm.yaml
@@ -12,10 +12,7 @@ spec:
       modprobe:
         moduleName: kmm-ci-a
       kernelMappings:
-        - literal: 4.18.0-372.19.1.el8_6.x86_64 
+        - literal: 4.18.0-372.19.1.el8_6.x86_64
           containerImage: image-registry.openshift-image-registry.svc:5000/default/kmm-kmod:4.18.0single
-          pull:
-            insecureSkipTLSVerify: true
-      
   selector:
     feature.kmm.lab: 'true'

--- a/docs/labs/multistepbuild-kmm.yaml
+++ b/docs/labs/multistepbuild-kmm.yaml
@@ -9,18 +9,12 @@ spec:
       modprobe:
         moduleName: kmm-ci-a
       kernelMappings:
-        - literal: 4.18.0-372.19.1.el8_6.x86_64 
+        - literal: 4.18.0-372.19.1.el8_6.x86_64
           containerImage: image-registry.openshift-image-registry.svc:5000/default/kmm-kmod:4.18.0f
-          pull:
-            insecureSkipTLSVerify: true
           build:
-            pull:
-              insecureSkipTLSVerify: true
-            push:
-              insecureSkipTLSVerify: true
             dockerfileConfigMap:
               name: build-module-multi
-      
+
   selector:
     feature.kmm.lab: 'true'
 

--- a/docs/labs/prebuilt-kmm.yaml
+++ b/docs/labs/prebuilt-kmm.yaml
@@ -9,12 +9,8 @@ spec:
       modprobe:
         moduleName: kmm-ci-a
       kernelMappings:
-        - literal: 4.18.0-372.19.1.el8_6.x86_64 
+        - literal: 4.18.0-372.19.1.el8_6.x86_64
           containerImage: image-registry.openshift-image-registry.svc:5000/default/kmm-kmod:4.18.1single
-          pull:
-            insecureSkipTLSVerify: true
-            insecure: true
-      
   selector:
     feature.kmm.lab: 'true'
 

--- a/docs/labs/singlebuild-kmm.yaml
+++ b/docs/labs/singlebuild-kmm.yaml
@@ -9,15 +9,9 @@ spec:
       modprobe:
         moduleName: kmm-ci-a
       kernelMappings:
-        - literal: 4.18.0-372.19.1.el8_6.x86_64 
+        - literal: 4.18.0-372.19.1.el8_6.x86_64
           containerImage: image-registry.openshift-image-registry.svc:5000/default/kmm-kmod:4.18.0single
-          pull:
-            insecureSkipTLSVerify: true
           build:
-            pull:
-              insecureSkipTLSVerify: true
-            push:
-              insecureSkipTLSVerify: true
             dockerfileConfigMap:
               name: build-module-single
   selector:


### PR DESCRIPTION
With [MGMT-12141](https://issues.redhat.com//browse/MGMT-12141) completed, these options are no longer required when working with the internal registry.

/cc @enriquebelarte