### PR TITLE
Configure related images via environment variables

### DIFF
--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -186,6 +186,8 @@ spec:
                       fieldPath: metadata.namespace
                 - name: SSL_CERT_DIR
                   value: /etc/pki/ca-trust/extracted/pem
+                - name: RELATED_IMAGES_SIGN
+                  value: quay.io/edge-infrastructure/kernel-module-management-signimage:latest
                 image: quay.io/edge-infrastructure/kernel-module-management-operator-hub:latest
                 imagePullPolicy: Always
                 livenessProbe:

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -327,6 +327,8 @@ spec:
                 env:
                 - name: SSL_CERT_DIR
                   value: /etc/pki/ca-trust/extracted/pem
+                - name: RELATED_IMAGES_SIGN
+                  value: quay.io/edge-infrastructure/kernel-module-management-signimage:latest
                 image: quay.io/edge-infrastructure/kernel-module-management-operator:latest
                 imagePullPolicy: Always
                 livenessProbe:

--- a/config/manager-base/manager.yaml
+++ b/config/manager-base/manager.yaml
@@ -41,6 +41,9 @@ spec:
         - /usr/local/bin/manager
         image: controller:latest
         name: manager
+        env:
+          - name: RELATED_IMAGES_SIGN
+            value: quay.io/edge-infrastructure/kernel-module-management-signimage:latest
         imagePullPolicy: Always
         securityContext:
           allowPrivilegeEscalation: false

--- a/internal/sign/job/signer.go
+++ b/internal/sign/job/signer.go
@@ -3,6 +3,7 @@ package signjob
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/mitchellh/hashstructure"
@@ -133,7 +134,7 @@ func (m *signer) MakeJobTemplate(
 			Containers: []v1.Container{
 				{
 					Name:         "signimage",
-					Image:        "quay.io/edge-infrastructure/kernel-module-management-signimage:latest",
+					Image:        os.Getenv("RELATED_IMAGES_SIGN"),
 					Args:         args,
 					VolumeMounts: volumeMounts,
 				},

--- a/internal/sign/job/signer_test.go
+++ b/internal/sign/job/signer_test.go
@@ -28,6 +28,7 @@ var _ = Describe("MakeJobTemplate", func() {
 	const (
 		unsignedImage = "my.registry/my/image"
 		signedImage   = "my.registry/my/image-signed"
+		signerImage   = "some-signer-image:some-tag"
 		filesToSign   = "/modules/simple-kmod.ko:/modules/simple-procfs-kmod.ko"
 		kernelVersion = "1.2.3"
 		moduleName    = "module-name"
@@ -72,6 +73,8 @@ var _ = Describe("MakeJobTemplate", func() {
 	privateSignData := map[string][]byte{constants.PrivateSignDataKey: []byte(privateKey)}
 
 	DescribeTable("should set fields correctly", func(imagePullSecret *v1.LocalObjectReference) {
+		GinkgoT().Setenv("RELATED_IMAGES_SIGN", signerImage)
+
 		ctx := context.Background()
 		nodeSelector := map[string]string{"arch": "x64"}
 
@@ -151,7 +154,7 @@ var _ = Describe("MakeJobTemplate", func() {
 						Containers: []v1.Container{
 							{
 								Name:  "signimage",
-								Image: "quay.io/edge-infrastructure/kernel-module-management-signimage:latest",
+								Image: signerImage,
 								Args: []string{
 									"-signedimage", signedImage,
 									"-unsignedimage", unsignedImage,


### PR DESCRIPTION
This allows us to patch those variables with the digest equivalent of the images. Unfortunately operator-sdk does not seem to identify them properly for an unknown reason; that means that the images are not listed under the CSV's relatedImages field, nor are they automatically replaced with their digest equivalent.

/cc @chr15p @ybettan 

Fixes #331