### PR TITLE
ModuleReconciler and ManagedCluster controllers should not requeue on…

### DIFF
--- a/controllers/hub/managedclustermodule_reconciler.go
+++ b/controllers/hub/managedclustermodule_reconciler.go
@@ -110,14 +110,13 @@ func (r *ManagedClusterModuleReconciler) Reconcile(ctx context.Context, req ctrl
 		logger := log.FromContext(ctx).WithValues("cluster", cluster.Name)
 		clusterCtx := log.IntoContext(ctx, logger)
 
-		requeue, err := r.clusterAPI.BuildAndSign(clusterCtx, *mcm, cluster)
+		completedSuccessfully, err := r.clusterAPI.BuildAndSign(clusterCtx, *mcm, cluster)
 		if err != nil {
 			logger.Error(err, "failed to build")
 			continue
 		}
-		if requeue {
-			logger.Info("Build and Sign require a requeue; skipping ManifestWork reconciliation")
-			res.Requeue = true
+		if !completedSuccessfully {
+			logger.Info("Build and Sign have not finished successfully yet; skipping ManifestWork reconciliation")
 			continue
 		}
 

--- a/controllers/hub/managedclustermodule_reconciler_test.go
+++ b/controllers/hub/managedclustermodule_reconciler_test.go
@@ -319,7 +319,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 		Expect(res).To(Equal(reconcile.Result{}))
 	})
 
