### PR TITLE
Implement ManagedClusterModuleStatus for KMM-Hub

### DIFF
--- a/api-hub/v1beta1/managedclustermodule_types.go
+++ b/api-hub/v1beta1/managedclustermodule_types.go
@@ -38,6 +38,14 @@ type ManagedClusterModuleSpec struct {
 
 // ManagedClusterModuleStatus defines the observed state of ManagedClusterModule.
 type ManagedClusterModuleStatus struct {
+	// Number of ManifestWorks to be applied.
+	NumberDesired int32 `json:"numberDesired"`
+
+	// Number of ManifestWorks that have been successfully applied.
+	NumberApplied int32 `json:"numberApplied"`
+
+	// Number of ManifestWorks that could not be successfully applied.
+	NumberDegraded int32 `json:"numberDegraded"`
 }
 
 //+kubebuilder:object:root=true

--- a/cmd/manager-hub/main.go
+++ b/cmd/manager-hub/main.go
@@ -23,14 +23,6 @@ import (
 
 	buildv1 "github.com/openshift/api/build/v1"
 	imagev1 "github.com/openshift/api/image/v1"
-	"github.com/rh-ecosystem-edge/kernel-module-management/api-hub/v1beta1"
-	"github.com/rh-ecosystem-edge/kernel-module-management/controllers"
-	"github.com/rh-ecosystem-edge/kernel-module-management/controllers/hub"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/auth"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/build/buildconfig"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/cmd"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/syncronizedmap"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -48,8 +40,15 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	"github.com/rh-ecosystem-edge/kernel-module-management/api-hub/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/controllers"
+	"github.com/rh-ecosystem-edge/kernel-module-management/controllers/hub"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/auth"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/build"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/build/buildconfig"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/cluster"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/cmd"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/filter"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/manifestwork"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/metrics"
@@ -57,6 +56,8 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/registry"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/sign"
 	signjob "github.com/rh-ecosystem-edge/kernel-module-management/internal/sign/job"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/statusupdater"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/syncronizedmap"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	//+kubebuilder:scaffold:imports
 )
@@ -155,6 +156,7 @@ func main() {
 		client,
 		manifestwork.NewCreator(client, scheme),
 		cluster.NewClusterAPI(client, module.NewKernelMapper(), buildAPI, signAPI, operatorNamespace),
+		statusupdater.NewManagedClusterModuleStatusUpdater(client),
 		filterAPI,
 	)
 

--- a/config/crd-hub/bases/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
+++ b/config/crd-hub/bases/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
@@ -2412,6 +2412,24 @@ spec:
           status:
             description: ManagedClusterModuleStatus defines the observed state of
               ManagedClusterModule.
+            properties:
+              numberApplied:
+                description: Number of ManifestWorks that have been successfully applied.
+                format: int32
+                type: integer
+              numberDegraded:
+                description: Number of ManifestWorks that could not be successfully
+                  applied.
+                format: int32
+                type: integer
+              numberDesired:
+                description: Number of ManifestWorks to be applied.
+                format: int32
+                type: integer
+            required:
+            - numberApplied
+            - numberDegraded
+            - numberDesired
             type: object
         type: object
     served: true

--- a/controllers/hub/managedclustermodule_reconciler_test.go
+++ b/controllers/hub/managedclustermodule_reconciler_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/cluster"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/manifestwork"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/statusupdater"
 )
 
 var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
@@ -45,6 +46,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 		clnt           *client.MockClient
 		mockMW         *manifestwork.MockManifestWorkCreator
 		mockClusterAPI *cluster.MockClusterAPI
+		mockSU         *statusupdater.MockManagedClusterModuleStatusUpdater
 	)
 
 	BeforeEach(func() {
@@ -52,6 +54,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 		clnt = client.NewMockClient(ctrl)
 		mockMW = manifestwork.NewMockManifestWorkCreator(ctrl)
 		mockClusterAPI = cluster.NewMockClusterAPI(ctrl)
+		mockSU = statusupdater.NewMockManagedClusterModuleStatusUpdater(ctrl)
 	})
 
 	const (
@@ -73,7 +76,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 				apierrors.NewNotFound(schema.GroupResource{}, mcmName),
 			)
 
