### PR TITLE
Add GarbageCollector for successful Sign job

### DIFF
--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -426,6 +426,14 @@ func (r *ModuleReconciler) garbageCollect(ctx context.Context,
 
 	logger.Info("Garbage-collected Build objects", "names", deleted)
 
+	// Garbage collect for successfully finished sign jobs
+	deleted, err = r.signAPI.GarbageCollect(ctx, mod.Name, mod.Namespace, mod)
+	if err != nil {
+		return fmt.Errorf("could not garbage collect sign objects: %v", err)
+	}
+
+	logger.Info("Garbage-collected Sign objects", "names", deleted)
+
 	return nil
 }
 

--- a/controllers/module_reconciler_test.go
+++ b/controllers/module_reconciler_test.go
@@ -208,6 +208,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			mockDC.EXPECT().ModuleDaemonSetsByKernelVersion(ctx, moduleName, namespace).Return(dsByKernelVersion, nil),
 			mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString()),
 			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace, &mod),
+			mockSM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace, &mod),
 			mockSU.EXPECT().ModuleUpdateStatus(ctx, &mod, []v1.Node{}, []v1.Node{}, dsByKernelVersion).Return(nil),
 		)
 
@@ -275,6 +276,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			mockDC.EXPECT().ModuleDaemonSetsByKernelVersion(ctx, moduleName, namespace).Return(dsByKernelVersion, nil),
 			mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString()),
 			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace, &mod),
+			mockSM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace, &mod),
 			mockSU.EXPECT().ModuleUpdateStatus(ctx, &mod, []v1.Node{}, []v1.Node{}, dsByKernelVersion).Return(nil),
 		)
 
@@ -352,6 +354,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			mockDC.EXPECT().ModuleDaemonSetsByKernelVersion(ctx, moduleName, namespace).Return(dsByKernelVersion, nil),
 			mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString()),
 			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace, &mod),
+			mockSM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace, &mod),
 			mockSU.EXPECT().ModuleUpdateStatus(ctx, &mod, []v1.Node{}, []v1.Node{}, dsByKernelVersion).Return(nil),
 		)
 
@@ -463,6 +466,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			mockMetrics.EXPECT().SetCompletedStage(moduleName, namespace, kernelVersion, metrics.ModuleLoaderStage, false),
 			mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString(kernelVersion)),
 			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace, &mod),
+			mockSM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace, &mod),
 			mockSU.EXPECT().ModuleUpdateStatus(ctx, &mod, nodeList.Items, nodeList.Items, dsByKernelVersion).Return(nil),
 		)
 
@@ -587,6 +591,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 				}),
 			mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString(kernelVersion)),
 			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace, &mod),
+			mockSM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace, &mod),
 			mockSU.EXPECT().ModuleUpdateStatus(ctx, &mod, nodeList.Items, nodeList.Items, dsByKernelVersion).Return(nil),
 		)
 
@@ -679,6 +684,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			mockMetrics.EXPECT().SetCompletedStage(moduleName, namespace, "", metrics.DevicePluginStage, false),
 			mockDC.EXPECT().GarbageCollect(ctx, nil, sets.NewString()),
 			mockBM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace, &mod),
+			mockSM.EXPECT().GarbageCollect(ctx, mod.Name, mod.Namespace, &mod),
 			mockSU.EXPECT().ModuleUpdateStatus(ctx, &mod, []v1.Node{}, []v1.Node{}, nil).Return(nil),
 		)
 

--- a/internal/sign/job/manager_test.go
+++ b/internal/sign/job/manager_test.go
@@ -3,6 +3,7 @@ package signjob
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -19,363 +20,417 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 )
 
