### PR TITLE
Improve push/pull secret handling in signing (#352)

### DIFF
--- a/internal/sign/job/signer.go
+++ b/internal/sign/job/signer.go
@@ -64,7 +64,7 @@ func NewSigner(
 	}
 }
 
-func (m *signer) MakeJobTemplate(
+func (s *signer) MakeJobTemplate(
 	ctx context.Context,
 	mod kmmv1beta1.Module,
 	km kmmv1beta1.KernelMapping,
@@ -74,7 +74,7 @@ func (m *signer) MakeJobTemplate(
 	pushImage bool,
 	owner metav1.Object) (*batchv1.Job, error) {
 
-	signConfig, err := m.helper.GetRelevantSign(mod.Spec, km, targetKernel)
+	signConfig, err := s.helper.GetRelevantSign(mod.Spec, km, targetKernel)
 	if err != nil {
 		return nil, fmt.Errorf("calculate the signing parameters: %v", err)
 	}
@@ -126,10 +126,11 @@ func (m *signer) MakeJobTemplate(
 		utils.MakeSecretVolumeMount(signConfig.KeySecret, "/signingkey"),
 	}
 
-	if mod.Spec.ImageRepoSecret != nil {
-		args = append(args, "-pullsecret", "/docker_config/config.json")
-		volumes = append(volumes, utils.MakeSecretVolume(mod.Spec.ImageRepoSecret, v1.DockerConfigJsonKey, "config.json"))
-		volumeMounts = append(volumeMounts, utils.MakeSecretVolumeMount(mod.Spec.ImageRepoSecret, "/docker_config"))
+	args = append(args, "-secretdir", "/docker_config/")
+	imageSecret := mod.Spec.ImageRepoSecret
+	if imageSecret != nil {
+		volumes = append(volumes, utils.MakeSecretVolume(imageSecret, "", ""))
+		volumeMounts = append(volumeMounts, utils.MakeSecretVolumeMount(imageSecret, "/docker_config/"+imageSecret.Name))
 	}
 
 	specTemplate := v1.PodTemplateSpec{
@@ -148,7 +149,7 @@ func (m *signer) MakeJobTemplate(
 		},
 	}
 
-	specTemplateHash, err := m.getHashAnnotationValue(ctx, signConfig.KeySecret.Name, signConfig.CertSecret.Name, mod.Namespace, &specTemplate)
+	specTemplateHash, err := s.getHashAnnotationValue(ctx, signConfig.KeySecret.Name, signConfig.CertSecret.Name, mod.Namespace, &specTemplate)
 	if err != nil {
 		return nil, fmt.Errorf("could not hash job's definitions: %v", err)
 	}
@@ -166,7 +167,7 @@ func (m *signer) MakeJobTemplate(
 		},
 	}
 
-	if err := controllerutil.SetControllerReference(owner, job, m.scheme); err != nil {
+	if err := controllerutil.SetControllerReference(owner, job, s.scheme); err != nil {
 		return nil, fmt.Errorf("could not set the owner reference: %v", err)
 	}
 

--- a/internal/sign/job/signer_test.go
+++ b/internal/sign/job/signer_test.go
@@ -161,6 +161,7 @@ var _ = Describe("MakeJobTemplate", func() {
 									"-key", "/signingkey/key.priv",
 									"-cert", "/signingcert/public.der",
 									"-filestosign", filesToSign,
+									"-secretdir", "/docker_config/",
 								},
 								VolumeMounts: []v1.VolumeMount{secretMount, certMount},
 							},
@@ -175,14 +176,12 @@ var _ = Describe("MakeJobTemplate", func() {
 		}
 		if imagePullSecret != nil {
 			mod.Spec.ImageRepoSecret = imagePullSecret
-			expected.Spec.Template.Spec.Containers[0].Args = append(expected.Spec.Template.Spec.Containers[0].Args, "-pullsecret")
-			expected.Spec.Template.Spec.Containers[0].Args = append(expected.Spec.Template.Spec.Containers[0].Args, "/docker_config/config.json")
 			expected.Spec.Template.Spec.Containers[0].VolumeMounts =
 				append(expected.Spec.Template.Spec.Containers[0].VolumeMounts,
 					v1.VolumeMount{
 						Name:      "secret-pull-push-secret",
 						ReadOnly:  true,
-						MountPath: "/docker_config",
+						MountPath: "/docker_config/pull-push-secret",
 					},
 				)
 
@@ -193,12 +192,6 @@ var _ = Describe("MakeJobTemplate", func() {
 						VolumeSource: v1.VolumeSource{
 							Secret: &v1.SecretVolumeSource{
 								SecretName: "pull-push-secret",
-								Items: []v1.KeyToPath{
-									{
-										Key:  v1.DockerConfigJsonKey,
-										Path: "config.json",
-									},
-								},
 							},
 						},
 					},

--- a/internal/utils/volume_helper.go
+++ b/internal/utils/volume_helper.go
@@ -9,20 +9,25 @@ func MakeSecretVolume(secretRef *v1.LocalObjectReference, key string, path strin
 		return v1.Volume{}
 	}
 
-	return v1.Volume{
+	vol := v1.Volume{
 		Name: volumeNameFromSecretRef(*secretRef),
 		VolumeSource: v1.VolumeSource{
 			Secret: &v1.SecretVolumeSource{
 				SecretName: secretRef.Name,
-				Items: []v1.KeyToPath{
-					{
-						Key:  key,
-						Path: path,
-					},
-				},
 			},
 		},
 	}
+
+	if key != "" {
+		vol.VolumeSource.Secret.Items = []v1.KeyToPath{
+			{
+				Key:  key,
+				Path: path,
+			},
+		}
+	}
+
+	return vol
 }
 
 func MakeSecretVolumeMount(secretRef *v1.LocalObjectReference, mountPath string) v1.VolumeMount {


### PR DESCRIPTION
Fixes #352

> Improve push/pull secret handling in signing
> 
> Re-work secret handling for pulling and pushing images Add support for dockerconfigjson and dockercfg style
> secrets Add support for multiple keys in a single secret (useful for pulling and pushing to different registries)
> 
> This also sets the stage for allowing service account secrets
> 
> We do this by mounting secrets in their own directories then reading all the files (keys) in that dir