-	It("should requeue the request when build is specified and a managed cluster matches the selector", func() {
+	It("should not requeue the request when build is specified and not completed and a managed cluster matches the selector", func() {
 		mcm := v1beta1.ManagedClusterModule{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: mcmName,
@@ -352,7 +352,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 		gomock.InOrder(
 			mockClusterAPI.EXPECT().RequestedManagedClusterModule(ctx, req.NamespacedName).Return(&mcm, nil),
 			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, gomock.Any()).Return(&clusterList, nil),
-			mockClusterAPI.EXPECT().BuildAndSign(gomock.Any(), mcm, clusterList.Items[0]).Return(true, nil),
+			mockClusterAPI.EXPECT().BuildAndSign(gomock.Any(), mcm, clusterList.Items[0]).Return(false, nil),
 			mockMW.EXPECT().GarbageCollect(ctx, clusterList, mcm),
 			mockClusterAPI.EXPECT().GarbageCollectBuilds(ctx, mcm),
 			mockMW.EXPECT().GetOwnedManifestWorks(ctx, mcm).Return(&manifestWorkList, nil),
@@ -370,10 +370,10 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 
 		res, err := mr.Reconcile(context.Background(), req)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(res).To(Equal(reconcile.Result{Requeue: true}))
+		Expect(res).To(Equal(reconcile.Result{Requeue: false}))
 	})
 
-	It("should create a ManifestWork if a managed cluster matches the selector", func() {
+	It("should create a ManifestWork if a managed cluster matches the selector and build/sign is completed", func() {
 		mcm := v1beta1.ManagedClusterModule{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: mcmName,
@@ -406,7 +406,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 		gomock.InOrder(
 			mockClusterAPI.EXPECT().RequestedManagedClusterModule(ctx, req.NamespacedName).Return(&mcm, nil),
 			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, gomock.Any()).Return(&clusterList, nil),
-			mockClusterAPI.EXPECT().BuildAndSign(gomock.Any(), mcm, clusterList.Items[0]).Return(false, nil),
+			mockClusterAPI.EXPECT().BuildAndSign(gomock.Any(), mcm, clusterList.Items[0]).Return(true, nil),
 			clnt.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
 			mockMW.EXPECT().SetManifestWorkAsDesired(context.Background(), &mw, gomock.AssignableToTypeOf(mcm)),
 			clnt.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil),
@@ -464,7 +464,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 		gomock.InOrder(
 			mockClusterAPI.EXPECT().RequestedManagedClusterModule(ctx, req.NamespacedName).Return(&mcm, nil),
 			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, gomock.Any()).Return(&clusterList, nil),
-			mockClusterAPI.EXPECT().BuildAndSign(gomock.Any(), mcm, clusterList.Items[0]).Return(false, nil),
+			mockClusterAPI.EXPECT().BuildAndSign(gomock.Any(), mcm, clusterList.Items[0]).Return(true, nil),
 			clnt.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()),
 			mockMW.EXPECT().SetManifestWorkAsDesired(context.Background(), &mw, gomock.AssignableToTypeOf(mcm)).Do(
 				func(ctx context.Context, m *workv1.ManifestWork, _ v1beta1.ManagedClusterModule) {

--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -145,23 +145,21 @@ func (r *ModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	for kernelVersion, m := range mappings {
-		requeue, err := r.handleBuild(ctx, mod, m, kernelVersion)
+		completedSuccessfully, err := r.handleBuild(ctx, mod, m, kernelVersion)
 		if err != nil {
 			return res, fmt.Errorf("failed to handle build for kernel version %s: %v", kernelVersion, err)
 		}
-		if requeue {
-			logger.Info("Build requires a requeue; skipping handling driver container for now", "kernelVersion", kernelVersion, "image", m)
-			res.Requeue = true
+		if !completedSuccessfully {
+			logger.Info("Build has not finished successfully yet:skipping handling signing and driver container for now", "kernelVersion", kernelVersion, "image", m)
 			continue
 		}
 
-		signrequeue, err := r.handleSigning(ctx, mod, m, kernelVersion)
+		completedSuccessfully, err = r.handleSigning(ctx, mod, m, kernelVersion)
 		if err != nil {
 			return res, fmt.Errorf("failed to handle signing for kernel version %s: %v", kernelVersion, err)
 		}
-		if signrequeue {
-			logger.Info("Signing requires a requeue; skipping handling driver container for now", "kernelVersion", kernelVersion, "image", m)
-			res.Requeue = true
+		if !completedSuccessfully {
+			logger.Info("Signing has not finished successfully yet; skipping handling driver container for now", "kernelVersion", kernelVersion, "image", m)
 			continue
 		}
 
@@ -253,6 +251,7 @@ func (r *ModuleReconciler) getNodesListBySelector(ctx context.Context, mod *kmmv
 	return nodes, nil
 }
 
+// handleBuild returns true if build is not needed or finished successfully
 func (r *ModuleReconciler) handleBuild(ctx context.Context,
 	mod *kmmv1beta1.Module,
 	km *kmmv1beta1.KernelMapping,
@@ -263,27 +262,32 @@ func (r *ModuleReconciler) handleBuild(ctx context.Context,
 		return false, fmt.Errorf("could not check if build synchronization is needed: %w", err)
 	}
 	if !shouldSync {
-		return false, nil
+		return true, nil
 	}
 
 	logger := log.FromContext(ctx).WithValues("kernel version", kernelVersion, "image", km.ContainerImage)
 	buildCtx := log.IntoContext(ctx, logger)
 
-	buildRes, err := r.buildAPI.Sync(buildCtx, *mod, *km, kernelVersion, true, mod)
+	buildStatus, err := r.buildAPI.Sync(buildCtx, *mod, *km, kernelVersion, true, mod)
 	if err != nil {
 		return false, fmt.Errorf("could not synchronize the build: %w", err)
 	}
 
-	switch buildRes.Status {
-	case build.StatusCreated:
+	completedSuccessfully := false
+	switch buildStatus {
+	case utils.StatusCreated:
 		r.metricsAPI.SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.BuildStage, false)
-	case build.StatusCompleted:
+	case utils.StatusCompleted:
+		completedSuccessfully = true
 		r.metricsAPI.SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.BuildStage, true)
+	case utils.StatusFailed:
+		logger.Info(utils.WarnString("Build job has failed. If the fix is not in Module CR, then delete job after the fix in order to restart the job"))
 	}
 
-	return buildRes.Requeue, nil
+	return completedSuccessfully, nil
 }
 
+// handleSigning returns true if signing is not needed or finished successfully
 func (r *ModuleReconciler) handleSigning(ctx context.Context,
 	mod *kmmv1beta1.Module,
 	km *kmmv1beta1.KernelMapping,
@@ -294,7 +298,7 @@ func (r *ModuleReconciler) handleSigning(ctx context.Context,
 		return false, fmt.Errorf("cound not check if synchronization is needed: %w", err)
 	}
 	if !shouldSync {
-		return false, nil
+		return true, nil
 	}
 
 	// if we need to sign AND we've built, then we must have built the intermediate image so must figure out its name
@@ -306,19 +310,23 @@ func (r *ModuleReconciler) handleSigning(ctx context.Context,
 	logger := log.FromContext(ctx).WithValues("kernel version", kernelVersion, "image", km.ContainerImage)
 	signCtx := log.IntoContext(ctx, logger)
 
-	signRes, err := r.signAPI.Sync(signCtx, *mod, *km, kernelVersion, previousImage, true, mod)
+	signStatus, err := r.signAPI.Sync(signCtx, *mod, *km, kernelVersion, previousImage, true, mod)
 	if err != nil {
 		return false, fmt.Errorf("could not synchronize the signing: %w", err)
 	}
 
-	switch signRes.Status {
+	completedSuccessfully := false
+	switch signStatus {
 	case utils.StatusCreated:
 		r.metricsAPI.SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.SignStage, false)
 	case utils.StatusCompleted:
+		completedSuccessfully = true
 		r.metricsAPI.SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.SignStage, true)
+	case utils.StatusFailed:
+		logger.Info(utils.WarnString("Sign job has failed. If the fix is not in Module CR, then delete job after the fix in order to restart the job"))
 	}
 
-	return signRes.Requeue, nil
+	return completedSuccessfully, nil
 }
 
 func (r *ModuleReconciler) handleDriverContainer(ctx context.Context,

--- a/internal/build/manager.go
+++ b/internal/build/manager.go
@@ -6,20 +6,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 )
-
-type Status string
-
-const (
-	StatusCompleted  = "completed"
-	StatusCreated    = "created"
-	StatusInProgress = "in progress"
-)
-
-type Result struct {
-	Requeue bool
-	Status  Status
-}
 
 //go:generate mockgen -source=manager.go -package=build -destination=mock_manager.go
 
@@ -37,5 +25,5 @@ type Manager interface {
 		m kmmv1beta1.KernelMapping,
 		targetKernel string,
 		pushImage bool,
-		owner metav1.Object) (Result, error)
+		owner metav1.Object) (utils.Status, error)
 }

--- a/internal/build/mock_manager.go
+++ b/internal/build/mock_manager.go
@@ -10,6 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	utils "github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -67,10 +68,10 @@ func (mr *MockManagerMockRecorder) ShouldSync(ctx, mod, m interface{}) *gomock.C
 }
 
 // Sync mocks base method.
-func (m_2 *MockManager) Sync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping, targetKernel string, pushImage bool, owner v1.Object) (Result, error) {
+func (m_2 *MockManager) Sync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping, targetKernel string, pushImage bool, owner v1.Object) (utils.Status, error) {
 	m_2.ctrl.T.Helper()
 	ret := m_2.ctrl.Call(m_2, "Sync", ctx, mod, m, targetKernel, pushImage, owner)
-	ret0, _ := ret[0].(Result)
+	ret0, _ := ret[0].(utils.Status)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/module"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/sign"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 )
 
 //go:generate mockgen -source=cluster.go -package=cluster -destination=mock_cluster.go
@@ -86,12 +87,15 @@ func (c *clusterAPI) BuildAndSign(
 	mcm hubv1beta1.ManagedClusterModule,
 	cluster clusterv1.ManagedCluster) (bool, error) {
 
-	requeue := false
-
 	modSpec := mcm.Spec.ModuleSpec
 	mappings, err := c.kernelMappingsByKernelVersion(ctx, &modSpec, cluster)
 	if err != nil {
 		return false, err
+	}
+
+	// if no mappings were found, return not completed
+	if len(mappings) == 0 {
+		return false, nil
 	}
 
 	mod := kmmv1beta1.Module{
@@ -102,29 +106,38 @@ func (c *clusterAPI) BuildAndSign(
 		Spec: modSpec,
 	}
 
+	logger := log.FromContext(ctx)
+
+	completedSuccessfully := true
 	for kernelVersion, m := range mappings {
-		buildRequeue, err := c.build(ctx, mod, &mcm, m, kernelVersion)
+		buildCompleted, err := c.build(ctx, mod, &mcm, m, kernelVersion)
 		if err != nil {
 			return false, err
 		}
 
-		if buildRequeue {
-			requeue = true
+		kernelVersionLogger := logger.WithValues(
+			"kernel version", kernelVersion,
+		)
+
+		if !buildCompleted {
+			kernelVersionLogger.Info("Build for mapping has not completed yet, skipping Sign")
+			completedSuccessfully = false
 			continue
 		}
 
-		signRequeue, err := c.sign(ctx, mod, &mcm, m, kernelVersion)
+		signCompleted, err := c.sign(ctx, mod, &mcm, m, kernelVersion)
 		if err != nil {
 			return false, err
 		}
 
-		if signRequeue {
-			requeue = true
+		if !signCompleted {
+			kernelVersionLogger.Info("Sign for mapping has not completed yet")
+			completedSuccessfully = false
 			continue
 		}
 	}
 
-	return requeue, nil
+	return completedSuccessfully, nil
 }
 
 func (c *clusterAPI) GarbageCollectBuilds(ctx context.Context, mcm hubv1beta1.ManagedClusterModule) ([]string, error) {
@@ -195,7 +208,7 @@ func (c *clusterAPI) build(
 		return false, fmt.Errorf("could not check if build synchronization is needed: %v", err)
 	}
 	if !shouldSync {
-		return false, nil
+		return true, nil
 	}
 
 	logger := log.FromContext(ctx).WithValues(
@@ -203,12 +216,15 @@ func (c *clusterAPI) build(
 		"image", kernelMapping.ContainerImage)
 	buildCtx := log.IntoContext(ctx, logger)
 
-	buildRes, err := c.buildAPI.Sync(buildCtx, mod, *kernelMapping, kernelVersion, true, mcm)
+	buildStatus, err := c.buildAPI.Sync(buildCtx, mod, *kernelMapping, kernelVersion, true, mcm)
 	if err != nil {
 		return false, fmt.Errorf("could not synchronize the build: %w", err)
 	}
 
-	return buildRes.Requeue, nil
+	if buildStatus == utils.StatusCompleted {
+		return true, nil
+	}
+	return false, nil
 }
 
 func (c *clusterAPI) sign(
@@ -223,7 +239,7 @@ func (c *clusterAPI) sign(
 		return false, fmt.Errorf("could not check if signing synchronization is needed: %v", err)
 	}
 	if !shouldSync {
-		return false, nil
+		return true, nil
 	}
 
 	// if we need to sign AND we've built, then we must have built
@@ -238,10 +254,13 @@ func (c *clusterAPI) sign(
 		"image", kernelMapping.ContainerImage)
 	signCtx := log.IntoContext(ctx, logger)
 
-	signRes, err := c.signAPI.Sync(signCtx, mod, *kernelMapping, kernelVersion, previousImage, true, mcm)
+	signStatus, err := c.signAPI.Sync(signCtx, mod, *kernelMapping, kernelVersion, previousImage, true, mcm)
 	if err != nil {
 		return false, fmt.Errorf("could not synchronize the signing: %w", err)
 	}
 
-	return signRes.Requeue, nil
+	if signStatus == utils.StatusCompleted {
+		return true, nil
+	}
+	return false, nil
 }

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -159,12 +159,12 @@ func (p *preflightHelper) verifyBuild(ctx context.Context,
 	mod *kmmv1beta1.Module) (bool, string) {
 	log := ctrlruntime.LoggerFrom(ctx)
 	// at this stage we know that eiher mapping Build or Container build are defined
-	buildRes, err := p.buildAPI.Sync(ctx, *mod, *mapping, pv.Spec.KernelVersion, pv.Spec.PushBuiltImage, pv)
+	buildStatus, err := p.buildAPI.Sync(ctx, *mod, *mapping, pv.Spec.KernelVersion, pv.Spec.PushBuiltImage, pv)
 	if err != nil {
 		return false, fmt.Sprintf("Failed to verify build for module %s, kernel version %s, error %s", mod.Name, pv.Spec.KernelVersion, err)
 	}
 
-	if buildRes.Status == build.StatusCompleted {
+	if buildStatus == utils.StatusCompleted {
 		msg := "build compiles"
 		if pv.Spec.PushBuiltImage {
 			msg += " and image pushed"
@@ -187,12 +187,12 @@ func (p *preflightHelper) verifySign(ctx context.Context,
 	}
 
 	// at this stage we know that eiher mapping Sign or Container sign are defined
-	signRes, err := p.signAPI.Sync(ctx, *mod, *mapping, pv.Spec.KernelVersion, previousImage, pv.Spec.PushBuiltImage, pv)
+	signStatus, err := p.signAPI.Sync(ctx, *mod, *mapping, pv.Spec.KernelVersion, previousImage, pv.Spec.PushBuiltImage, pv)
 	if err != nil {
 		return false, fmt.Sprintf("Failed to verify signing for module %s, kernel version %s, error %s", mod.Name, pv.Spec.KernelVersion, err)
 	}
 
-	if signRes.Status == utils.StatusCompleted {
+	if signStatus == utils.StatusCompleted {
 		msg := "sign completes"
 		if pv.Spec.PushBuiltImage {
 			msg += " and image pushed"

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -315,7 +315,7 @@ var _ = Describe("preflightHelper_verifyBuild", func() {
 		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
 
 		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, pv.Spec.PushBuiltImage, pv).
-			Return(build.Result{}, fmt.Errorf("some error"))
+			Return(utils.Status(""), fmt.Errorf("some error"))
 
 		res, msg := ph.verifyBuild(context.Background(), pv, &mapping, mod)
 		Expect(res).To(BeFalse())
@@ -327,7 +327,7 @@ var _ = Describe("preflightHelper_verifyBuild", func() {
 		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
 
 		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, pv.Spec.PushBuiltImage, pv).
-			Return(build.Result{Status: build.StatusCompleted}, nil)
+			Return(utils.Status(utils.StatusCompleted), nil)
 
 		res, msg := ph.verifyBuild(context.Background(), pv, &mapping, mod)
 		Expect(res).To(BeTrue())
@@ -339,7 +339,7 @@ var _ = Describe("preflightHelper_verifyBuild", func() {
 		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
 
 		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, pv.Spec.PushBuiltImage, pv).
-			Return(build.Result{Status: build.StatusInProgress}, nil)
+			Return(utils.Status(utils.StatusInProgress), nil)
 
 		res, msg := ph.verifyBuild(context.Background(), pv, &mapping, mod)
 		Expect(res).To(BeFalse())
@@ -377,7 +377,7 @@ var _ = Describe("preflightHelper_verifySign", func() {
 		previousImage := ""
 
 		mockSignAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, previousImage, pv.Spec.PushBuiltImage, pv).
-			Return(utils.Result{}, fmt.Errorf("some error"))
+			Return(utils.Status(""), fmt.Errorf("some error"))
 
 		res, msg := ph.verifySign(context.Background(), pv, &mapping, mod)
 		Expect(res).To(BeFalse())
@@ -391,7 +391,7 @@ var _ = Describe("preflightHelper_verifySign", func() {
 		previousImage := ""
 
 		mockSignAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, previousImage, pv.Spec.PushBuiltImage, pv).
-			Return(utils.Result{Status: utils.StatusCompleted}, nil)
+			Return(utils.Status(utils.StatusCompleted), nil)
 
 		res, msg := ph.verifySign(context.Background(), pv, &mapping, mod)
 		Expect(res).To(BeTrue())
@@ -405,7 +405,7 @@ var _ = Describe("preflightHelper_verifySign", func() {
 		previousImage := ""
 
 		mockSignAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, previousImage, pv.Spec.PushBuiltImage, pv).
-			Return(utils.Result{Status: utils.StatusInProgress}, nil)
+			Return(utils.Status(utils.StatusInProgress), nil)
 
 		res, msg := ph.verifySign(context.Background(), pv, &mapping, mod)
 		Expect(res).To(BeFalse())

--- a/internal/sign/job/manager_test.go
+++ b/internal/sign/job/manager_test.go
@@ -182,7 +182,7 @@ var _ = Describe("Sync", func() {
 	}
 
 	DescribeTable("should return the correct status depending on the job status",
-		func(s batchv1.JobStatus, r utils.Result, expectsErr bool) {
+		func(s batchv1.JobStatus, jobStatus utils.Status, expectsErr bool) {
 			j := batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{"kmm.node.kubernetes.io/job-type": "sign",
@@ -217,7 +217,7 @@ var _ = Describe("Sync", func() {
 				maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
 				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(&newJob, nil),
 				jobhelper.EXPECT().IsJobChanged(&j, &newJob).Return(false, nil),
-				jobhelper.EXPECT().GetJobStatus(&newJob).Return(r.Status, r.Requeue, joberr),
+				jobhelper.EXPECT().GetJobStatus(&newJob).Return(jobStatus, joberr),
 			)
 
 			res, err := mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod)
@@ -227,12 +227,12 @@ var _ = Describe("Sync", func() {
 				return
 			}
 
-			Expect(res).To(Equal(r))
+			Expect(res).To(Equal(jobStatus))
 		},
-		Entry("active", batchv1.JobStatus{Active: 1}, utils.Result{Requeue: true, Status: utils.StatusInProgress}, false),
-		Entry("active", batchv1.JobStatus{Active: 1}, utils.Result{Requeue: true, Status: utils.StatusInProgress}, false),
-		Entry("succeeded", batchv1.JobStatus{Succeeded: 1}, utils.Result{Status: utils.StatusCompleted}, false),
-		Entry("failed", batchv1.JobStatus{Failed: 1}, utils.Result{}, true),
+		Entry("active", batchv1.JobStatus{Active: 1}, utils.Status(utils.StatusInProgress), false),
+		Entry("active", batchv1.JobStatus{Active: 1}, utils.Status(utils.StatusInProgress), false),
+		Entry("succeeded", batchv1.JobStatus{Succeeded: 1}, utils.Status(utils.StatusCompleted), false),
+		Entry("failed", batchv1.JobStatus{Failed: 1}, utils.Status(""), true),
 	)
 
 	It("should return an error if there was an error creating the job template", func() {
@@ -328,7 +328,7 @@ var _ = Describe("Sync", func() {
 		Expect(
 			mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod),
 		).To(
-			Equal(utils.Result{Requeue: true, Status: utils.StatusCreated}),
+			Equal(utils.Status(utils.StatusCreated)),
 		)
 	})
 
@@ -358,7 +358,7 @@ var _ = Describe("Sync", func() {
 		Expect(
 			mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod),
 		).To(
-			Equal(utils.Result{Requeue: true, Status: utils.StatusInProgress}),
+			Equal(utils.Status(utils.StatusInProgress)),
 		)
 	})
 })

--- a/internal/sign/manager.go
+++ b/internal/sign/manager.go
@@ -26,5 +26,5 @@ type SignManager interface {
 		targetKernel string,
 		imageToSign string,
 		pushImage bool,
-		owner metav1.Object) (utils.Result, error)
+		owner metav1.Object) (utils.Status, error)
 }

--- a/internal/sign/mock_manager.go
+++ b/internal/sign/mock_manager.go
@@ -68,10 +68,10 @@ func (mr *MockSignManagerMockRecorder) ShouldSync(ctx, mod, m interface{}) *gomo
 }
 
 // Sync mocks base method.
-func (m_2 *MockSignManager) Sync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping, targetKernel, imageToSign string, pushImage bool, owner v1.Object) (utils.Result, error) {
+func (m_2 *MockSignManager) Sync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping, targetKernel, imageToSign string, pushImage bool, owner v1.Object) (utils.Status, error) {
 	m_2.ctrl.T.Helper()
 	ret := m_2.ctrl.Call(m_2, "Sync", ctx, mod, m, targetKernel, imageToSign, pushImage, owner)
-	ret0, _ := ret[0].(utils.Result)
+	ret0, _ := ret[0].(utils.Status)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/utils/jobhelper_test.go
+++ b/internal/utils/jobhelper_test.go
@@ -414,21 +414,20 @@ var _ = Describe("JobStatus", func() {
 	})
 
 	DescribeTable("should return the correct status depending on the job status",
-		func(s *batchv1.Job, r string, expectinprogress bool, expectsErr bool) {
+		func(s *batchv1.Job, jobStatus string, expectsErr bool) {
 
-			res, inprogress, err := jh.GetJobStatus(s)
+			res, err := jh.GetJobStatus(s)
 			if expectsErr {
 				Expect(err).To(HaveOccurred())
 				return
 			}
 
-			Expect(string(res)).To(Equal(r))
-			Expect(inprogress).To(Equal(expectinprogress))
+			Expect(string(res)).To(Equal(jobStatus))
 		},
-		Entry("succeeded", &batchv1.Job{Status: batchv1.JobStatus{Succeeded: 1}}, StatusCompleted, false, false),
-		Entry("in progress", &batchv1.Job{Status: batchv1.JobStatus{Active: 1}}, StatusInProgress, true, false),
-		Entry("Failed", &batchv1.Job{Status: batchv1.JobStatus{Failed: 1}}, StatusFailed, false, true),
-		Entry("unknown", &batchv1.Job{Status: batchv1.JobStatus{Failed: 2}}, StatusFailed, false, true),
+		Entry("succeeded", &batchv1.Job{Status: batchv1.JobStatus{Succeeded: 1}}, StatusCompleted, false),
+		Entry("in progress", &batchv1.Job{Status: batchv1.JobStatus{Active: 1}}, StatusInProgress, false),
+		Entry("Failed", &batchv1.Job{Status: batchv1.JobStatus{Failed: 1}}, StatusFailed, false),
+		Entry("unknown", &batchv1.Job{Status: batchv1.JobStatus{Failed: 2}}, "", true),
 	)
 })
 
@@ -449,13 +448,11 @@ var _ = Describe("IsJobChnaged", func() {
 		func(annotation map[string]string, expectchanged bool, expectsErr bool) {
 			existingJob := batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{
-					//Namespace:   namespace,
 					Annotations: annotation,
 				},
 			}
 			newJob := batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{
-					//Namespace:   namespace,
 					Annotations: map[string]string{constants.JobHashAnnotation: "some hash"},
 				},
 			}

--- a/internal/utils/mock_jobhelper.go
+++ b/internal/utils/mock_jobhelper.go
@@ -65,13 +65,12 @@ func (mr *MockJobHelperMockRecorder) DeleteJob(ctx, job interface{}) *gomock.Cal
 }
 
 // GetJobStatus mocks base method.
-func (m *MockJobHelper) GetJobStatus(job *v1.Job) (Status, bool, error) {
+func (m *MockJobHelper) GetJobStatus(job *v1.Job) (Status, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetJobStatus", job)
 	ret0, _ := ret[0].(Status)
-	ret1, _ := ret[1].(bool)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetJobStatus indicates an expected call of GetJobStatus.


### PR DESCRIPTION
… Build/Sign valid statuses (#296)

Currently both controllers are requeueing the reconciliation event, in case Build or Sign has returned a flag of requeue. This is not necessary, since both controllers are watching the owned Job object. This PR changes this logic so that in case Build or Sign job has returned valid, but not complete status (Created, In Progress, Failed), the reconciliation request is not requeued The changes are:
1) Manager functions of Build, Sign return only the current status of the job and error code.
   No need to return requeueing indication. The statuses returned are defined in the utils packages
2) The boolean return code of HandleBuild and HandleSign now indicates whether the Build or Sign
   jobs habe been successfully completed or not
3) In the reconciliation loop, in case HandleBuild or HandleSign successfull completion indicator
   is false, the flow does not continue to the ModuleLoader creation
4) No matter which if Sign/Build job has completed successfully or not, the reconciliation request
   is not requeued. The request is requeued only in case of an actual error in the flow