-var _ = Describe("JobManager", func() {
-	Describe("ShouldSync", func() {
-		var (
-			ctrl        *gomock.Controller
-			authFactory *auth.MockRegistryAuthGetterFactory
-			reg         *registry.MockRegistry
-		)
+var _ = Describe("ShouldSync", func() {
+	var (
+		ctrl        *gomock.Controller
+		authFactory *auth.MockRegistryAuthGetterFactory
+		reg         *registry.MockRegistry
+		mgr         *signJobManager
+	)
 
-		const (
-			moduleName    = "module-name"
-			imageName     = "image-name"
-			namespace     = "some-namespace"
-			kernelVersion = "1.2.3"
-		)
+	const (
+		moduleName    = "module-name"
+		imageName     = "image-name"
+		namespace     = "some-namespace"
+		kernelVersion = "1.2.3"
+	)
 
-		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
-			authFactory = auth.NewMockRegistryAuthGetterFactory(ctrl)
-			reg = registry.NewMockRegistry(ctrl)
-		})
-
-		It("should return false if there was not sign section", func() {
-			ctx := context.Background()
-
-			mod := kmmv1beta1.Module{}
-			km := kmmv1beta1.KernelMapping{}
-
-			mgr := NewSignJobManager(nil, nil, authFactory, reg)
-
-			shouldSync, err := mgr.ShouldSync(ctx, mod, km)
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(shouldSync).To(BeFalse())
-		})
-
-		It("should return false if image already exists", func() {
-			ctx := context.Background()
-
-			km := kmmv1beta1.KernelMapping{
-				Sign:           &kmmv1beta1.Sign{},
-				ContainerImage: imageName,
-			}
-
-			mod := kmmv1beta1.Module{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      moduleName,
-					Namespace: namespace,
-				},
-				Spec: kmmv1beta1.ModuleSpec{
-					ImageRepoSecret: &v1.LocalObjectReference{Name: "pull-push-secret"},
-				},
-			}
-
-			gomock.InOrder(
-				authFactory.EXPECT().NewRegistryAuthGetterFrom(&mod),
-				reg.EXPECT().ImageExists(ctx, imageName, gomock.Any(), gomock.Any()).Return(true, nil),
-			)
-
-			mgr := NewSignJobManager(nil, nil, authFactory, reg)
-
-			shouldSync, err := mgr.ShouldSync(ctx, mod, km)
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(shouldSync).To(BeFalse())
-		})
-
-		It("should return false and an error if image check fails", func() {
-			ctx := context.Background()
-
-			km := kmmv1beta1.KernelMapping{
-				Sign:           &kmmv1beta1.Sign{},
-				ContainerImage: imageName,
-			}
-
-			mod := kmmv1beta1.Module{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      moduleName,
-					Namespace: namespace,
-				},
-				Spec: kmmv1beta1.ModuleSpec{
-					ImageRepoSecret: &v1.LocalObjectReference{Name: "pull-push-secret"},
-				},
-			}
-
-			gomock.InOrder(
-				authFactory.EXPECT().NewRegistryAuthGetterFrom(&mod),
-				reg.EXPECT().ImageExists(ctx, imageName, gomock.Any(), gomock.Any()).Return(false, errors.New("generic-registry-error")),
-			)
-
-			mgr := NewSignJobManager(nil, nil, authFactory, reg)
-
-			shouldSync, err := mgr.ShouldSync(ctx, mod, km)
-
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("generic-registry-error"))
-			Expect(shouldSync).To(BeFalse())
-		})
-
-		It("should return true if image does not exist", func() {
-			ctx := context.Background()
-
-			km := kmmv1beta1.KernelMapping{
-				Sign:           &kmmv1beta1.Sign{},
-				ContainerImage: imageName,
-			}
-
-			mod := kmmv1beta1.Module{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      moduleName,
-					Namespace: namespace,
-				},
-				Spec: kmmv1beta1.ModuleSpec{
-					ImageRepoSecret: &v1.LocalObjectReference{Name: "pull-push-secret"},
-				},
-			}
-
-			gomock.InOrder(
-				authFactory.EXPECT().NewRegistryAuthGetterFrom(&mod),
-				reg.EXPECT().ImageExists(ctx, imageName, gomock.Any(), gomock.Any()).Return(false, nil),
-			)
-
-			mgr := NewSignJobManager(nil, nil, authFactory, reg)
-
-			shouldSync, err := mgr.ShouldSync(ctx, mod, km)
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(shouldSync).To(BeTrue())
-		})
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		authFactory = auth.NewMockRegistryAuthGetterFactory(ctrl)
+		reg = registry.NewMockRegistry(ctrl)
+		mgr = NewSignJobManager(nil, nil, authFactory, reg)
 	})
 
