### PR TITLE
Adding `dependabot[bot]` as an ignored author for `sync`.

### DIFF
--- a/.github/gitstream.yml
+++ b/.github/gitstream.yml
@@ -5,6 +5,8 @@ downstream:
   github_repo_name: rh-ecosystem-edge/kernel-module-management
   local_repo_path: _gitstream_downstream
   max_open_items: 3
+  ignore_authors:
+    - "dependabot[bot]"
 
 log_level: 1000
 


### PR DESCRIPTION
We shouldn't not pull commits from `dependabot` as we have `dependabot` set on this repo as well.

Signed-off-by: Yoni Bettan <yonibettan@gmail.com>

---

/cc @qbarrand 
/hold
Should be merged only after https://github.com/qbarrand/gitstream/pull/37