### PR TITLE
Add must-gather as a related image

### DIFF
--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -198,6 +198,8 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
+                - name: RELATED_IMAGES_MUST_GATHER
+                  value: quay.io/edge-infrastructure/kernel-module-management-must-gather:latest
                 - name: RELATED_IMAGES_SIGN
                   value: quay.io/edge-infrastructure/kernel-module-management-signimage:latest
                 image: quay.io/edge-infrastructure/kernel-module-management-operator-hub:latest

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -304,6 +304,8 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
+                - name: RELATED_IMAGES_MUST_GATHER
+                  value: quay.io/edge-infrastructure/kernel-module-management-must-gather:latest
                 - name: RELATED_IMAGES_SIGN
                   value: quay.io/edge-infrastructure/kernel-module-management-signimage:latest
                 image: quay.io/edge-infrastructure/kernel-module-management-operator:latest

--- a/config/manager-base/manager.yaml
+++ b/config/manager-base/manager.yaml
@@ -46,6 +46,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: RELATED_IMAGES_MUST_GATHER
+            value: quay.io/edge-infrastructure/kernel-module-management-must-gather:latest
           - name: RELATED_IMAGES_SIGN
             value: quay.io/edge-infrastructure/kernel-module-management-signimage:latest
         imagePullPolicy: Always


### PR DESCRIPTION
This is useful for users to determine which must-gather image must be used to troubleshoot their deployment.

/cc @mresvanis @ybettan 