-		mcmr := NewManagedClusterModuleReconciler(clnt, nil, mockClusterAPI, nil)
+		mcmr := NewManagedClusterModuleReconciler(clnt, nil, mockClusterAPI, nil, nil)
 		Expect(
 			mcmr.Reconcile(ctx, req),
 		).To(
@@ -85,7 +88,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 		mockClusterAPI.EXPECT().RequestedManagedClusterModule(ctx, req.NamespacedName).
 			Return(nil, errors.New("test"))
 
-		mr := NewManagedClusterModuleReconciler(clnt, nil, mockClusterAPI, nil)
+		mr := NewManagedClusterModuleReconciler(clnt, nil, mockClusterAPI, nil, nil)
 
 		res, err := mr.Reconcile(ctx, req)
 		Expect(err).To(HaveOccurred())
@@ -112,7 +115,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 				),
 		)
 
-		mr := NewManagedClusterModuleReconciler(clnt, nil, mockClusterAPI, nil)
+		mr := NewManagedClusterModuleReconciler(clnt, nil, mockClusterAPI, nil, nil)
 
 		res, err := mr.Reconcile(context.Background(), req)
 		Expect(err).To(HaveOccurred())
@@ -131,15 +134,18 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 		}
 
 		clusterList := clusterv1.ManagedClusterList{}
+		manifestWorkList := workv1.ManifestWorkList{}
 
 		gomock.InOrder(
 			mockClusterAPI.EXPECT().RequestedManagedClusterModule(ctx, req.NamespacedName).Return(mcm, nil),
 			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, gomock.Any()).Return(&clusterList, nil),
 			mockMW.EXPECT().GarbageCollect(ctx, clusterList, *mcm),
 			mockClusterAPI.EXPECT().GarbageCollectBuilds(ctx, *mcm),
+			mockMW.EXPECT().GetOwnedManifestWorks(ctx, *mcm).Return(&manifestWorkList, nil),
+			mockSU.EXPECT().ManagedClusterModuleUpdateStatus(ctx, mcm, manifestWorkList.Items).Return(nil),
 		)
 
-		mr := NewManagedClusterModuleReconciler(clnt, mockMW, mockClusterAPI, nil)
+		mr := NewManagedClusterModuleReconciler(clnt, mockMW, mockClusterAPI, mockSU, nil)
 
 		res, err := mr.Reconcile(context.Background(), req)
 		Expect(err).NotTo(HaveOccurred())
@@ -165,7 +171,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 			mockMW.EXPECT().GarbageCollect(ctx, clusterList, *mcm).Return(errors.New("test")),
 		)
 
-		mr := NewManagedClusterModuleReconciler(clnt, mockMW, mockClusterAPI, nil)
+		mr := NewManagedClusterModuleReconciler(clnt, mockMW, mockClusterAPI, nil, nil)
 
 		res, err := mr.Reconcile(context.Background(), req)
 		Expect(err).To(HaveOccurred())
@@ -192,7 +198,65 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 			mockClusterAPI.EXPECT().GarbageCollectBuilds(ctx, *mcm).Return(nil, errors.New("test")),
 		)
 
