### PR TITLE
Adjust KMM-Hub Makefile rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,11 @@ bundle-hub: operator-sdk manifests kustomize ## Generate bundle manifests and me
 	SUFFIX="-hub" \
 	./hack/generate-bundle
 
-	${OPERATOR_SDK} bundle validate ./bundle
+	${OPERATOR_SDK} bundle validate ./bundle-hub
+
+.PHONY: bundle-build-hub
+bundle-build-hub: ## Build the bundle-hub image.
+	docker build -f bundle-hub.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.


### PR DESCRIPTION
This changes adds a helper Makefile rule to build the KMM-Hub bundle container image and fixes the `bundle-hub` rule to validate the correct `./bundle-hub` directory.

Signed-off-by: Michail Resvanis <mresvani@redhat.com>

/cc @qbarrand 