-	Describe("Sync", func() {
-		var (
-			ctrl      *gomock.Controller
-			maker     *MockSigner
-			jobhelper *utils.MockJobHelper
-		)
+	It("should return false if there was not sign section", func() {
+		ctx := context.Background()
 
-		const (
-			imageName         = "image-name"
-			previousImageName = "previous-image"
-			namespace         = "some-namespace"
+		mod := kmmv1beta1.Module{}
+		km := kmmv1beta1.KernelMapping{}
 
-			moduleName    = "module-name"
-			kernelVersion = "1.2.3"
-			jobName       = "some-job"
-		)
+		shouldSync, err := mgr.ShouldSync(ctx, mod, km)
 
-		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
-			maker = NewMockSigner(ctrl)
-			jobhelper = utils.NewMockJobHelper(ctrl)
-		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(shouldSync).To(BeFalse())
+	})
+
+	It("should return false if image already exists", func() {
+		ctx := context.Background()
 
 		km := kmmv1beta1.KernelMapping{
-			Build:          &kmmv1beta1.Build{},
+			Sign:           &kmmv1beta1.Sign{},
 			ContainerImage: imageName,
-		}
-		labels := map[string]string{"kmm.node.kubernetes.io/job-type": "sign",
-			"kmm.node.kubernetes.io/module.name":   moduleName,
-			"kmm.node.kubernetes.io/target-kernel": kernelVersion,
 		}
 
 		mod := kmmv1beta1.Module{
-			ObjectMeta: metav1.ObjectMeta{Name: moduleName},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      moduleName,
+				Namespace: namespace,
+			},
+			Spec: kmmv1beta1.ModuleSpec{
+				ImageRepoSecret: &v1.LocalObjectReference{Name: "pull-push-secret"},
+			},
 		}
 
-		DescribeTable("should return the correct status depending on the job status",
-			func(s batchv1.JobStatus, r utils.Result, expectsErr bool) {
-				j := batchv1.Job{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{"kmm.node.kubernetes.io/job-type": "sign",
-							"kmm.node.kubernetes.io/module.name":   moduleName,
-							"kmm.node.kubernetes.io/target-kernel": kernelVersion,
-						},
-						Namespace:   namespace,
-						Annotations: map[string]string{constants.JobHashAnnotation: "some hash"},
-					},
-					Status: s,
-				}
-				newJob := batchv1.Job{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{"kmm.node.kubernetes.io/job-type": "sign",
-							"kmm.node.kubernetes.io/module.name":   moduleName,
-							"kmm.node.kubernetes.io/target-kernel": kernelVersion,
-						},
-						Namespace:   namespace,
-						Annotations: map[string]string{constants.JobHashAnnotation: "some hash"},
-					},
-					Status: s,
-				}
-				ctx := context.Background()
-
-				var joberr error
-				if expectsErr {
-					joberr = errors.New("random error")
-				}
-
-				gomock.InOrder(
-					jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
-					maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
-					jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(&newJob, nil),
-					jobhelper.EXPECT().IsJobChanged(&j, &newJob).Return(false, nil),
-					jobhelper.EXPECT().GetJobStatus(&newJob).Return(r.Status, r.Requeue, joberr),
-				)
-
-				mgr := NewSignJobManager(maker, jobhelper, nil, nil)
-
-				res, err := mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod)
-
-				if expectsErr {
-					Expect(err).To(HaveOccurred())
-					return
-				}
-
-				Expect(res).To(Equal(r))
-			},
-			Entry("active", batchv1.JobStatus{Active: 1}, utils.Result{Requeue: true, Status: utils.StatusInProgress}, false),
-			Entry("active", batchv1.JobStatus{Active: 1}, utils.Result{Requeue: true, Status: utils.StatusInProgress}, false),
-			Entry("succeeded", batchv1.JobStatus{Succeeded: 1}, utils.Result{Status: utils.StatusCompleted}, false),
-			Entry("failed", batchv1.JobStatus{Failed: 1}, utils.Result{}, true),
+		gomock.InOrder(
+			authFactory.EXPECT().NewRegistryAuthGetterFrom(&mod),
+			reg.EXPECT().ImageExists(ctx, imageName, gomock.Any(), gomock.Any()).Return(true, nil),
 		)
 
-		It("should return an error if there was an error creating the job template", func() {
-			ctx := context.Background()
+		shouldSync, err := mgr.ShouldSync(ctx, mod, km)
 
-			gomock.InOrder(
-				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
-				maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).
-					Return(nil, errors.New("random error")),
-			)
-
-			mgr := NewSignJobManager(maker, jobhelper, nil, nil)
-
-			Expect(
-				mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod),
-			).Error().To(
-				HaveOccurred(),
-			)
-		})
-
-		It("should return an error if there was an error getting running jobs", func() {
-			ctx := context.Background()
-			j := batchv1.Job{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "batch/v1",
-					Kind:       "Job",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      jobName,
-					Namespace: namespace,
-				},
-			}
-
-			gomock.InOrder(
-				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
-				maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
-				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(nil, errors.New("random error")),
-			)
-
-			mgr := NewSignJobManager(maker, jobhelper, nil, nil)
-
-			Expect(
-				mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod),
-			).Error().To(
-				HaveOccurred(),
-			)
-		})
-
-		It("should return an error if there was an error creating the job", func() {
-			ctx := context.Background()
-			j := batchv1.Job{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "batch/v1",
-					Kind:       "Job",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      jobName,
-					Namespace: namespace,
-				},
-			}
-
-			gomock.InOrder(
-				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
-				maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
-				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(nil, utils.ErrNoMatchingJob),
-				jobhelper.EXPECT().CreateJob(ctx, &j).Return(errors.New("unable to create job")),
-			)
-
-			mgr := NewSignJobManager(maker, jobhelper, nil, nil)
-
-			Expect(
-				mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod),
-			).Error().To(
-				HaveOccurred(),
-			)
-		})
-
-		It("should create the job and return without error if it doesn't exist", func() {
-			ctx := context.Background()
-
-			j := batchv1.Job{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "batch/v1",
-					Kind:       "Job",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      jobName,
-					Namespace: namespace,
-				},
-			}
-
-			gomock.InOrder(
-				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
-				maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
-				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(nil, utils.ErrNoMatchingJob),
-				jobhelper.EXPECT().CreateJob(ctx, &j).Return(nil),
-			)
-
-			mgr := NewSignJobManager(maker, jobhelper, nil, nil)
-
-			Expect(
-				mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod),
-			).To(
-				Equal(utils.Result{Requeue: true, Status: utils.StatusCreated}),
-			)
-		})
-
-		It("should delete the job if it was edited", func() {
-			ctx := context.Background()
-
-			newJob := batchv1.Job{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "batch/v1",
-					Kind:       "Job",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:        jobName,
-					Namespace:   namespace,
-					Annotations: map[string]string{constants.JobHashAnnotation: "new hash"},
-				},
-			}
-
-			gomock.InOrder(
-				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
-				maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&newJob, nil),
-				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(&newJob, nil),
-				jobhelper.EXPECT().IsJobChanged(&newJob, &newJob).Return(true, nil),
-				jobhelper.EXPECT().DeleteJob(ctx, &newJob).Return(nil),
-			)
-
-			mgr := NewSignJobManager(maker, jobhelper, nil, nil)
-
-			Expect(
-				mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod),
-			).To(
-				Equal(utils.Result{Requeue: true, Status: utils.StatusInProgress}),
-			)
-		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(shouldSync).To(BeFalse())
 	})