-		mr := NewManagedClusterModuleReconciler(clnt, mockMW, mockClusterAPI, nil)
+		mr := NewManagedClusterModuleReconciler(clnt, mockMW, mockClusterAPI, nil, nil)
+
+		res, err := mr.Reconcile(context.Background(), req)
+		Expect(err).To(HaveOccurred())
+		Expect(res).To(Equal(reconcile.Result{}))
+	})
+
+	It("should return an error when fetching the owned ManifestWorks fails", func() {
+		mcm := &v1beta1.ManagedClusterModule{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: mcmName,
+			},
+			Spec: v1beta1.ManagedClusterModuleSpec{
+				ModuleSpec: kmmv1beta1.ModuleSpec{},
+				Selector:   map[string]string{"key": "value"},
+			},
+		}
+
+		clusterList := clusterv1.ManagedClusterList{}
+
+		gomock.InOrder(
+			mockClusterAPI.EXPECT().RequestedManagedClusterModule(ctx, req.NamespacedName).Return(mcm, nil),
+			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, gomock.Any()).Return(&clusterList, nil),
+			mockMW.EXPECT().GarbageCollect(ctx, clusterList, *mcm),
+			mockClusterAPI.EXPECT().GarbageCollectBuilds(ctx, *mcm),
+			mockMW.EXPECT().GetOwnedManifestWorks(ctx, *mcm).Return(nil, errors.New("generic-error")),
+		)
+
+		mr := NewManagedClusterModuleReconciler(clnt, mockMW, mockClusterAPI, nil, nil)
+
+		res, err := mr.Reconcile(context.Background(), req)
+		Expect(err).To(HaveOccurred())
+		Expect(res).To(Equal(reconcile.Result{}))
+	})
+
+	It("should return an error when status update fails", func() {
+		mcm := &v1beta1.ManagedClusterModule{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: mcmName,
+			},
+			Spec: v1beta1.ManagedClusterModuleSpec{
+				ModuleSpec: kmmv1beta1.ModuleSpec{},
+				Selector:   map[string]string{"key": "value"},
+			},
+		}
+
+		clusterList := clusterv1.ManagedClusterList{}
+		manifestWorkList := workv1.ManifestWorkList{}
+
+		gomock.InOrder(
+			mockClusterAPI.EXPECT().RequestedManagedClusterModule(ctx, req.NamespacedName).Return(mcm, nil),
+			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, gomock.Any()).Return(&clusterList, nil),
+			mockMW.EXPECT().GarbageCollect(ctx, clusterList, *mcm),
+			mockClusterAPI.EXPECT().GarbageCollectBuilds(ctx, *mcm),
+			mockMW.EXPECT().GetOwnedManifestWorks(ctx, *mcm).Return(&manifestWorkList, nil),
+			mockSU.EXPECT().ManagedClusterModuleUpdateStatus(ctx, mcm, manifestWorkList.Items).Return(errors.New("generic-error")),
+		)
+
+		mr := NewManagedClusterModuleReconciler(clnt, mockMW, mockClusterAPI, mockSU, nil)
 
 		res, err := mr.Reconcile(context.Background(), req)
 		Expect(err).To(HaveOccurred())
@@ -227,15 +291,19 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 			},
 		}
 
+		manifestWorkList := workv1.ManifestWorkList{}
+
 		gomock.InOrder(
 			mockClusterAPI.EXPECT().RequestedManagedClusterModule(ctx, req.NamespacedName).Return(&mcm, nil),
 			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, gomock.Any()).Return(&clusterList, nil),
 			mockClusterAPI.EXPECT().BuildAndSign(gomock.Any(), mcm, clusterList.Items[0]).Return(true, nil),
 			mockMW.EXPECT().GarbageCollect(ctx, clusterList, mcm),
 			mockClusterAPI.EXPECT().GarbageCollectBuilds(ctx, mcm),
+			mockMW.EXPECT().GetOwnedManifestWorks(ctx, mcm).Return(&manifestWorkList, nil),
+			mockSU.EXPECT().ManagedClusterModuleUpdateStatus(ctx, &mcm, manifestWorkList.Items).Return(nil),
 		)
 
-		mr := NewManagedClusterModuleReconciler(clnt, mockMW, mockClusterAPI, nil)
+		mr := NewManagedClusterModuleReconciler(clnt, mockMW, mockClusterAPI, mockSU, nil)
 
 		res, err := mr.Reconcile(context.Background(), req)
 		Expect(err).ToNot(HaveOccurred())
@@ -263,6 +331,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 				},
 			},
 		}
