### PR TITLE
log error if sign-file fails (cherry-pick/minor discrepancy fix)  #359

### DIFF
--- a/cmd/signimage/signimage.go
+++ b/cmd/signimage/signimage.go
@@ -214,7 +214,7 @@ func processFile(filename string, header *tar.Header, tarreader io.Reader, data 
 		//sign it
 		err = signFile(kmodsToSign[canonfilename], pubKeyFile, privKeyFile)
 		if err != nil {
-			return fmt.Errorf("error signing file %s: %w", canonfilename, err)
+			return fmt.Errorf("error signing file %s: %v", canonfilename, err)
 		}
 		logger.Info("Signed successfully", "kmod", canonfilename)
 		return nil


### PR DESCRIPTION
Fixes #359 

(this fixes a small discrepancy between upstream and midstream in favour of upstream)

> log error if sign-file fails (#237)
> 
> the error from the sign-file binary was getting lost because it wasn't returned through the stack call correctly. 
> This commit fixes that by passing the message up.
> 
> Also remove a couple of commented out code lines.