### PR TITLE
Adjust ManagedClusterModuleReconciler ManagedCluster watch predicate

### DIFF
--- a/controllers/hub/managedclustermodule_reconciler.go
+++ b/controllers/hub/managedclustermodule_reconciler.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	hubv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api-hub/v1beta1"
@@ -167,7 +166,10 @@ func (r *ManagedClusterModuleReconciler) SetupWithManager(mgr ctrl.Manager) erro
 		Watches(
 			&source.Kind{Type: &clusterv1.ManagedCluster{}},
 			handler.EnqueueRequestsFromMapFunc(r.filter.FindManagedClusterModulesForCluster),
-			builder.WithPredicates(predicate.LabelChangedPredicate{})).
+			builder.WithPredicates(
+				r.filter.ManagedClusterModuleReconcilerManagedClusterPredicate(),
+			),
+		).
 		Named(ManagedClusterModuleReconcilerName).
 		Complete(r)
 }

--- a/controllers/node_kernel_clusterclaim.go
+++ b/controllers/node_kernel_clusterclaim.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/filter"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"open-cluster-management.io/api/cluster/v1alpha1"
@@ -19,6 +18,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/filter"
 )
 
 //+kubebuilder:rbac:groups="core",resources=nodes,verbs=get;patch;list;watch
@@ -26,8 +28,6 @@ import (
 //+kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,resourceNames=kernel-versions.kmm.node.kubernetes.io,verbs=delete;patch;update
 
 const (
-	clusterClaimName = "kernel-versions.kmm.node.kubernetes.io"
-
 	NodeKernelClusterClaimReconcilerName = "NodeKernelClusterClaim"
 )
 
@@ -68,7 +68,7 @@ func (r *NodeKernelClusterClaimReconciler) Reconcile(ctx context.Context, req ct
 	sort.Strings(kernelsSlice)
 
 	cc := v1alpha1.ClusterClaim{
-		ObjectMeta: metav1.ObjectMeta{Name: clusterClaimName},
+		ObjectMeta: metav1.ObjectMeta{Name: constants.KernelVersionsClusterClaimName},
 	}
 
 	logger.Info("Creating or patching ClusterClaim")
@@ -109,7 +109,7 @@ func (r *NodeKernelClusterClaimReconciler) SetupWithManager(mgr ctrl.Manager) er
 			}),
 			builder.WithPredicates(
 				predicate.NewPredicateFuncs(func(object client.Object) bool {
-					return object.GetName() == clusterClaimName
+					return object.GetName() == constants.KernelVersionsClusterClaimName
 				}),
 			),
 		).

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -16,12 +16,9 @@ import (
 	hubv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api-hub/v1beta1"
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/build"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/module"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/sign"
-)
-
-const (
-	clusterClaimName = "kernel-versions.kmm.node.kubernetes.io"
 )
 
 //go:generate mockgen -source=cluster.go -package=cluster -destination=mock_cluster.go
