### PR TITLE
Updating the triggers for the `gitstream` workflow.

### DIFF
--- a/.github/workflows/gitstream.yml
+++ b/.github/workflows/gitstream.yml
@@ -3,12 +3,6 @@ name: GitStream
 concurrency: gitstream
 
 on:
-  issues:
-    types: [closed]
-
-  pull_request:
-    types: [closed]
-
   schedule:
     - cron: '*/10 * * * *'
 


### PR DESCRIPTION
We do not gain any benefit from running this workflow on PRs and issues.

In addition to that, seems like when the job is triggered on a PR it is running in the fork context, therefore, using the `GITHUB_TOKEN` from the fork which can lead to some API errors.

One example error that we experienced was:
```
POST
https://api.github.com/repos/rh-ecosystem-edge/kernel-module-management/issues/392/assignees:
403 Resource not accessible by integration []
```
.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>

---

/cc @qbarrand 