### PR TITLE
Add support for insecure pull/push of images to signing job (#330)

### DIFF
--- a/cmd/signimage/signimage.go
+++ b/cmd/signimage/signimage.go
@@ -57,8 +57,8 @@ func signFile(filename string, publickey string, privatekey string) error {
 
 func getAuthFromFile(configfile string, repo string) (authn.Authenticator, error) {
 
-	if configfile == "" {
-		logger.Info("no pull secret defined, default to Anonymous")
+	if configfile == "" || configfile == "anonymous" {
+		logger.Info("no secret given, default to Anonymous")
 		return authn.Anonymous, nil
 	}
 
@@ -182,6 +182,10 @@ func main() {
 	var privKeyFile string
 	var pubKeyFile string
 	var nopush bool
+	var insecurePull bool
+	var skipTlsVerifyPull bool
+	var insecurePush bool
+	var skipTlsVerifyPush bool
 
 	logger = klogr.New()
 
@@ -194,6 +198,11 @@ func main() {
 	flag.StringVar(&pullSecret, "pushsecret", "", "path to file containing credentials for pushing images")
 	flag.BoolVar(&nopush, "no-push", false, "do not push the resulting image")
 
+	flag.BoolVar(&insecurePull, "insecure-pull", false, "images can be pulled from an insecure (plain HTTP) registry")
+	flag.BoolVar(&skipTlsVerifyPull, "skip-tls-verify-pull", false, "do not check TLS certs on pull")
+	flag.BoolVar(&insecurePush, "insecure", false, "built images can be pushed to an insecure (plain HTTP) registry")
+	flag.BoolVar(&skipTlsVerifyPush, "skip-tls-verify", false, "do not check TLS certs on push")
+
 	flag.Parse()
 
 	checkArg(&unsignedImageName, "unsignedimage", "")
@@ -201,7 +210,7 @@ func main() {
 	checkArg(&filesList, "filestosign", "")
 	checkArg(&privKeyFile, "key", "")
 	checkArg(&pubKeyFile, "cert", "")
-	checkArg(&pullSecret, "pullsecret", "")
+	checkArg(&pullSecret, "pullsecret", "anonymous")
 	checkArg(&pushSecret, "pushsecret", pullSecret)
 	// if we've made it this far the arguments are sane
 
@@ -233,7 +242,7 @@ func main() {
 
 	r := registry.NewRegistry()
 
-	img, err := r.GetImageByName(unsignedImageName, a)
+	img, err := r.GetImageByName(unsignedImageName, a, insecurePull, skipTlsVerifyPull)
 	if err != nil {
 		die(3, "could not Image()", err)
 	}
@@ -290,7 +299,7 @@ func main() {
 		}
 
 		// write the image back to the name:tag set via the args
-		err := r.WriteImageByName(signedImageName, signedImage, a)
+		err := r.WriteImageByName(signedImageName, signedImage, a, insecurePush, skipTlsVerifyPush)
 		if err != nil {
 			die(8, "failed to write signed image", err)
 		}

--- a/internal/registry/mock_registry_api.go
+++ b/internal/registry/mock_registry_api.go
@@ -12,7 +12,6 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	authn "github.com/google/go-containerregistry/pkg/authn"
-	name "github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	types "github.com/google/go-containerregistry/pkg/v1/types"
 	v1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
@@ -102,18 +101,18 @@ func (mr *MockRegistryMockRecorder) GetHeaderDataFromLayer(layer, headerName int
 }
 
 // GetImageByName mocks base method.
-func (m *MockRegistry) GetImageByName(imageName string, auth authn.Authenticator) (v1.Image, error) {
+func (m *MockRegistry) GetImageByName(imageName string, auth authn.Authenticator, insecure, skipTLSVerify bool) (v1.Image, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetImageByName", imageName, auth)
+	ret := m.ctrl.Call(m, "GetImageByName", imageName, auth, insecure, skipTLSVerify)
 	ret0, _ := ret[0].(v1.Image)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetImageByName indicates an expected call of GetImageByName.
-func (mr *MockRegistryMockRecorder) GetImageByName(imageName, auth interface{}) *gomock.Call {
+func (mr *MockRegistryMockRecorder) GetImageByName(imageName, auth, insecure, skipTLSVerify interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageByName", reflect.TypeOf((*MockRegistry)(nil).GetImageByName), imageName, auth)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageByName", reflect.TypeOf((*MockRegistry)(nil).GetImageByName), imageName, auth, insecure, skipTLSVerify)
 }
 
 // GetLayerByDigest mocks base method.
@@ -192,21 +191,6 @@ func (mr *MockRegistryMockRecorder) LastLayer(ctx, image, po, registryAuthGetter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LastLayer", reflect.TypeOf((*MockRegistry)(nil).LastLayer), ctx, image, po, registryAuthGetter)
 }
 
-// ParseReference mocks base method.
-func (m *MockRegistry) ParseReference(imageName string) (name.Reference, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ParseReference", imageName)
-	ret0, _ := ret[0].(name.Reference)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ParseReference indicates an expected call of ParseReference.
-func (mr *MockRegistryMockRecorder) ParseReference(imageName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ParseReference", reflect.TypeOf((*MockRegistry)(nil).ParseReference), imageName)
-}
-
 // VerifyModuleExists mocks base method.
 func (m *MockRegistry) VerifyModuleExists(layer v1.Layer, pathPrefix, kernelVersion, moduleFileName string) bool {
 	m.ctrl.T.Helper()
@@ -241,15 +225,15 @@ func (mr *MockRegistryMockRecorder) WalkFilesInImage(image, fn interface{}, data
 }
 
 // WriteImageByName mocks base method.
-func (m *MockRegistry) WriteImageByName(imageName string, image v1.Image, auth authn.Authenticator) error {
+func (m *MockRegistry) WriteImageByName(imageName string, image v1.Image, auth authn.Authenticator, insecure, skipTLSVerify bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteImageByName", imageName, image, auth)
+	ret := m.ctrl.Call(m, "WriteImageByName", imageName, image, auth, insecure, skipTLSVerify)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // WriteImageByName indicates an expected call of WriteImageByName.
-func (mr *MockRegistryMockRecorder) WriteImageByName(imageName, image, auth interface{}) *gomock.Call {
+func (mr *MockRegistryMockRecorder) WriteImageByName(imageName, image, auth, insecure, skipTLSVerify interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteImageByName", reflect.TypeOf((*MockRegistry)(nil).WriteImageByName), imageName, image, auth)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteImageByName", reflect.TypeOf((*MockRegistry)(nil).WriteImageByName), imageName, image, auth, insecure, skipTLSVerify)
 }

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -22,9 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/google/go-containerregistry/pkg/authn"
-	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
@@ -52,16 +50,15 @@ type Registry interface {
 	VerifyModuleExists(layer v1.Layer, pathPrefix, kernelVersion, moduleFileName string) bool
 	GetLayersDigests(ctx context.Context, image string, tlsOptions *kmmv1beta1.TLSOptions, registryAuthGetter auth.RegistryAuthGetter) ([]string, *RepoPullConfig, error)
 	GetLayerByDigest(digest string, pullConfig *RepoPullConfig) (v1.Layer, error)
-	WriteImageByName(imageName string, image v1.Image, auth authn.Authenticator) error
 	WalkFilesInImage(image v1.Image, fn func(filename string, header *tar.Header, tarreader io.Reader, data []interface{}) error, data ...interface{}) error
 	GetLayerMediaType(image v1.Image) (types.MediaType, error)
 	AddLayerToImage(tarfile string, image v1.Image) (v1.Image, error)
-	GetImageByName(imageName string, auth authn.Authenticator) (v1.Image, error)
-	ParseReference(imageName string) (name.Reference, error)
 	ExtractBytesFromTar(size int64, tarreader io.Reader) ([]byte, error)
 	ExtractFileToFile(destination string, header *tar.Header, tarreader io.Reader) error
 	LastLayer(ctx context.Context, image string, po *kmmv1beta1.TLSOptions, registryAuthGetter auth.RegistryAuthGetter) (v1.Layer, error)
 	GetHeaderDataFromLayer(layer v1.Layer, headerName string) ([]byte, error)
+	WriteImageByName(imageName string, image v1.Image, auth authn.Authenticator, insecure bool, skipTLSVerify bool) error
+	GetImageByName(imageName string, auth authn.Authenticator, insecure bool, skipTLSVerify bool) (v1.Image, error)
 }
 
 type registry struct {
@@ -288,49 +285,6 @@ func (r *registry) getImageDigestFromMultiImage(manifestListStream []byte) (stri
 	return "", fmt.Errorf("Failed to find manifest for architecture %s", arch)
 }
 
-func (r *registry) GetImageByName(imageName string, auth authn.Authenticator) (v1.Image, error) {
-
-	ref, err := r.ParseReference(imageName)
-	if err != nil {
-		return nil, err
-	}
-
-	descriptor, err := remote.Get(ref, remote.WithAuth(auth))
-	if err != nil {
-		return nil, fmt.Errorf("could not get image: %w", err)
-	}
-
-	img, err := descriptor.Image()
-	if err != nil {
-		return nil, fmt.Errorf("could not call image: %w", err)
-	}
-	return img, nil
-}
-
-func (r *registry) ParseReference(imageName string) (name.Reference, error) {
-	opts := make([]name.Option, 0)
-	ref, err := name.ParseReference(imageName, opts...)
-	if err != nil {
-		return nil, fmt.Errorf("could not parse the container image %s: %w", imageName, err)
-	}
-
-	return ref, nil
-}
-
-func (r *registry) WriteImageByName(imageName string, image v1.Image, auth authn.Authenticator) error {
-
-	ref, err := r.ParseReference(imageName)
-	if err != nil {
-		return err
-	}
-
-	err = remote.Write(ref, image, remote.WithAuth(auth))
-	if err != nil {
-		return fmt.Errorf("failed to push signed image: %w", err)
-	}
-	return nil
-}
-
 func (r *registry) AddLayerToImage(tarfile string, image v1.Image) (v1.Image, error) {
 
 	//turn our tar archive into a layer
@@ -341,13 +295,13 @@ func (r *registry) AddLayerToImage(tarfile string, image v1.Image) (v1.Image, er
 
 	signedLayer, err := tarball.LayerFromFile(tarfile, tarball.WithMediaType(mt))
 	if err != nil {
-		return nil, fmt.Errorf("failed to generate layer from tar: %w", err)
+		return nil, fmt.Errorf("failed to generate layer from tar: %v", err)
 	}
 
 	// add the layer to the unsigned image
 	newImage, err := mutate.AppendLayers(image, signedLayer)
 	if err != nil {
-		return nil, fmt.Errorf("failed to append layer: %w", err)
+		return nil, fmt.Errorf("failed to append layer: %v", err)
 	}
 
 	// this is needde because mutate.AppendLayers loses the image mediatype
@@ -355,7 +309,7 @@ func (r *registry) AddLayerToImage(tarfile string, image v1.Image) (v1.Image, er
 	imageMediaType, _ := image.MediaType()
 	newImageWithMT := mutate.MediaType(newImage, imageMediaType)
 	if err != nil {
-		return nil, fmt.Errorf("failed to change medaitype of image: %w", err)
+		return nil, fmt.Errorf("failed to change medaitype of image: %v", err)
 	}
 	return newImageWithMT, nil
 }
@@ -363,7 +317,7 @@ func (r *registry) AddLayerToImage(tarfile string, image v1.Image) (v1.Image, er
 func (r *registry) GetLayerMediaType(image v1.Image) (types.MediaType, error) {
 	layers, err := image.Layers()
 	if err != nil {
-		return types.OCILayer, fmt.Errorf("could not get the layers from image: %w", err)
+		return types.OCILayer, fmt.Errorf("could not get the layers from image: %v", err)
 	}
 	return layers[len(layers)-1].MediaType()
 }
@@ -373,20 +327,20 @@ func (r *registry) GetLayerMediaType(image v1.Image) (types.MediaType, error) {
 ** a function on them, based loosly on ftw() or filepath.Walk().
 ** image   - the image to examine
 ** fn	   - the function to call on each file
-** ...data - all other arguements are passed through to the helper function
+** ...data - all other arguments are passed through to the helper function
 **	     to provide any additional data needed.
  */
 func (r *registry) WalkFilesInImage(image v1.Image, fn func(filename string, header *tar.Header, tarreader io.Reader, data []interface{}) error, data ...interface{}) error {
 	layers, err := image.Layers()
 	if err != nil {
-		return fmt.Errorf("could not get the layers from the fetched image: %w", err)
+		return fmt.Errorf("could not get the layers from the fetched image: %v", err)
 	}
 	for i := len(layers) - 1; i >= 0; i-- {
 		currentlayer := layers[i]
 
 		layerreader, err := currentlayer.Uncompressed()
 		if err != nil {
-			return fmt.Errorf("could not get layer: %w", err)
+			return fmt.Errorf("could not get layer: %v", err)
 		}
 
 		/*
@@ -400,7 +354,7 @@ func (r *registry) WalkFilesInImage(image v1.Image, fn func(filename string, hea
 			}
 			err = fn(header.Name, header, tarreader, data)
 			if err != nil {
-				return fmt.Errorf("died processing file %s: %w", header.Name, err)
+				return fmt.Errorf("died processing file %s: %v", header.Name, err)
 			}
 		}
 	}
@@ -409,7 +363,7 @@ func (r *registry) WalkFilesInImage(image v1.Image, fn func(filename string, hea
 }
 
 /*
-** extract size bytres from the start of an io.Reader
+** extract size bytes from the start of an io.Reader
  */
 func (r *registry) ExtractBytesFromTar(size int64, tarreader io.Reader) ([]byte, error) {
 
@@ -418,7 +372,7 @@ func (r *registry) ExtractBytesFromTar(size int64, tarreader io.Reader) ([]byte,
 	for {
 		rc, err := tarreader.Read(contents[offset:])
 		if err != nil && err != io.EOF {
-			return nil, fmt.Errorf("could not read from tar: %w ", err)
+			return nil, fmt.Errorf("could not read from tar: %v ", err)
 		}
 		offset += rc
 		if err == io.EOF {
@@ -435,7 +389,7 @@ func (r *registry) ExtractFileToFile(destination string, header *tar.Header, tar
 
 	contents, err := r.ExtractBytesFromTar(header.Size, tarreader)
 	if err != nil {
-		return fmt.Errorf("could not read file %s: %w", destination, err)
+		return fmt.Errorf("could not read file %s: %v", destination, err)
 	}
 
 	dirname := filepath.Dir(destination)
@@ -443,12 +397,60 @@ func (r *registry) ExtractFileToFile(destination string, header *tar.Header, tar
 	// I hope you've set your umask to something sensible!
 	err = os.MkdirAll(dirname, 0770)
 	if err != nil {
-		return fmt.Errorf("could not create directory structure for %s: %w", destination, err)
+		return fmt.Errorf("could not create directory structure for %s: %v", destination, err)
 	}
 	err = os.WriteFile(destination, contents, 0700)
 	if err != nil {
-		return fmt.Errorf("could not create temp %s: %w", destination, err)
+		return fmt.Errorf("could not create temp %s: %v", destination, err)
 	}
 	return nil
 
+}
+
+func (r *registry) getTransportOptions(insecure bool, skipTLSVerify bool) []crane.Option {
+	options := []crane.Option{}
+
+	if insecure {
+		options = append(options, crane.Insecure)
+	}
+
+	if skipTLSVerify {
+		rt := http.DefaultTransport.(*http.Transport).Clone()
+		rt.TLSClientConfig.InsecureSkipVerify = true
+		options = append(
+			options,
+			crane.WithTransport(rt),
+		)
+	}
+
+	return options
+}
+
+func (r *registry) WriteImageByName(imageName string, image v1.Image, auth authn.Authenticator, insecure bool, skipTLSVerify bool) error {
+	options := r.getTransportOptions(insecure, skipTLSVerify)
+	options = append(
+		options,
+		crane.WithAuth(auth),
+	)
+
+	err := crane.Push(image, imageName, options...)
+	if err != nil {
+		return fmt.Errorf("failed to push signed image: %v", err)
+	}
+	return nil
+}
+
+func (r *registry) GetImageByName(imageName string, auth authn.Authenticator, insecure bool, skipTLSVerify bool) (v1.Image, error) {
+	options := r.getTransportOptions(insecure, skipTLSVerify)
+	options = append(
+		options,
+		crane.WithAuth(auth),
+	)
+
+	img, err := crane.Pull(imageName, options...)
+	if err != nil {
+		return nil, fmt.Errorf("could not get image: %v", err)
+	}
+
+	return img, nil
 }

--- a/internal/sign/helper.go
+++ b/internal/sign/helper.go
@@ -31,6 +31,14 @@ func (m *helper) GetRelevantSign(modSpec kmmv1beta1.ModuleSpec, km kmmv1beta1.Ke
 	if km.Sign.UnsignedImage != "" {
 		signConfig.UnsignedImage = km.Sign.UnsignedImage
 	}
+
+	if km.Sign.UnsignedImageRegistryTLS.Insecure {
+		signConfig.UnsignedImageRegistryTLS.Insecure = km.Sign.UnsignedImageRegistryTLS.Insecure
+	}
+	if km.Sign.UnsignedImageRegistryTLS.InsecureSkipTLSVerify {
+		signConfig.UnsignedImageRegistryTLS.InsecureSkipTLSVerify = km.Sign.UnsignedImageRegistryTLS.InsecureSkipTLSVerify
+	}
+
 	if km.Sign.KeySecret != nil {
 		signConfig.KeySecret = km.Sign.KeySecret
 	}


### PR DESCRIPTION
Fixes #330

> Add support for insecure pull/push of images to signing job. (#192)
> 
> For some reason api support was there but pull/push via http or without TLS cert checking hadn't made it into 
> the signing job itself. This fixes that issue by passing those options into the signing job and through to the
> appropriate functions in the registry package.