@@ -188,7 +185,7 @@ func (c *clusterAPI) kernelMappingsByKernelVersion(
 
 func (c *clusterAPI) kernelVersions(cluster clusterv1.ManagedCluster) ([]string, error) {
 	for _, clusterClaim := range cluster.Status.ClusterClaims {
-		if clusterClaim.Name != clusterClaimName {
+		if clusterClaim.Name != constants.KernelVersionsClusterClaimName {
 			continue
 		}
 		return strings.Split(clusterClaim.Value, "\n"), nil

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -16,6 +16,7 @@ import (
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/build"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/module"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/sign"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
@@ -195,7 +196,7 @@ var _ = Describe("ClusterAPI", func() {
 						Status: clusterv1.ManagedClusterStatus{
 							ClusterClaims: []clusterv1.ManagedClusterClaim{
 								{
-									Name:  clusterClaimName,
+									Name:  constants.KernelVersionsClusterClaimName,
 									Value: kernelVersion,
 								},
 							},
@@ -300,7 +301,7 @@ var _ = Describe("ClusterAPI", func() {
 						Status: clusterv1.ManagedClusterStatus{
 							ClusterClaims: []clusterv1.ManagedClusterClaim{
 								{
-									Name:  clusterClaimName,
+									Name:  constants.KernelVersionsClusterClaimName,
 									Value: kernelVersion,
 								},
 							},
@@ -371,7 +372,7 @@ var _ = Describe("ClusterAPI", func() {
 						Status: clusterv1.ManagedClusterStatus{
 							ClusterClaims: []clusterv1.ManagedClusterClaim{
 								{
-									Name:  clusterClaimName,
+									Name:  constants.KernelVersionsClusterClaimName,
 									Value: kernelVersion,
 								},
 							},
@@ -443,7 +444,7 @@ var _ = Describe("ClusterAPI", func() {
 						Status: clusterv1.ManagedClusterStatus{
 							ClusterClaims: []clusterv1.ManagedClusterClaim{
 								{
-									Name:  clusterClaimName,
+									Name:  constants.KernelVersionsClusterClaimName,
 									Value: kernelVersion,
 								},
 							},
@@ -514,7 +515,7 @@ var _ = Describe("ClusterAPI", func() {
 						Status: clusterv1.ManagedClusterStatus{
 							ClusterClaims: []clusterv1.ManagedClusterClaim{
 								{
-									Name:  clusterClaimName,
+									Name:  constants.KernelVersionsClusterClaimName,
 									Value: kernelVersion,
 								},
 							},
@@ -586,7 +587,7 @@ var _ = Describe("ClusterAPI", func() {
 						Status: clusterv1.ManagedClusterStatus{
 							ClusterClaims: []clusterv1.ManagedClusterClaim{
 								{
-									Name:  clusterClaimName,
+									Name:  constants.KernelVersionsClusterClaimName,
 									Value: kernelVersion,
 								},
 							},
@@ -658,7 +659,7 @@ var _ = Describe("ClusterAPI", func() {
 						Status: clusterv1.ManagedClusterStatus{
 							ClusterClaims: []clusterv1.ManagedClusterClaim{
 								{
-									Name:  clusterClaimName,
+									Name:  constants.KernelVersionsClusterClaimName,
 									Value: kernelVersion,
 								},
 							},
@@ -730,7 +731,7 @@ var _ = Describe("ClusterAPI", func() {
 						Status: clusterv1.ManagedClusterStatus{
 							ClusterClaims: []clusterv1.ManagedClusterClaim{
 								{
-									Name:  clusterClaimName,
+									Name:  constants.KernelVersionsClusterClaimName,
 									Value: kernelVersion,
 								},
 							},

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -10,8 +10,9 @@ const (
 	JobHashAnnotation            = "kmm.node.kubernetes.io/last-hash"
 	KernelLabel                  = "kmm.node.kubernetes.io/kernel-version.full"
 
-	ManagedClusterModuleNameLabel = "kmm.node.kubernetes.io/managedclustermodule.name"
-	DockerfileCMKey               = "dockerfile"
-	PublicSignDataKey             = "cert"
-	PrivateSignDataKey            = "key"
+	ManagedClusterModuleNameLabel  = "kmm.node.kubernetes.io/managedclustermodule.name"
+	KernelVersionsClusterClaimName = "kernel-versions.kmm.node.kubernetes.io"
+	DockerfileCMKey                = "dockerfile"
+	PublicSignDataKey              = "cert"
+	PrivateSignDataKey             = "key"
 )

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -6,17 +6,20 @@ import (
 
 	"github.com/go-logr/logr"
 	imagev1 "github.com/openshift/api/image/v1"
-	hubv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api-hub/v1beta1"
-	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubectl/pkg/util/podutils"
+	clusterv1 "open-cluster-management.io/api/cluster/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	hubv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api-hub/v1beta1"
+	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 )
 
 func HasLabel(label string) predicate.Predicate {
@@ -27,6 +30,37 @@ func HasLabel(label string) predicate.Predicate {
 
 var skipDeletions predicate.Predicate = predicate.Funcs{
 	DeleteFunc: func(_ event.DeleteEvent) bool { return false },
+}
+
+var kmmClusterClaimChanged predicate.Predicate = predicate.Funcs{
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		oldManagedCluster, ok := e.ObjectOld.(*clusterv1.ManagedCluster)
+		if !ok {
+			return false
+		}
+
+		newManagedCluster, ok := e.ObjectNew.(*clusterv1.ManagedCluster)
+		if !ok {
+			return false
+		}
+
+		newClusterClaim := clusterClaim(constants.KernelVersionsClusterClaimName, newManagedCluster.Status.ClusterClaims)
+		if newClusterClaim == nil {
+			return false
+		}
+		oldClusterClaim := clusterClaim(constants.KernelVersionsClusterClaimName, oldManagedCluster.Status.ClusterClaims)
+
+		return !reflect.DeepEqual(newClusterClaim, oldClusterClaim)
+	},
+}
+
+func clusterClaim(name string, clusterClaims []clusterv1.ManagedClusterClaim) *clusterv1.ManagedClusterClaim {
+	for _, clusterClaim := range clusterClaims {
+		if clusterClaim.Name == name {
+			return &clusterClaim
+		}
+	}
+	return nil
 }
 
 type Filter struct {
@@ -205,6 +239,13 @@ func (f *Filter) FindManagedClusterModulesForCluster(cluster client.Object) []re
 	logger.V(1).Info("New requests", "requests", reqs)
 
 	return reqs
+}
+
+func (f *Filter) ManagedClusterModuleReconcilerManagedClusterPredicate() predicate.Predicate {
+	return predicate.Or(
+		predicate.LabelChangedPredicate{},
+		kmmClusterClaimChanged,
+	)
 }
 
 func (f *Filter) EnqueueAllPreflightValidations(mod client.Object) []reconcile.Request {

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -3,10 +3,11 @@ package filter
 import (
 	"context"
 
-	"github.com/go-logr/logr"
-	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/go-logr/logr"
+	"github.com/golang/mock/gomock"
 	imagev1 "github.com/openshift/api/image/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -21,6 +22,7 @@ import (
 	hubv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api-hub/v1beta1"
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	mockClient "github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 )
 
 var (
@@ -65,6 +67,47 @@ var _ = Describe("skipDeletions", func() {
 			BeFalse(),
 		)
 	})
+})
+
+var _ = Describe("kmmClusterClaimChanged", func() {
+	updateFunc := kmmClusterClaimChanged.Update
+
+	managedCluster1 := clusterv1.ManagedCluster{
+		Status: clusterv1.ManagedClusterStatus{
+			ClusterClaims: []clusterv1.ManagedClusterClaim{
+				{
+					Name:  constants.KernelVersionsClusterClaimName,
+					Value: "a-kernel-version",
+				},
+			},
+		},
+	}
+	managedCluster2 := clusterv1.ManagedCluster{
+		Status: clusterv1.ManagedClusterStatus{
+			ClusterClaims: []clusterv1.ManagedClusterClaim{
+				{
+					Name:  constants.KernelVersionsClusterClaimName,
+					Value: "another-kernel-version",
+				},
+			},
+		},
+	}
+
+	DescribeTable(
+		"should work as expected",
+		func(updateEvent event.UpdateEvent, expectedResult bool) {
+			Expect(
+				updateFunc(updateEvent),
+			).To(
+				Equal(expectedResult),
+			)
+		},
+		Entry(nil, event.UpdateEvent{ObjectOld: &v1.Pod{}, ObjectNew: &clusterv1.ManagedCluster{}}, false),
+		Entry(nil, event.UpdateEvent{ObjectOld: &clusterv1.ManagedCluster{}, ObjectNew: &v1.Pod{}}, false),
+		Entry(nil, event.UpdateEvent{ObjectOld: &managedCluster1, ObjectNew: &clusterv1.ManagedCluster{}}, false),
+		Entry(nil, event.UpdateEvent{ObjectOld: &managedCluster1, ObjectNew: &managedCluster1}, false),
+		Entry(nil, event.UpdateEvent{ObjectOld: &managedCluster1, ObjectNew: &managedCluster2}, true),
+	)
 })
 
 var _ = Describe("ModuleReconcilerNodePredicate", func() {
@@ -461,6 +504,77 @@ var _ = Describe("FindManagedClusterModulesForCluster", func() {
 
 		reqs := p.FindManagedClusterModulesForCluster(&cluster)
 		Expect(reqs).To(Equal([]reconcile.Request{expectedReq}))
+	})
+})
+
+var _ = Describe("ManagedClusterModuleReconcilerManagedClusterPredicate", func() {
+	var p predicate.Predicate
+
+	BeforeEach(func() {
+		p = New(nil, logr.Discard()).ManagedClusterModuleReconcilerManagedClusterPredicate()
+	})
+
+	It("should return true for creations", func() {
+		ev := event.CreateEvent{
+			Object: &clusterv1.ManagedCluster{},
+		}
+
+		Expect(
+			p.Create(ev),
+		).To(
+			BeTrue(),
+		)
+	})
+
+	It("should return true for deletions", func() {
+		ev := event.DeleteEvent{
+			Object: &clusterv1.ManagedCluster{},
+		}
+
+		Expect(
+			p.Delete(ev),
+		).To(
+			BeTrue(),
+		)
+	})
+
+	It("should return true for label updates", func() {
+		ev := event.UpdateEvent{
+			ObjectOld: &clusterv1.ManagedCluster{},
+			ObjectNew: &clusterv1.ManagedCluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"key": "value"},
+				},
+			},
+		}
+
+		Expect(
+			p.Update(ev),
+		).To(
+			BeTrue(),
+		)
+	})
+
+	It("should return true for KMM ClusterClaim updates", func() {
+		ev := event.UpdateEvent{
+			ObjectOld: &clusterv1.ManagedCluster{},
+			ObjectNew: &clusterv1.ManagedCluster{
+				Status: clusterv1.ManagedClusterStatus{
+					ClusterClaims: []clusterv1.ManagedClusterClaim{
+						{
+							Name:  constants.KernelVersionsClusterClaimName,
+							Value: "a-kernel-version",
+						},
+					},
+				},
+			},
+		}
+
+		Expect(
+			p.Update(ev),
+		).To(
+			BeTrue(),
+		)
 	})
 })
 


### PR DESCRIPTION
This change updates the ManagedClusterModule reconciler's ManagedCluster watch predicate, in order to enqueue update events of changed KMM ClusterClaims. This way whenever a new kernel version is available on a ManagedCluster, the ManagedClusterModule reconciler will reconcile the affected ManagedClusterModules.

Signed-off-by: Michail Resvanis <mresvani@redhat.com>

Upstream-Commit: d5bfacd648598dd2b6559c52b00f2073b86b9b71