### PR TITLE
Adding back the build-secret to the e2e test. (#232)

### DIFF
--- a/ci/kmm-kmod-dockerfile.yaml
+++ b/ci/kmm-kmod-dockerfile.yaml
@@ -13,6 +13,8 @@ data:
 
     WORKDIR /usr/src
 
+    RUN grep super-secret-value /run/secrets/build-secret/ci-build-secret
+
     RUN git clone https://github.com/rh-ecosystem-edge/kernel-module-management.git
 
     WORKDIR /usr/src/kernel-module-management/ci/kmm-kmod

--- a/ci/module-kmm-ci-build.yaml
+++ b/ci/module-kmm-ci-build.yaml
@@ -12,6 +12,8 @@ spec:
         - regexp: '^.+$'
           containerImage: image-registry.openshift-image-registry.svc:5000/default/kmm-kmod:$KERNEL_FULL_VERSION
           build:
+            secrets:
+              - name: build-secret
             dockerfileConfigMap:
               name: kmm-kmod-dockerfile
   selector:

--- a/ci/prow/e2e-incluster-build
+++ b/ci/prow/e2e-incluster-build
@@ -18,6 +18,9 @@ if oc debug node/${NODE} -- chroot host/ lsmod | grep kmm_ci_a; then
  exit 1
 fi
 
+echo "Create a build secret..."
+oc create secret generic build-secret --from-literal=ci-build-secret=super-secret-value
+
 echo "Add a configmap that contain the kernel module build dockerfile..."
 oc apply -f ci/kmm-kmod-dockerfile.yaml
 
@@ -30,10 +33,11 @@ echo "Waiting for the build pod to be created..."
 timeout 1m bash -c 'until oc get pods -o json | jq -er ".items[].metadata.name | select(.? | match(\"build\"))"; do sleep 1; done'
 POD_NAME=$(oc get pods -o json | jq -r '.items[].metadata.name | select(.? | match("build"))')
 
-# The build job/pod is deleted once done so we won't be able to get this info in the CI artifacts.
-echo "Print the build logs..."
-# we can't get the logs on a pod that isn't `Running` yet.
+# we can't exec a command nor get the logs on a pod that isn't `Running` yet.
 oc wait pod/${POD_NAME} --for jsonpath='{.status.phase}'=Running --timeout=60s
+
+# The build job/pod is deleted once done so we won't be able to get this info later on in the troubleshooting section.
+echo "Print the build logs..."
 oc logs pod/${POD_NAME} -f
 
 echo "Check that the module gets loaded on the node..."


### PR DESCRIPTION
The decision to remove it was a mistake. It was confused with
`imageRepoSecret`.

The build arg is supposed to be available to the `build` Dockerfile at
`/run/secrets/build-secret/filename`.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>

---

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/346