+		manifestWorkList := workv1.ManifestWorkList{}
 
 		mw := workv1.ManifestWork{
 			ObjectMeta: metav1.ObjectMeta{
@@ -280,9 +349,11 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 			clnt.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil),
 			mockMW.EXPECT().GarbageCollect(ctx, clusterList, mcm),
 			mockClusterAPI.EXPECT().GarbageCollectBuilds(ctx, mcm),
+			mockMW.EXPECT().GetOwnedManifestWorks(ctx, mcm).Return(&manifestWorkList, nil),
+			mockSU.EXPECT().ManagedClusterModuleUpdateStatus(ctx, &mcm, manifestWorkList.Items).Return(nil),
 		)
 
-		mr := NewManagedClusterModuleReconciler(clnt, mockMW, mockClusterAPI, nil)
+		mr := NewManagedClusterModuleReconciler(clnt, mockMW, mockClusterAPI, mockSU, nil)
 
 		res, err := mr.Reconcile(context.Background(), req)
 		Expect(err).NotTo(HaveOccurred())
@@ -311,6 +382,8 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 			},
 		}
 
+		manifestWorkList := workv1.ManifestWorkList{}
+
 		mw := workv1.ManifestWork{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      mcm.Name,
@@ -330,9 +403,11 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 			clnt.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()),
 			mockMW.EXPECT().GarbageCollect(ctx, clusterList, mcm),
 			mockClusterAPI.EXPECT().GarbageCollectBuilds(ctx, mcm),
+			mockMW.EXPECT().GetOwnedManifestWorks(ctx, mcm).Return(&manifestWorkList, nil),
+			mockSU.EXPECT().ManagedClusterModuleUpdateStatus(ctx, &mcm, manifestWorkList.Items).Return(nil),
 		)
 
-		mr := NewManagedClusterModuleReconciler(clnt, mockMW, mockClusterAPI, nil)
+		mr := NewManagedClusterModuleReconciler(clnt, mockMW, mockClusterAPI, mockSU, nil)
 
 		res, err := mr.Reconcile(context.Background(), req)
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/manifestwork/manifestwork.go
+++ b/internal/manifestwork/manifestwork.go
@@ -24,6 +24,7 @@ import (
 
 type ManifestWorkCreator interface {
 	GarbageCollect(ctx context.Context, clusters clusterv1.ManagedClusterList, mcm hubv1beta1.ManagedClusterModule) error
+	GetOwnedManifestWorks(ctx context.Context, mcm hubv1beta1.ManagedClusterModule) (*workv1.ManifestWorkList, error)
 	SetManifestWorkAsDesired(ctx context.Context, mw *workv1.ManifestWork, mcm hubv1beta1.ManagedClusterModule) error
 }
 
@@ -61,6 +62,10 @@ func (mwg *manifestWorkGenerator) GarbageCollect(ctx context.Context, clusters c
 	}
 
 	return nil
+}
+
+func (mwg *manifestWorkGenerator) GetOwnedManifestWorks(ctx context.Context, mcm hubv1beta1.ManagedClusterModule) (*workv1.ManifestWorkList, error) {
+	return mwg.getOwnedManifestWorks(ctx, mcm)
 }
 
 func (mwg *manifestWorkGenerator) SetManifestWorkAsDesired(ctx context.Context, mw *workv1.ManifestWork, mcm hubv1beta1.ManagedClusterModule) error {

--- a/internal/manifestwork/manifestwork_test.go
+++ b/internal/manifestwork/manifestwork_test.go
@@ -88,7 +88,66 @@ var _ = Describe("GarbageCollect", func() {
 		err := mwc.GarbageCollect(context.Background(), clusterList, mcm)
 		Expect(err).NotTo(HaveOccurred())
 	})
+})
 