+
+	It("should return false and an error if image check fails", func() {
+		ctx := context.Background()
+
+		km := kmmv1beta1.KernelMapping{
+			Sign:           &kmmv1beta1.Sign{},
+			ContainerImage: imageName,
+		}
+
+		mod := kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      moduleName,
+				Namespace: namespace,
+			},
+			Spec: kmmv1beta1.ModuleSpec{
+				ImageRepoSecret: &v1.LocalObjectReference{Name: "pull-push-secret"},
+			},
+		}
+
+		gomock.InOrder(
+			authFactory.EXPECT().NewRegistryAuthGetterFrom(&mod),
+			reg.EXPECT().ImageExists(ctx, imageName, gomock.Any(), gomock.Any()).Return(false, errors.New("generic-registry-error")),
+		)
+
+		shouldSync, err := mgr.ShouldSync(ctx, mod, km)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("generic-registry-error"))
+		Expect(shouldSync).To(BeFalse())
+	})
+
+	It("should return true if image does not exist", func() {
+		ctx := context.Background()
+
+		km := kmmv1beta1.KernelMapping{
+			Sign:           &kmmv1beta1.Sign{},
+			ContainerImage: imageName,
+		}
+
+		mod := kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      moduleName,
+				Namespace: namespace,
+			},
+			Spec: kmmv1beta1.ModuleSpec{
+				ImageRepoSecret: &v1.LocalObjectReference{Name: "pull-push-secret"},
+			},
+		}
+
+		gomock.InOrder(
+			authFactory.EXPECT().NewRegistryAuthGetterFrom(&mod),
+			reg.EXPECT().ImageExists(ctx, imageName, gomock.Any(), gomock.Any()).Return(false, nil),
+		)
+
+		shouldSync, err := mgr.ShouldSync(ctx, mod, km)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(shouldSync).To(BeTrue())
+	})
+})
+
+var _ = Describe("Sync", func() {
+	var (
+		ctrl      *gomock.Controller
+		maker     *MockSigner
+		jobhelper *utils.MockJobHelper
+		mgr       *signJobManager
+	)
+
+	const (
+		imageName         = "image-name"
+		previousImageName = "previous-image"
+		namespace         = "some-namespace"
+
+		moduleName    = "module-name"
+		kernelVersion = "1.2.3"
+		jobName       = "some-job"
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		maker = NewMockSigner(ctrl)
+		jobhelper = utils.NewMockJobHelper(ctrl)
+		mgr = NewSignJobManager(maker, jobhelper, nil, nil)
+	})
+
+	km := kmmv1beta1.KernelMapping{
+		Build:          &kmmv1beta1.Build{},
+		ContainerImage: imageName,
+	}
+	labels := map[string]string{"kmm.node.kubernetes.io/job-type": "sign",
+		"kmm.node.kubernetes.io/module.name":   moduleName,
+		"kmm.node.kubernetes.io/target-kernel": kernelVersion,
+	}
+
+	mod := kmmv1beta1.Module{
+		ObjectMeta: metav1.ObjectMeta{Name: moduleName},
+	}
+
+	DescribeTable("should return the correct status depending on the job status",
+		func(s batchv1.JobStatus, r utils.Result, expectsErr bool) {
+			j := batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"kmm.node.kubernetes.io/job-type": "sign",
+						"kmm.node.kubernetes.io/module.name":   moduleName,
+						"kmm.node.kubernetes.io/target-kernel": kernelVersion,
+					},
+					Namespace:   namespace,
+					Annotations: map[string]string{constants.JobHashAnnotation: "some hash"},
+				},
+				Status: s,
+			}
+			newJob := batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"kmm.node.kubernetes.io/job-type": "sign",
+						"kmm.node.kubernetes.io/module.name":   moduleName,
+						"kmm.node.kubernetes.io/target-kernel": kernelVersion,
+					},
+					Namespace:   namespace,
+					Annotations: map[string]string{constants.JobHashAnnotation: "some hash"},
+				},
+				Status: s,
+			}
+			ctx := context.Background()
+
+			var joberr error
+			if expectsErr {
+				joberr = errors.New("random error")
+			}
+
+			gomock.InOrder(
+				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
+				maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
+				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(&newJob, nil),
+				jobhelper.EXPECT().IsJobChanged(&j, &newJob).Return(false, nil),
+				jobhelper.EXPECT().GetJobStatus(&newJob).Return(r.Status, r.Requeue, joberr),
+			)
+
+			res, err := mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod)
+
+			if expectsErr {
+				Expect(err).To(HaveOccurred())
+				return
+			}
+
+			Expect(res).To(Equal(r))
+		},
+		Entry("active", batchv1.JobStatus{Active: 1}, utils.Result{Requeue: true, Status: utils.StatusInProgress}, false),
+		Entry("active", batchv1.JobStatus{Active: 1}, utils.Result{Requeue: true, Status: utils.StatusInProgress}, false),
+		Entry("succeeded", batchv1.JobStatus{Succeeded: 1}, utils.Result{Status: utils.StatusCompleted}, false),
+		Entry("failed", batchv1.JobStatus{Failed: 1}, utils.Result{}, true),
+	)
+
+	It("should return an error if there was an error creating the job template", func() {
+		ctx := context.Background()
+
+		gomock.InOrder(
+			jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
+			maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).
+				Return(nil, errors.New("random error")),
+		)
+
+		Expect(
+			mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod),
+		).Error().To(
+			HaveOccurred(),
+		)
+	})
+
+	It("should return an error if there was an error getting running jobs", func() {
+		ctx := context.Background()
+		j := batchv1.Job{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "batch/v1",
+				Kind:       "Job",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      jobName,
+				Namespace: namespace,
+			},
+		}
+
+		gomock.InOrder(
+			jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
+			maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
+			jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(nil, errors.New("random error")),
+		)
+
+		Expect(
+			mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod),
+		).Error().To(
+			HaveOccurred(),
+		)
+	})
+
+	It("should return an error if there was an error creating the job", func() {
+		ctx := context.Background()
+		j := batchv1.Job{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "batch/v1",
+				Kind:       "Job",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      jobName,
+				Namespace: namespace,
+			},
+		}
+
+		gomock.InOrder(
+			jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
+			maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
+			jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(nil, utils.ErrNoMatchingJob),
+			jobhelper.EXPECT().CreateJob(ctx, &j).Return(errors.New("unable to create job")),
+		)
+
+		Expect(
+			mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod),
+		).Error().To(
+			HaveOccurred(),
+		)
+	})
+
+	It("should create the job and return without error if it doesn't exist", func() {
+		ctx := context.Background()
+
+		j := batchv1.Job{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "batch/v1",
+				Kind:       "Job",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      jobName,
+				Namespace: namespace,
+			},
+		}
+
+		gomock.InOrder(
+			jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
+			maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
+			jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(nil, utils.ErrNoMatchingJob),
+			jobhelper.EXPECT().CreateJob(ctx, &j).Return(nil),
+		)
+
+		Expect(
+			mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod),
+		).To(
+			Equal(utils.Result{Requeue: true, Status: utils.StatusCreated}),
+		)
+	})
+
+	It("should delete the job if it was edited", func() {
+		ctx := context.Background()
+
+		newJob := batchv1.Job{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "batch/v1",
+				Kind:       "Job",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        jobName,
+				Namespace:   namespace,
+				Annotations: map[string]string{constants.JobHashAnnotation: "new hash"},
+			},
+		}
+
+		gomock.InOrder(
+			jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
+			maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&newJob, nil),
+			jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(&newJob, nil),
+			jobhelper.EXPECT().IsJobChanged(&newJob, &newJob).Return(true, nil),
+			jobhelper.EXPECT().DeleteJob(ctx, &newJob).Return(nil),
+		)
+
+		Expect(
+			mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod),
+		).To(
+			Equal(utils.Result{Requeue: true, Status: utils.StatusInProgress}),
+		)
+	})
+})
+
+var _ = Describe("GarbageCollect", func() {
+	var (
+		ctrl      *gomock.Controller
+		jobhelper *utils.MockJobHelper
+		mgr       *signJobManager
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		jobhelper = utils.NewMockJobHelper(ctrl)
+		mgr = NewSignJobManager(nil, jobhelper, nil, nil)
+	})
+
+	mod := kmmv1beta1.Module{
+		ObjectMeta: metav1.ObjectMeta{Name: "moduleName"},
+	}
+
+	DescribeTable("should return the correct error and names of the collected jobs",
+		func(jobStatus1 batchv1.JobStatus, jobStatus2 batchv1.JobStatus, expectsErr bool) {
+			job1 := batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "jobName1",
+				},
+				Status: jobStatus1,
+			}
+			job2 := batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "jobName2",
+				},
+				Status: jobStatus2,
+			}
+			expectedNames := []string{}
+			if !expectsErr {
+				if job1.Status.Succeeded == 1 {
+					expectedNames = append(expectedNames, "jobName1")
+				}
+				if job2.Status.Succeeded == 1 {
+					expectedNames = append(expectedNames, "jobName2")
+				}
+			}
+			returnedError := fmt.Errorf("some error")
+			if !expectsErr {
+				returnedError = nil
+			}
+
+			jobhelper.EXPECT().GetModuleJobs(context.Background(), mod.Name, mod.Namespace, utils.JobTypeSign, &mod).Return([]batchv1.Job{job1, job2}, returnedError)
+			if !expectsErr {
+				if job1.Status.Succeeded == 1 {
+					jobhelper.EXPECT().DeleteJob(context.Background(), &job1).Return(nil)
+				}
+				if job2.Status.Succeeded == 1 {
+					jobhelper.EXPECT().DeleteJob(context.Background(), &job2).Return(nil)
+				}
+			}
+
+			names, err := mgr.GarbageCollect(context.Background(), mod.Name, mod.Namespace, &mod)
+
+			if expectsErr {
+				Expect(err).To(HaveOccurred())
+				Expect(names).To(BeNil())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(expectedNames).To(Equal(names))
+			}
+		},
+		Entry("all jobs succeeded", batchv1.JobStatus{Succeeded: 1}, batchv1.JobStatus{Succeeded: 1}, false),
+		Entry("1 job succeeded", batchv1.JobStatus{Succeeded: 1}, batchv1.JobStatus{Succeeded: 0}, false),
+		Entry("0 job succeeded", batchv1.JobStatus{Succeeded: 0}, batchv1.JobStatus{Succeeded: 0}, false),
+		Entry("error occured", batchv1.JobStatus{Succeeded: 0}, batchv1.JobStatus{Succeeded: 0}, true),
+	)
 })

