### PR TITLE
MGMT-12691 add support for KERNEL_VERSION etc replacement for filesToSign and unsignedImage fields (#336)

### DIFF
--- a/internal/sign/helper.go
+++ b/internal/sign/helper.go
@@ -2,51 +2,56 @@ package sign
 
 import (
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 )
 
 //go:generate mockgen -source=helper.go -package=sign -destination=mock_helper.go
 
 type Helper interface {
-	GetRelevantSign(modSpec kmmv1beta1.ModuleSpec, km kmmv1beta1.KernelMapping) *kmmv1beta1.Sign
+	GetRelevantSign(modSpec kmmv1beta1.ModuleSpec, km kmmv1beta1.KernelMapping, kernel string) (*kmmv1beta1.Sign, error)
 }
 
-type helper struct{}
+type helper struct {
+}
 
 func NewSignerHelper() Helper {
 	return &helper{}
 }
 
-func (m *helper) GetRelevantSign(modSpec kmmv1beta1.ModuleSpec, km kmmv1beta1.KernelMapping) *kmmv1beta1.Sign {
+func (m *helper) GetRelevantSign(modSpec kmmv1beta1.ModuleSpec, km kmmv1beta1.KernelMapping, kernel string) (*kmmv1beta1.Sign, error) {
+	var signConfig *kmmv1beta1.Sign
 	if modSpec.ModuleLoader.Container.Sign == nil {
 		// km.Sign cannot be nil in case mod.Sign is nil, checked above
-		return km.Sign.DeepCopy()
-	}
+		signConfig = km.Sign.DeepCopy()
+	} else if km.Sign == nil {
+		signConfig = modSpec.ModuleLoader.Container.Sign.DeepCopy()
+	} else {
+		signConfig = modSpec.ModuleLoader.Container.Sign.DeepCopy()
 
-	if km.Sign == nil {
-		return modSpec.ModuleLoader.Container.Sign.DeepCopy()
-	}
+		if km.Sign.UnsignedImage != "" {
+			signConfig.UnsignedImage = km.Sign.UnsignedImage
+		}
 
-	signConfig := modSpec.ModuleLoader.Container.Sign.DeepCopy()
+		if km.Sign.KeySecret != nil {
+			signConfig.KeySecret = km.Sign.KeySecret
+		}
+		if km.Sign.CertSecret != nil {
+			signConfig.CertSecret = km.Sign.CertSecret
+		}
+		//append (not overwrite) any files in the km to the defaults
+		signConfig.FilesToSign = append(signConfig.FilesToSign, km.Sign.FilesToSign...)
+	}
+	osConfigEnvVars := utils.KernelComponentsAsEnvVars(kernel)
+	unsignedImage, err := utils.ReplaceInTemplates(osConfigEnvVars, signConfig.UnsignedImage)
+	if err != nil {
+		return nil, err
+	}
+	signConfig.UnsignedImage = unsignedImage[0]
+	filesToSign, err := utils.ReplaceInTemplates(osConfigEnvVars, signConfig.FilesToSign...)
+	if err != nil {
+		return nil, err
+	}
+	signConfig.FilesToSign = filesToSign
 
-	if km.Sign.UnsignedImage != "" {
-		signConfig.UnsignedImage = km.Sign.UnsignedImage
-	}
-
-	if km.Sign.UnsignedImageRegistryTLS.Insecure {
-		signConfig.UnsignedImageRegistryTLS.Insecure = km.Sign.UnsignedImageRegistryTLS.Insecure
-	}
-	if km.Sign.UnsignedImageRegistryTLS.InsecureSkipTLSVerify {
-		signConfig.UnsignedImageRegistryTLS.InsecureSkipTLSVerify = km.Sign.UnsignedImageRegistryTLS.InsecureSkipTLSVerify
-	}
-
-	if km.Sign.KeySecret != nil {
-		signConfig.KeySecret = km.Sign.KeySecret
-	}
-	if km.Sign.CertSecret != nil {
-		signConfig.CertSecret = km.Sign.CertSecret
-	}
-	//append (not overwrite) any files in the km to the defaults
-	signConfig.FilesToSign = append(signConfig.FilesToSign, km.Sign.FilesToSign...)
-
-	return signConfig
+	return signConfig, nil
 }

--- a/internal/sign/helper_test.go
+++ b/internal/sign/helper_test.go
@@ -17,6 +17,7 @@ var _ = Describe("GetRelevantSign", func() {
 		keySecret     = "securebootkey"
 		certSecret    = "securebootcert"
 		filesToSign   = "/modules/simple-kmod.ko:/modules/simple-procfs-kmod.ko"
+		kernelVersion = "1.2.3"
 	)
 
 	var (
@@ -35,8 +36,8 @@ var _ = Describe("GetRelevantSign", func() {
 	}
 
 	DescribeTable("should set fields correctly", func(mod kmmv1beta1.Module, km kmmv1beta1.KernelMapping) {
-
-		actual := h.GetRelevantSign(mod.Spec, km)
+		actual, err := h.GetRelevantSign(mod.Spec, km, kernelVersion)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(
 			cmp.Diff(expected, actual),
 		).To(
@@ -165,4 +166,75 @@ var _ = Describe("GetRelevantSign", func() {
 		),
 	)
 
+})
+var _ = Describe("GetRelevantSign", func() {
+
+	const (
+		unsignedImage = "my.registry/my/image"
+		keySecret     = "securebootkey"
+		certSecret    = "securebootcert"
+		filesToSign   = "/modules/${KERNEL_VERSION}/simple-kmod.ko:/modules/${KERNEL_VERSION}/simple-procfs-kmod.ko"
+		kernelVersion = "1.2.3"
+	)
+
+	var (
+		h Helper
+	)
+
+	BeforeEach(func() {
+		h = NewSignerHelper()
+	})
+
+	expected := &kmmv1beta1.Sign{
+		UnsignedImage: unsignedImage + ":" + kernelVersion,
+		KeySecret:     &v1.LocalObjectReference{Name: keySecret},
+		CertSecret:    &v1.LocalObjectReference{Name: certSecret},
+		FilesToSign:   strings.Split("/modules/"+kernelVersion+"/simple-kmod.ko:/modules/"+kernelVersion+"/simple-procfs-kmod.ko", ":"),
+	}
+
+	DescribeTable("should set fields correctly", func(mod kmmv1beta1.Module, km kmmv1beta1.KernelMapping) {
+		actual, _ := h.GetRelevantSign(mod.Spec, km, kernelVersion)
+		Expect(
+			cmp.Diff(expected, actual),
+		).To(
+			BeEmpty(),
+		)
+	},
+		Entry(
+			"no km.Sign",
+			kmmv1beta1.Module{
+				Spec: kmmv1beta1.ModuleSpec{
+					ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+						Container: kmmv1beta1.ModuleLoaderContainerSpec{
+							Sign: &kmmv1beta1.Sign{
+								UnsignedImage: unsignedImage + ":${KERNEL_VERSION}",
+								KeySecret:     &v1.LocalObjectReference{Name: keySecret},
+								CertSecret:    &v1.LocalObjectReference{Name: certSecret},
+								FilesToSign:   strings.Split(filesToSign, ":"),
+							},
+						},
+					},
+				},
+			},
+			kmmv1beta1.KernelMapping{},
+		),
+		Entry(
+			"no container.Sign",
+			kmmv1beta1.Module{
+				Spec: kmmv1beta1.ModuleSpec{
+					ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+						Container: kmmv1beta1.ModuleLoaderContainerSpec{},
+					},
+				},
+			},
+			kmmv1beta1.KernelMapping{
+				Sign: &kmmv1beta1.Sign{
+					UnsignedImage: unsignedImage + ":${KERNEL_VERSION}",
+					KeySecret:     &v1.LocalObjectReference{Name: keySecret},
+					CertSecret:    &v1.LocalObjectReference{Name: certSecret},
+					FilesToSign:   strings.Split(filesToSign, ":"),
+				},
+			},
+		),
+	)
 })

--- a/internal/sign/job/signer.go
+++ b/internal/sign/job/signer.go
@@ -73,7 +73,10 @@ func (m *signer) MakeJobTemplate(
 	pushImage bool,
 	owner metav1.Object) (*batchv1.Job, error) {
 
-	signConfig := m.helper.GetRelevantSign(mod.Spec, km)
+	signConfig, err := m.helper.GetRelevantSign(mod.Spec, km, targetKernel)
+	if err != nil {
+		return nil, fmt.Errorf("calculate the signing parameters: %v", err)
+	}
 
 	args := make([]string, 0)
 

--- a/internal/sign/job/signer_test.go
+++ b/internal/sign/job/signer_test.go
@@ -211,7 +211,7 @@ var _ = Describe("MakeJobTemplate", func() {
 		mod.Spec.Selector = nodeSelector
 
 		gomock.InOrder(
-			helper.EXPECT().GetRelevantSign(mod.Spec, km).Return(km.Sign),
+			helper.EXPECT().GetRelevantSign(mod.Spec, km, kernelVersion).Return(km.Sign, nil),
 			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: km.Sign.KeySecret.Name, Namespace: mod.Namespace}, gomock.Any()).DoAndReturn(
 				func(_ interface{}, _ interface{}, secret *v1.Secret, _ ...ctrlclient.GetOption) error {
 					secret.Data = privateSignData
@@ -258,7 +258,7 @@ var _ = Describe("MakeJobTemplate", func() {
 		}
 
 		gomock.InOrder(
-			helper.EXPECT().GetRelevantSign(mod.Spec, km).Return(km.Sign),
+			helper.EXPECT().GetRelevantSign(mod.Spec, km, kernelVersion).Return(km.Sign, nil),
 			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: km.Sign.KeySecret.Name, Namespace: mod.Namespace}, gomock.Any()).DoAndReturn(
 				func(_ interface{}, _ interface{}, secret *v1.Secret, _ ...ctrlclient.GetOption) error {
 					secret.Data = privateSignData
@@ -323,7 +323,7 @@ var _ = Describe("MakeJobTemplate", func() {
 		}
 
 		gomock.InOrder(
-			helper.EXPECT().GetRelevantSign(mod.Spec, km).Return(km.Sign),
+			helper.EXPECT().GetRelevantSign(mod.Spec, km, kernelVersion).Return(km.Sign, nil),
 			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: km.Sign.KeySecret.Name, Namespace: mod.Namespace}, gomock.Any()).DoAndReturn(
 				func(_ interface{}, _ interface{}, secret *v1.Secret, _ ...ctrlclient.GetOption) error {
 					secret.Data = privateSignData

--- a/internal/sign/mock_helper.go
+++ b/internal/sign/mock_helper.go
@@ -35,15 +35,16 @@ func (m *MockHelper) EXPECT() *MockHelperMockRecorder {
 }
 
 // GetRelevantSign mocks base method.
-func (m *MockHelper) GetRelevantSign(modSpec v1beta1.ModuleSpec, km v1beta1.KernelMapping) *v1beta1.Sign {
+func (m *MockHelper) GetRelevantSign(modSpec v1beta1.ModuleSpec, km v1beta1.KernelMapping, kernel string) (*v1beta1.Sign, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRelevantSign", modSpec, km)
+	ret := m.ctrl.Call(m, "GetRelevantSign", modSpec, km, kernel)
 	ret0, _ := ret[0].(*v1beta1.Sign)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetRelevantSign indicates an expected call of GetRelevantSign.
-func (mr *MockHelperMockRecorder) GetRelevantSign(modSpec, km interface{}) *gomock.Call {
+func (mr *MockHelperMockRecorder) GetRelevantSign(modSpec, km, kernel interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelevantSign", reflect.TypeOf((*MockHelper)(nil).GetRelevantSign), modSpec, km)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRelevantSign", reflect.TypeOf((*MockHelper)(nil).GetRelevantSign), modSpec, km, kernel)
 }

--- a/internal/utils/replaceStrings.go
+++ b/internal/utils/replaceStrings.go
@@ -1,0 +1,48 @@
+package utils
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/a8m/envsubst/parse"
+)
+
+const (
+	kernelVersionMajorIdx = 0
+	kernelVersionMinorIdx = 1
+	kernelVersionPatchIdx = 2
+)
+
+var kernelRegexp = regexp.MustCompile("[.,-]")
+
+func KernelComponentsAsEnvVars(kernel string) []string {
+	osConfigFieldsList := kernelRegexp.Split(kernel, -1)
+
+	envvars := []string{
+		"KERNEL_FULL_VERSION=" + kernel,
+		"KERNEL_VERSION=" + kernel,
+		"KERNEL_XYZ=" + strings.Join(osConfigFieldsList[:kernelVersionPatchIdx+1], "."),
+		"KERNEL_X=" + osConfigFieldsList[kernelVersionMajorIdx],
+		"KERNEL_Y=" + osConfigFieldsList[kernelVersionMinorIdx],
+		"KERNEL_Z=" + osConfigFieldsList[kernelVersionPatchIdx],
+	}
+
+	return envvars
+}
+
+func ReplaceInTemplates(envvars []string, templates ...string) ([]string, error) {
+	parser := parse.New("mapping", envvars, &parse.Restrictions{})
+
+	replacedStrings := make([]string, 0, len(templates))
+
+	for _, v := range templates {
+		resultString, err := parser.Parse(v)
+		if err != nil {
+			return nil, fmt.Errorf("failed to substitute %q: %v", v, err)
+		}
+
+		replacedStrings = append(replacedStrings, resultString)
+	}
+	return replacedStrings, nil
+}

--- a/internal/utils/replaceStrings_test.go
+++ b/internal/utils/replaceStrings_test.go
@@ -1,0 +1,39 @@
+package utils
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("KernelComponentsAsEnvVars", func() {
+	const kernelVersion = "6.0.15-300.fc37.x86_64"
+
+	expected := []string{
+		"KERNEL_FULL_VERSION=" + kernelVersion,
+		"KERNEL_VERSION=" + kernelVersion,
+		"KERNEL_XYZ=6.0.15",
+		"KERNEL_X=6",
+		"KERNEL_Y=0",
+		"KERNEL_Z=15",
+	}
+
+	Expect(KernelComponentsAsEnvVars(kernelVersion)).To(Equal(expected))
+})
+
+var _ = Describe("ReplaceInTemplates", func() {
+	vars := []string{"A=AAA", "B=BBB", "C=CCC"}
+
+	templates := []string{
+		"string with template $A",
+		"string with template ${B}",
+		"string without template",
+	}
+
+	expected := []string{
+		"string with template AAA",
+		"string with template BBB",
+		"string without template",
+	}
+
+	Expect(ReplaceInTemplates(vars, templates...)).To(Equal(expected))
+})


### PR DESCRIPTION
Fixes #336

Upstream-Commit: 546c83387da884997298e4b34086acd9bcbfba02
Upstream-Commit: 00d1995fd5c09fa7efd6a2630604dd074515ee58

> [MGMT-12691](https://issues.redhat.com//browse/MGMT-12691) add support for KERNEL_VERSION etc replacement for filesToSign and unsignedImage fields (#187)
> 
> filesToSign (the filepaths of the kmods to sign) and unsignedImage (the name of the image that contains the
> kmods if its not built in cluster) both normally would contain the kernel version, this commit allows the
> embedding of "${KERNEL_VERSION}" and/or ${KERNEL_FULL_VERSION} in them and have it replaced with the
> actual kernel version
> 
> The code for doing this search/replace has been added to internal/utils/replaceStrings.go to make a generally
> useful library for other places that may need similar functionality