### PR TITLE
Configuring sign job backoff and restart policies (#250)

### DIFF
--- a/internal/sign/job/signer.go
+++ b/internal/sign/job/signer.go
@@ -217,7 +217,7 @@ func (s *signer) MakeJobTemplate(
 					VolumeMounts: volumeMounts,
 				},
 			},
-			RestartPolicy: v1.RestartPolicyOnFailure,
+			RestartPolicy: v1.RestartPolicyNever,
 			Volumes:       volumes,
 			NodeSelector:  mod.Spec.Selector,
 		},
@@ -236,8 +236,9 @@ func (s *signer) MakeJobTemplate(
 			Annotations:  map[string]string{constants.JobHashAnnotation: fmt.Sprintf("%d", specTemplateHash)},
 		},
 		Spec: batchv1.JobSpec{
-			Completions: pointer.Int32(1),
-			Template:    specTemplate,
+			Completions:  pointer.Int32(1),
+			Template:     specTemplate,
+			BackoffLimit: pointer.Int32(0),
 		},
 	}
 

--- a/internal/sign/job/signer_test.go
+++ b/internal/sign/job/signer_test.go
@@ -192,7 +192,8 @@ var _ = Describe("MakeJobTemplate", func() {
 				},
 			},
 			Spec: batchv1.JobSpec{
-				Completions: pointer.Int32(1),
+				Completions:  pointer.Int32(1),
+				BackoffLimit: pointer.Int32(0),
 				Template: v1.PodTemplateSpec{
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{
@@ -217,7 +218,7 @@ var _ = Describe("MakeJobTemplate", func() {
 							},
 						},
 						NodeSelector:  nodeSelector,
-						RestartPolicy: v1.RestartPolicyOnFailure,
+						RestartPolicy: v1.RestartPolicyNever,
 
 						Volumes: []v1.Volume{keysecret, certsecret, trustedCA},
 					},


### PR DESCRIPTION
In the default configuration, once the failed container of the pod is restarted 6 times, and after the final failure it is deleted. This PR changes the policy to never restart, and the backoff limit to 0, meaning that after first failure, the pod/container won't be restarted, but the failed pod itself will be kept in the cluster for future debugging

Upstream-Commit: 35b5cf24b4e6f2c4ea0e52c2511eae828d984ef1