+var _ = Describe("GetOwnedManifestWorks", func() {
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+	})
+
+	ctx := context.Background()
+
+	It("should work as expected", func() {
+		mcm := hubv1beta1.ManagedClusterModule{
+			Spec: hubv1beta1.ManagedClusterModuleSpec{
+				ModuleSpec: kmmv1beta1.ModuleSpec{
+					Selector: map[string]string{"key": "value"},
+				},
+			},
+		}
+
+		clusterList := clusterv1.ManagedClusterList{
+			Items: []clusterv1.ManagedCluster{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "default",
+						Labels: map[string]string{"key": "value"},
+					},
+				},
+			},
+		}
+
+		mw := workv1.ManifestWork{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: clusterList.Items[0].Name,
+				Labels: map[string]string{
+					constants.ManagedClusterModuleNameLabel: mcm.Name,
+				},
+			},
+		}
+
+		manifestWorkList := workv1.ManifestWorkList{
+			Items: []workv1.ManifestWork{mw},
+		}
+
+		gomock.InOrder(
+			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ interface{}, list *workv1.ManifestWorkList, _ ...interface{}) error {
+					list.Items = manifestWorkList.Items
+					return nil
+				},
+			),
+		)
+
+		mwc := NewCreator(clnt, scheme)
+
+		ownedManifestWorks, err := mwc.GetOwnedManifestWorks(context.Background(), mcm)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ownedManifestWorks.Items).NotTo(BeEmpty())
+		Expect(ownedManifestWorks.Items).To(Equal(manifestWorkList.Items))
+	})
 })
 
 var _ = Describe("SetManifestWorkAsDesired", func() {

--- a/internal/manifestwork/mock_manifestwork.go
+++ b/internal/manifestwork/mock_manifestwork.go
@@ -51,6 +51,21 @@ func (mr *MockManifestWorkCreatorMockRecorder) GarbageCollect(ctx, clusters, mcm
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockManifestWorkCreator)(nil).GarbageCollect), ctx, clusters, mcm)
 }
 