--- a/internal/sign/manager.go
+++ b/internal/sign/manager.go
@@ -12,6 +12,8 @@ import (
 //go:generate mockgen -source=manager.go -package=sign -destination=mock_manager.go
 
 type SignManager interface {
+	GarbageCollect(ctx context.Context, modName, namespace string, owner metav1.Object) ([]string, error)
+
 	ShouldSync(
 		ctx context.Context,
 		mod kmmv1beta1.Module,

--- a/internal/sign/mock_manager.go
+++ b/internal/sign/mock_manager.go
@@ -37,6 +37,21 @@ func (m *MockSignManager) EXPECT() *MockSignManagerMockRecorder {
 	return m.recorder
 }
 
+// GarbageCollect mocks base method.
+func (m *MockSignManager) GarbageCollect(ctx context.Context, modName, namespace string, owner v1.Object) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GarbageCollect", ctx, modName, namespace, owner)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GarbageCollect indicates an expected call of GarbageCollect.
+func (mr *MockSignManagerMockRecorder) GarbageCollect(ctx, modName, namespace, owner interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockSignManager)(nil).GarbageCollect), ctx, modName, namespace, owner)
+}
+
 // ShouldSync mocks base method.
 func (m_2 *MockSignManager) ShouldSync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping) (bool, error) {
 	m_2.ctrl.T.Helper()


### PR DESCRIPTION
In case Sign job has finished successfully, operator should delete it.

Upstream-Commit: 94747dc4e475b7c5b36cbc0c524f30ecae99aecf

Fixes: https://github.com/rh-ecosystem-edge/kernel-module-management/issues/372