+// GetOwnedManifestWorks mocks base method.
+func (m *MockManifestWorkCreator) GetOwnedManifestWorks(ctx context.Context, mcm v1beta1.ManagedClusterModule) (*v10.ManifestWorkList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOwnedManifestWorks", ctx, mcm)
+	ret0, _ := ret[0].(*v10.ManifestWorkList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOwnedManifestWorks indicates an expected call of GetOwnedManifestWorks.
+func (mr *MockManifestWorkCreatorMockRecorder) GetOwnedManifestWorks(ctx, mcm interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOwnedManifestWorks", reflect.TypeOf((*MockManifestWorkCreator)(nil).GetOwnedManifestWorks), ctx, mcm)
+}
+
 // SetManifestWorkAsDesired mocks base method.
 func (m *MockManifestWorkCreator) SetManifestWorkAsDesired(ctx context.Context, mw *v10.ManifestWork, mcm v1beta1.ManagedClusterModule) error {
 	m.ctrl.T.Helper()

--- a/internal/statusupdater/mock_statusupdater.go
+++ b/internal/statusupdater/mock_statusupdater.go
@@ -9,10 +9,12 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	v1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api-hub/v1beta1"
+	v1beta10 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	v1 "k8s.io/api/apps/v1"
 	v10 "k8s.io/api/core/v1"
 	sets "k8s.io/apimachinery/pkg/util/sets"
+	v11 "open-cluster-management.io/api/work/v1"
 )
 
 // MockModuleStatusUpdater is a mock of ModuleStatusUpdater interface.
@@ -39,7 +41,7 @@ func (m *MockModuleStatusUpdater) EXPECT() *MockModuleStatusUpdaterMockRecorder 
 }
 
 // ModuleUpdateStatus mocks base method.
-func (m *MockModuleStatusUpdater) ModuleUpdateStatus(ctx context.Context, mod *v1beta1.Module, kernelMappingNodes, targetedNodes []v10.Node, dsByKernelVersion map[string]*v1.DaemonSet) error {
+func (m *MockModuleStatusUpdater) ModuleUpdateStatus(ctx context.Context, mod *v1beta10.Module, kernelMappingNodes, targetedNodes []v10.Node, dsByKernelVersion map[string]*v1.DaemonSet) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ModuleUpdateStatus", ctx, mod, kernelMappingNodes, targetedNodes, dsByKernelVersion)
 	ret0, _ := ret[0].(error)
@@ -50,6 +52,43 @@ func (m *MockModuleStatusUpdater) ModuleUpdateStatus(ctx context.Context, mod *v
 func (mr *MockModuleStatusUpdaterMockRecorder) ModuleUpdateStatus(ctx, mod, kernelMappingNodes, targetedNodes, dsByKernelVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ModuleUpdateStatus", reflect.TypeOf((*MockModuleStatusUpdater)(nil).ModuleUpdateStatus), ctx, mod, kernelMappingNodes, targetedNodes, dsByKernelVersion)
+}
+
+// MockManagedClusterModuleStatusUpdater is a mock of ManagedClusterModuleStatusUpdater interface.
+type MockManagedClusterModuleStatusUpdater struct {
+	ctrl     *gomock.Controller
+	recorder *MockManagedClusterModuleStatusUpdaterMockRecorder
+}
+
+// MockManagedClusterModuleStatusUpdaterMockRecorder is the mock recorder for MockManagedClusterModuleStatusUpdater.
+type MockManagedClusterModuleStatusUpdaterMockRecorder struct {
+	mock *MockManagedClusterModuleStatusUpdater
+}
+
+// NewMockManagedClusterModuleStatusUpdater creates a new mock instance.
+func NewMockManagedClusterModuleStatusUpdater(ctrl *gomock.Controller) *MockManagedClusterModuleStatusUpdater {
+	mock := &MockManagedClusterModuleStatusUpdater{ctrl: ctrl}
+	mock.recorder = &MockManagedClusterModuleStatusUpdaterMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockManagedClusterModuleStatusUpdater) EXPECT() *MockManagedClusterModuleStatusUpdaterMockRecorder {
+	return m.recorder
+}
+
+// ManagedClusterModuleUpdateStatus mocks base method.
+func (m *MockManagedClusterModuleStatusUpdater) ManagedClusterModuleUpdateStatus(ctx context.Context, mcm *v1beta1.ManagedClusterModule, ownedManifestWorks []v11.ManifestWork) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ManagedClusterModuleUpdateStatus", ctx, mcm, ownedManifestWorks)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ManagedClusterModuleUpdateStatus indicates an expected call of ManagedClusterModuleUpdateStatus.
+func (mr *MockManagedClusterModuleStatusUpdaterMockRecorder) ManagedClusterModuleUpdateStatus(ctx, mcm, ownedManifestWorks interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ManagedClusterModuleUpdateStatus", reflect.TypeOf((*MockManagedClusterModuleStatusUpdater)(nil).ManagedClusterModuleUpdateStatus), ctx, mcm, ownedManifestWorks)
 }
 
 // MockPreflightStatusUpdater is a mock of PreflightStatusUpdater interface.
@@ -76,7 +115,7 @@ func (m *MockPreflightStatusUpdater) EXPECT() *MockPreflightStatusUpdaterMockRec
 }
 
 // PreflightPresetStatuses mocks base method.
-func (m *MockPreflightStatusUpdater) PreflightPresetStatuses(ctx context.Context, pv *v1beta1.PreflightValidation, existingModules sets.String, newModules []string) error {
+func (m *MockPreflightStatusUpdater) PreflightPresetStatuses(ctx context.Context, pv *v1beta10.PreflightValidation, existingModules sets.String, newModules []string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PreflightPresetStatuses", ctx, pv, existingModules, newModules)
 	ret0, _ := ret[0].(error)
@@ -90,7 +129,7 @@ func (mr *MockPreflightStatusUpdaterMockRecorder) PreflightPresetStatuses(ctx, p
 }
 
 // PreflightSetVerificationStage mocks base method.
-func (m *MockPreflightStatusUpdater) PreflightSetVerificationStage(ctx context.Context, preflight *v1beta1.PreflightValidation, moduleName, stage string) error {
+func (m *MockPreflightStatusUpdater) PreflightSetVerificationStage(ctx context.Context, preflight *v1beta10.PreflightValidation, moduleName, stage string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PreflightSetVerificationStage", ctx, preflight, moduleName, stage)
 	ret0, _ := ret[0].(error)
@@ -104,7 +143,7 @@ func (mr *MockPreflightStatusUpdaterMockRecorder) PreflightSetVerificationStage(
 }
 
 // PreflightSetVerificationStatus mocks base method.
-func (m *MockPreflightStatusUpdater) PreflightSetVerificationStatus(ctx context.Context, preflight *v1beta1.PreflightValidation, moduleName, verificationStatus, message string) error {
+func (m *MockPreflightStatusUpdater) PreflightSetVerificationStatus(ctx context.Context, preflight *v1beta10.PreflightValidation, moduleName, verificationStatus, message string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PreflightSetVerificationStatus", ctx, preflight, moduleName, verificationStatus, message)
 	ret0, _ := ret[0].(error)
@@ -141,7 +180,7 @@ func (m *MockPreflightOCPStatusUpdater) EXPECT() *MockPreflightOCPStatusUpdaterM
 }
 
 // PreflightOCPUpdateStatus mocks base method.
-func (m *MockPreflightOCPStatusUpdater) PreflightOCPUpdateStatus(ctx context.Context, pvo *v1beta1.PreflightValidationOCP, pv *v1beta1.PreflightValidation) error {
+func (m *MockPreflightOCPStatusUpdater) PreflightOCPUpdateStatus(ctx context.Context, pvo *v1beta10.PreflightValidationOCP, pv *v1beta10.PreflightValidation) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PreflightOCPUpdateStatus", ctx, pvo, pv)
 	ret0, _ := ret[0].(error)

--- a/internal/statusupdater/statusupdater.go
+++ b/internal/statusupdater/statusupdater.go
@@ -5,14 +5,17 @@ import (
 	"fmt"
 	"time"
 
-	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/daemonset"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/metrics"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	workv1 "open-cluster-management.io/api/work/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	hubv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api-hub/v1beta1"
+	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/daemonset"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/metrics"
 )
 
 //go:generate mockgen -source=statusupdater.go -package=statusupdater -destination=mock_statusupdater.go
@@ -20,6 +23,13 @@ import (
 type ModuleStatusUpdater interface {
 	ModuleUpdateStatus(ctx context.Context, mod *kmmv1beta1.Module, kernelMappingNodes []v1.Node,
 		targetedNodes []v1.Node, dsByKernelVersion map[string]*appsv1.DaemonSet) error
+}
+
+//go:generate mockgen -source=statusupdater.go -package=statusupdater -destination=mock_statusupdater.go
+
+type ManagedClusterModuleStatusUpdater interface {
+	ManagedClusterModuleUpdateStatus(ctx context.Context, mcm *hubv1beta1.ManagedClusterModule,
+		ownedManifestWorks []workv1.ManifestWork) error
 }
 
 //go:generate mockgen -source=statusupdater.go -package=statusupdater -destination=mock_statusupdater.go
@@ -42,6 +52,10 @@ type moduleStatusUpdater struct {
 	metricsAPI metrics.Metrics
 }
 
+type managedClusterModuleStatusUpdater struct {
+	client client.Client
+}
+
 type preflightStatusUpdater struct {
 	client client.Client
 }
@@ -54,6 +68,12 @@ func NewModuleStatusUpdater(client client.Client, metricsAPI metrics.Metrics) Mo
 	return &moduleStatusUpdater{
 		client:     client,
 		metricsAPI: metricsAPI,
+	}
+}
+
+func NewManagedClusterModuleStatusUpdater(client client.Client) ManagedClusterModuleStatusUpdater {
+	return &managedClusterModuleStatusUpdater{
+		client: client,
 	}
 }
 
@@ -96,6 +116,33 @@ func (m *moduleStatusUpdater) ModuleUpdateStatus(ctx context.Context,
 	}
 	m.updateMetrics(ctx, mod, dsByKernelVersion)
 	return m.client.Status().Update(ctx, mod)
+}
+
+func (m *managedClusterModuleStatusUpdater) ManagedClusterModuleUpdateStatus(ctx context.Context,
+	mcm *hubv1beta1.ManagedClusterModule,
+	ownedManifestWorks []workv1.ManifestWork) error {
+
+	var numApplied int32
+	var numDegraded int32
+	for _, mw := range ownedManifestWorks {
+		for _, condition := range mw.Status.Conditions {
+			if condition.Status != metav1.ConditionTrue {
+				continue
+			}
+
+			switch condition.Type {
+			case workv1.WorkApplied:
+				numApplied += 1
+			case workv1.WorkDegraded:
+				numDegraded += 1
+			}
+		}
+	}
+	mcm.Status.NumberDesired = int32(len(ownedManifestWorks))
+	mcm.Status.NumberApplied = numApplied
+	mcm.Status.NumberDegraded = numDegraded
+
+	return m.client.Status().Update(ctx, mcm)
 }
 
 func (p *preflightStatusUpdater) PreflightPresetStatuses(ctx context.Context,

--- a/internal/statusupdater/statusupdater_test.go
+++ b/internal/statusupdater/statusupdater_test.go
@@ -7,14 +7,18 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/daemonset"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/metrics"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	workv1 "open-cluster-management.io/api/work/v1"
+
+	hubv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api-hub/v1beta1"
+	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/daemonset"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/metrics"
 )
 
 type daemonSetConfig struct {
@@ -115,6 +119,85 @@ var _ = Describe("module status update", func() {
 			true,
 		),
 	)
+})
+
+var _ = Describe("ManagedClusterModule status update", func() {
+	const (
+		name = "mcm-name"
+	)
+
+	var (
+		ctrl *gomock.Controller
+		clnt *client.MockClient
+		mcm  *hubv1beta1.ManagedClusterModule
+		su   ManagedClusterModuleStatusUpdater
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		mcm = &hubv1beta1.ManagedClusterModule{ObjectMeta: metav1.ObjectMeta{Name: name}}
+		su = NewManagedClusterModuleStatusUpdater(clnt)
+	})
+
+	It("", func() {
+		statusWrite := client.NewMockStatusWriter(ctrl)
+		clnt.EXPECT().Status().Return(statusWrite)
+		statusWrite.EXPECT().Update(context.Background(), mcm).Return(nil)
+
+		mw := workv1.ManifestWork{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "a-namespace",
+				Labels: map[string]string{
+					constants.ManagedClusterModuleNameLabel: mcm.Name,
+				},
+			},
+			Status: workv1.ManifestWorkStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   workv1.WorkApplied,
+						Status: metav1.ConditionTrue,
+					},
+					{
+						Type:   workv1.WorkDegraded,
+						Status: metav1.ConditionFalse,
+					},
+				},
+			},
+		}
+		degradedMW := workv1.ManifestWork{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-degraded",
+				Namespace: "another-namespace",
+				Labels: map[string]string{
+					constants.ManagedClusterModuleNameLabel: mcm.Name,
+				},
+			},
+			Status: workv1.ManifestWorkStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:   workv1.WorkApplied,
+						Status: metav1.ConditionFalse,
+					},
+					{
+						Type:   workv1.WorkDegraded,
+						Status: metav1.ConditionTrue,
+					},
+				},
+			},
+		}
+		manifestWorkList := workv1.ManifestWorkList{
+			Items: []workv1.ManifestWork{mw, degradedMW},
+		}
+
+		res := su.ManagedClusterModuleUpdateStatus(context.Background(), mcm, manifestWorkList.Items)
+
+		Expect(res).To(BeNil())
+		Expect(mcm.Status.NumberDesired).To(BeEquivalentTo(len(manifestWorkList.Items)))
+		Expect(mcm.Status.NumberApplied).To(BeEquivalentTo(1))
+		Expect(mcm.Status.NumberDegraded).To(BeEquivalentTo(1))
+	})
 })
 
 var _ = Describe("preflight status updates", func() {


### PR DESCRIPTION
This change adds the implementation of the `ManagedClusterModuleStatus`. The latter reflects the number of desired, applied and degraded `ManifestWork` CRs owned by the respective `ManagedClusterModule` CR.

Fixes #347
/cc @mresvanis 