### PR TITLE
Creating ModuleLoaderData sturcture for Build/Sign/ModuleLoader workf…

### DIFF
--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -23,6 +23,7 @@ import (
 
 	buildv1 "github.com/openshift/api/build/v1"
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/build"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/ca"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/daemonset"
@@ -134,7 +135,7 @@ func (r *ModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return res, fmt.Errorf("could get targeted nodes for module %s: %w", mod.Name, err)
 	}
 
-	mappings, nodesWithMapping, err := r.getRelevantKernelMappingsAndNodes(ctx, mod, targetedNodes)
+	mldMappings, nodesWithMapping, err := r.getRelevantKernelMappingsAndNodes(ctx, mod, targetedNodes)
 	if err != nil {
 		return res, fmt.Errorf("could get kernel mappings and nodes for modules %s: %w", mod.Name, err)
 	}
@@ -144,26 +145,30 @@ func (r *ModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return res, fmt.Errorf("could not get DaemonSets for module %s: %v", mod.Name, err)
 	}
 
-	for kernelVersion, m := range mappings {
-		completedSuccessfully, err := r.handleBuild(ctx, mod, m, kernelVersion)
+	for kernelVersion, mld := range mldMappings {
+		completedSuccessfully, err := r.handleBuild(ctx, mld)
 		if err != nil {
 			return res, fmt.Errorf("failed to handle build for kernel version %s: %v", kernelVersion, err)
 		}
+		mldLogger := logger.WithValues(
+			"kernel version", kernelVersion,
+			"mld", mld,
+		)
 		if !completedSuccessfully {
-			logger.Info("Build has not finished successfully yet:skipping handling signing and driver container for now", "kernelVersion", kernelVersion, "image", m)
+			mldLogger.Info("Build has not finished successfully yet:skipping handling signing and driver container for now")
 			continue
 		}
 
-		completedSuccessfully, err = r.handleSigning(ctx, mod, m, kernelVersion)
+		completedSuccessfully, err = r.handleSigning(ctx, mld)
 		if err != nil {
 			return res, fmt.Errorf("failed to handle signing for kernel version %s: %v", kernelVersion, err)
 		}
 		if !completedSuccessfully {
-			logger.Info("Signing has not finished successfully yet; skipping handling driver container for now", "kernelVersion", kernelVersion, "image", m)
+			mldLogger.Info("Signing has not finished successfully yet; skipping handling driver container for now")
 			continue
 		}
 
-		err = r.handleDriverContainer(ctx, mod, m, dsByKernelVersion, kernelVersion)
+		err = r.handleDriverContainer(ctx, mld, dsByKernelVersion)
 		if err != nil {
 			return res, fmt.Errorf("failed to handle driver container for kernel version %s: %v", kernelVersion, err)
 		}
@@ -176,7 +181,7 @@ func (r *ModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	logger.Info("Run garbage collection")
-	err = r.garbageCollect(ctx, mod, mappings, dsByKernelVersion)
+	err = r.garbageCollect(ctx, mod, mldMappings, dsByKernelVersion)
 	if err != nil {
 		return res, fmt.Errorf("failed to run garbage collection: %v", err)
 	}
@@ -193,9 +198,9 @@ func (r *ModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 func (r *ModuleReconciler) getRelevantKernelMappingsAndNodes(ctx context.Context,
 	mod *kmmv1beta1.Module,
-	targetedNodes []v1.Node) (map[string]*kmmv1beta1.KernelMapping, []v1.Node, error) {
+	targetedNodes []v1.Node) (map[string]*api.ModuleLoaderData, []v1.Node, error) {
 
-	mappings := make(map[string]*kmmv1beta1.KernelMapping)
+	mldMappings := make(map[string]*api.ModuleLoaderData)
 	logger := log.FromContext(ctx)
 
 	nodes := make([]v1.Node, 0, len(targetedNodes))
@@ -208,27 +213,27 @@ func (r *ModuleReconciler) getRelevantKernelMappingsAndNodes(ctx context.Context
 			"kernel version", kernelVersion,
 		)
 
-		if image, ok := mappings[kernelVersion]; ok {
+		if mld, ok := mldMappings[kernelVersion]; ok {
 			nodes = append(nodes, node)
-			nodeLogger.V(1).Info("Using cached image", "image", image)
+			nodeLogger.V(1).Info("Using cached mld mapping", "mld", mld)
 			continue
 		}
 
-		m, err := r.kernelAPI.GetMergedMappingForKernel(&mod.Spec, kernelVersion)
+		mld, err := r.kernelAPI.GetModuleLoaderDataForKernel(mod, kernelVersion)
 		if err != nil {
 			nodeLogger.Error(err, "failed to get and process kernel mapping")
 			continue
 		}
 
 		nodeLogger.V(1).Info("Found a valid mapping",
-			"image", m.ContainerImage,
-			"build", m.Build != nil,
+			"image", mld.ContainerImage,
+			"build", mld.Build != nil,
 		)
 
-		mappings[kernelVersion] = m
+		mldMappings[kernelVersion] = mld
 		nodes = append(nodes, node)
 	}
-	return mappings, nodes, nil
+	return mldMappings, nodes, nil
 }
 
 func (r *ModuleReconciler) getNodesListBySelector(ctx context.Context, mod *kmmv1beta1.Module) ([]v1.Node, error) {
@@ -252,12 +257,9 @@ func (r *ModuleReconciler) getNodesListBySelector(ctx context.Context, mod *kmmv
 }
 
 // handleBuild returns true if build is not needed or finished successfully
-func (r *ModuleReconciler) handleBuild(ctx context.Context,
-	mod *kmmv1beta1.Module,
-	km *kmmv1beta1.KernelMapping,
-	kernelVersion string) (bool, error) {
+func (r *ModuleReconciler) handleBuild(ctx context.Context, mld *api.ModuleLoaderData) (bool, error) {
 
-	shouldSync, err := r.buildAPI.ShouldSync(ctx, *mod, *km)
+	shouldSync, err := r.buildAPI.ShouldSync(ctx, mld)
 	if err != nil {
 		return false, fmt.Errorf("could not check if build synchronization is needed: %w", err)
 	}
@@ -265,10 +267,10 @@ func (r *ModuleReconciler) handleBuild(ctx context.Context,
 		return true, nil
 	}
 
-	logger := log.FromContext(ctx).WithValues("kernel version", kernelVersion, "image", km.ContainerImage)
+	logger := log.FromContext(ctx).WithValues("kernel version", mld.KernelVersion, "image", mld.ContainerImage)
 	buildCtx := log.IntoContext(ctx, logger)
 
-	buildStatus, err := r.buildAPI.Sync(buildCtx, *mod, *km, kernelVersion, true, mod)
+	buildStatus, err := r.buildAPI.Sync(buildCtx, mld, true, mld.Owner)
 	if err != nil {
 		return false, fmt.Errorf("could not synchronize the build: %w", err)
 	}
@@ -276,10 +278,10 @@ func (r *ModuleReconciler) handleBuild(ctx context.Context,
 	completedSuccessfully := false
 	switch buildStatus {
 	case utils.StatusCreated:
-		r.metricsAPI.SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.BuildStage, false)
+		r.metricsAPI.SetCompletedStage(mld.Name, mld.Namespace, mld.KernelVersion, metrics.BuildStage, false)
 	case utils.StatusCompleted:
 		completedSuccessfully = true
-		r.metricsAPI.SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.BuildStage, true)
+		r.metricsAPI.SetCompletedStage(mld.Name, mld.Namespace, mld.KernelVersion, metrics.BuildStage, true)
 	case utils.StatusFailed:
 		logger.Info(utils.WarnString("Build job has failed. If the fix is not in Module CR, then delete job after the fix in order to restart the job"))
 	}
@@ -288,12 +290,8 @@ func (r *ModuleReconciler) handleBuild(ctx context.Context,
 }
 
 // handleSigning returns true if signing is not needed or finished successfully
-func (r *ModuleReconciler) handleSigning(ctx context.Context,
-	mod *kmmv1beta1.Module,
-	km *kmmv1beta1.KernelMapping,
-	kernelVersion string) (bool, error) {
-
-	shouldSync, err := r.signAPI.ShouldSync(ctx, *mod, *km)
+func (r *ModuleReconciler) handleSigning(ctx context.Context, mld *api.ModuleLoaderData) (bool, error) {
+	shouldSync, err := r.signAPI.ShouldSync(ctx, mld)
 	if err != nil {
 		return false, fmt.Errorf("cound not check if synchronization is needed: %w", err)
 	}
@@ -303,14 +301,14 @@ func (r *ModuleReconciler) handleSigning(ctx context.Context,
 
 	// if we need to sign AND we've built, then we must have built the intermediate image so must figure out its name
 	previousImage := ""
-	if module.ShouldBeBuilt(*km) {
-		previousImage = module.IntermediateImageName(mod.Name, mod.Namespace, km.ContainerImage)
+	if module.ShouldBeBuilt(mld) {
+		previousImage = module.IntermediateImageName(mld.Name, mld.Namespace, mld.ContainerImage)
 	}
 
-	logger := log.FromContext(ctx).WithValues("kernel version", kernelVersion, "image", km.ContainerImage)
+	logger := log.FromContext(ctx).WithValues("kernel version", mld.KernelVersion, "image", mld.ContainerImage)
 	signCtx := log.IntoContext(ctx, logger)
 
-	signStatus, err := r.signAPI.Sync(signCtx, *mod, *km, kernelVersion, previousImage, true, mod)
+	signStatus, err := r.signAPI.Sync(signCtx, mld, previousImage, true, mld.Owner)
 	if err != nil {
 		return false, fmt.Errorf("could not synchronize the signing: %w", err)
 	}
@@ -318,10 +316,10 @@ func (r *ModuleReconciler) handleSigning(ctx context.Context,
 	completedSuccessfully := false
 	switch signStatus {
 	case utils.StatusCreated:
-		r.metricsAPI.SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.SignStage, false)
+		r.metricsAPI.SetCompletedStage(mld.Name, mld.Namespace, mld.KernelVersion, metrics.SignStage, false)
 	case utils.StatusCompleted:
 		completedSuccessfully = true
-		r.metricsAPI.SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.SignStage, true)
+		r.metricsAPI.SetCompletedStage(mld.Name, mld.Namespace, mld.KernelVersion, metrics.SignStage, true)
 	case utils.StatusFailed:
 		logger.Info(utils.WarnString("Sign job has failed. If the fix is not in Module CR, then delete job after the fix in order to restart the job"))
 	}
@@ -330,30 +328,28 @@ func (r *ModuleReconciler) handleSigning(ctx context.Context,
 }
 
 func (r *ModuleReconciler) handleDriverContainer(ctx context.Context,
-	mod *kmmv1beta1.Module,
-	km *kmmv1beta1.KernelMapping,
-	dsByKernelVersion map[string]*appsv1.DaemonSet,
-	kernelVersion string) error {
+	mld *api.ModuleLoaderData,
+	dsByKernelVersion map[string]*appsv1.DaemonSet) error {
 	ds := &appsv1.DaemonSet{
-		ObjectMeta: metav1.ObjectMeta{Namespace: mod.Namespace},
+		ObjectMeta: metav1.ObjectMeta{Namespace: mld.Namespace},
 	}
 
 	logger := log.FromContext(ctx)
-	if existingDS := dsByKernelVersion[kernelVersion]; existingDS != nil {
-		logger.Info("updating existing driver container DS", "kernel version", kernelVersion, "image", km, "name", ds.Name)
+	if existingDS := dsByKernelVersion[mld.KernelVersion]; existingDS != nil {
+		logger.Info("updating existing driver container DS", "kernel version", mld.KernelVersion, "image", mld.ContainerImage, "name", ds.Name)
 		ds = existingDS
 	} else {
-		logger.Info("creating new driver container DS", "kernel version", kernelVersion, "image", km)
-		ds.GenerateName = mod.Name + "-"
+		logger.Info("creating new driver container DS", "kernel version", mld.KernelVersion, "image", mld.ContainerImage)
+		ds.GenerateName = mld.Name + "-"
 	}
 
 	opRes, err := controllerutil.CreateOrPatch(ctx, r.Client, ds, func() error {
-		return r.daemonAPI.SetDriverContainerAsDesired(ctx, ds, km.ContainerImage, *mod, kernelVersion, mod.Namespace == r.operatorNamespace)
+		return r.daemonAPI.SetDriverContainerAsDesired(ctx, ds, mld, mld.Namespace == r.operatorNamespace)
 	})
 
 	if err == nil {
 		if opRes == controllerutil.OperationResultCreated {
-			r.metricsAPI.SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.ModuleLoaderStage, false)
+			r.metricsAPI.SetCompletedStage(mld.Name, mld.Namespace, mld.KernelVersion, metrics.ModuleLoaderStage, false)
 		}
 		logger.Info("Reconciled Driver Container", "name", ds.Name, "result", opRes)
 	}
@@ -393,11 +389,11 @@ func (r *ModuleReconciler) handleDevicePlugin(ctx context.Context, mod *kmmv1bet
 
 func (r *ModuleReconciler) garbageCollect(ctx context.Context,
 	mod *kmmv1beta1.Module,
-	mappings map[string]*kmmv1beta1.KernelMapping,
+	mldMappings map[string]*api.ModuleLoaderData,
 	existingDS map[string]*appsv1.DaemonSet) error {
 	logger := log.FromContext(ctx)
 	// Garbage collect old DaemonSets for which there are no nodes.
-	validKernels := sets.StringKeySet(mappings)
+	validKernels := sets.StringKeySet(mldMappings)
 
 	deleted, err := r.daemonAPI.GarbageCollect(ctx, existingDS, validKernels)
 	if err != nil {

--- a/controllers/module_reconciler_test.go
+++ b/controllers/module_reconciler_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/build"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/ca"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
@@ -449,6 +450,15 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			},
 		}
 
+		returnedMld := api.ModuleLoaderData{
+			ContainerImage:     imageName,
+			Name:               mod.Name,
+			Namespace:          mod.Namespace,
+			ServiceAccountName: serviceAccountName,
+			Selector:           mod.Spec.Selector,
+			KernelVersion:      kernelVersion,
+		}
+
 		nodeList := v1.NodeList{
 			Items: []v1.Node{
 				{
@@ -505,16 +515,16 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 					return nil
 				},
 			),
-			mockKM.EXPECT().GetMergedMappingForKernel(&mod.Spec, kernelVersion).Return(&mappings[0], nil),
+			mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&returnedMld, nil),
 			mockDC.EXPECT().ModuleDaemonSetsByKernelVersion(ctx, moduleName, namespace).Return(dsByKernelVersion, nil),
-			mockBM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(true, nil),
-			mockBM.EXPECT().Sync(gomock.Any(), mod, mappings[0], kernelVersion, true, &mod).Return(utils.Status(utils.StatusCompleted), nil),
+			mockBM.EXPECT().ShouldSync(gomock.Any(), &returnedMld).Return(true, nil),
+			mockBM.EXPECT().Sync(gomock.Any(), &returnedMld, true, returnedMld.Owner).Return(utils.Status(utils.StatusCompleted), nil),
 			mockMetrics.EXPECT().SetCompletedStage(moduleName, namespace, kernelVersion, metrics.BuildStage, true),
-			mockSM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(true, nil),
-			mockSM.EXPECT().Sync(gomock.Any(), mod, mappings[0], kernelVersion, "", true, &mod).Return(utils.Status(utils.StatusCompleted), nil),
+			mockSM.EXPECT().ShouldSync(gomock.Any(), &returnedMld).Return(true, nil),
+			mockSM.EXPECT().Sync(gomock.Any(), &returnedMld, "", true, returnedMld.Owner).Return(utils.Status(utils.StatusCompleted), nil),
 			mockMetrics.EXPECT().SetCompletedStage(moduleName, namespace, kernelVersion, metrics.SignStage, true),
 			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
-			mockDC.EXPECT().SetDriverContainerAsDesired(context.Background(), &ds, imageName, gomock.AssignableToTypeOf(mod), kernelVersion, true),
+			mockDC.EXPECT().SetDriverContainerAsDesired(context.Background(), &ds, gomock.AssignableToTypeOf(&returnedMld), true),
 			clnt.EXPECT().Create(ctx, gomock.Any()).Return(nil),
 			mockMetrics.EXPECT().SetCompletedStage(moduleName, namespace, kernelVersion, metrics.ModuleLoaderStage, false),
 			mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString(kernelVersion)),
@@ -558,6 +568,15 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 				},
 				Selector: nodeLabels,
 			},
+		}
+
+		returnedMld := api.ModuleLoaderData{
+			ContainerImage:     imageName,
+			Name:               mod.Name,
+			Namespace:          mod.Namespace,
+			ServiceAccountName: serviceAccountName,
+			Selector:           mod.Spec.Selector,
+			KernelVersion:      kernelVersion,
 		}
 
 		nodeList := v1.NodeList{
@@ -627,16 +646,16 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		dsByKernelVersion := map[string]*appsv1.DaemonSet{kernelVersion: &ds}
 
 		gomock.InOrder(
-			mockKM.EXPECT().GetMergedMappingForKernel(&mod.Spec, kernelVersion).Return(&mappings[0], nil),
+			mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&returnedMld, nil),
 			mockDC.EXPECT().ModuleDaemonSetsByKernelVersion(ctx, moduleName, namespace).Return(dsByKernelVersion, nil),
-			mockBM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(true, nil),
-			mockBM.EXPECT().Sync(gomock.Any(), mod, mappings[0], kernelVersion, true, &mod).Return(utils.Status(utils.StatusCompleted), nil),
+			mockBM.EXPECT().ShouldSync(gomock.Any(), &returnedMld).Return(true, nil),
+			mockBM.EXPECT().Sync(gomock.Any(), &returnedMld, true, returnedMld.Owner).Return(utils.Status(utils.StatusCompleted), nil),
 			mockMetrics.EXPECT().SetCompletedStage(moduleName, namespace, kernelVersion, metrics.BuildStage, true),
-			mockSM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(true, nil),
-			mockSM.EXPECT().Sync(gomock.Any(), mod, mappings[0], kernelVersion, "", true, &mod).Return(utils.Status(utils.StatusCompleted), nil),
+			mockSM.EXPECT().ShouldSync(gomock.Any(), &returnedMld).Return(true, nil),
+			mockSM.EXPECT().Sync(gomock.Any(), &returnedMld, "", true, returnedMld.Owner).Return(utils.Status(utils.StatusCompleted), nil),
 			mockMetrics.EXPECT().SetCompletedStage(moduleName, namespace, kernelVersion, metrics.SignStage, true),
-			mockDC.EXPECT().SetDriverContainerAsDesired(context.Background(), &ds, imageName, gomock.AssignableToTypeOf(mod), kernelVersion, true).Do(
-				func(ctx context.Context, d *appsv1.DaemonSet, _ string, _ kmmv1beta1.Module, _ string, _ bool) {
+			mockDC.EXPECT().SetDriverContainerAsDesired(context.Background(), &ds, gomock.AssignableToTypeOf(&returnedMld), true).Do(
+				func(ctx context.Context, d *appsv1.DaemonSet, _ *api.ModuleLoaderData, _ bool) {
 					d.SetLabels(map[string]string{"test": "test"})
 				}),
 			mockDC.EXPECT().GarbageCollect(ctx, dsByKernelVersion, sets.NewString(kernelVersion)),
@@ -775,15 +794,10 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 	)
 
 	It("should do nothing when build is skipped", func() {
-		km := &kmmv1beta1.KernelMapping{
-			ContainerImage: imageName,
-			Literal:        kernelVersion,
-		}
-
-		mod := &kmmv1beta1.Module{}
+		mld := &api.ModuleLoaderData{KernelVersion: kernelVersion}
 
 		gomock.InOrder(
-			mockBM.EXPECT().ShouldSync(gomock.Any(), *mod, *km).Return(false, nil),
+			mockBM.EXPECT().ShouldSync(gomock.Any(), mld).Return(false, nil),
 		)
 
 		mr := NewModuleReconciler(
@@ -799,57 +813,49 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 			namespace,
 		)
 
-		completed, err := mr.handleBuild(context.Background(), mod, km, kernelVersion)
+		completed, err := mr.handleBuild(context.Background(), mld)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(completed).To(BeTrue())
 	})
 
 	It("should record that a job was created when the build sync returns StatusCreated", func() {
-		km := &kmmv1beta1.KernelMapping{
+		mld := api.ModuleLoaderData{
+			Name:           moduleName,
+			Namespace:      namespace,
 			ContainerImage: imageName,
-			Literal:        kernelVersion,
 			Build:          &kmmv1beta1.Build{},
+			KernelVersion:  kernelVersion,
 		}
-		mod := &kmmv1beta1.Module{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      moduleName,
-				Namespace: namespace,
-			},
-			Spec: kmmv1beta1.ModuleSpec{},
-		}
+
 		gomock.InOrder(
-			mockBM.EXPECT().ShouldSync(gomock.Any(), *mod, *km).Return(true, nil),
-			mockBM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), true, mod).Return(utils.Status(utils.StatusCreated), nil),
-			mockMetrics.EXPECT().SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.BuildStage, false),
+			mockBM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
+			mockBM.EXPECT().Sync(gomock.Any(), &mld, true, mld.Owner).Return(utils.Status(utils.StatusCreated), nil),
+			mockMetrics.EXPECT().SetCompletedStage(mld.Name, mld.Namespace, kernelVersion, metrics.BuildStage, false),
 		)
 
 		mr := NewModuleReconciler(clnt, mockBM, mockSM, mockDC, mockKM, mockMetrics, nil, mockSU, mockCAH, namespace)
-		completed, err := mr.handleBuild(context.Background(), mod, km, kernelVersion)
+		completed, err := mr.handleBuild(context.Background(), &mld)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(completed).To(BeFalse())
 	})
 
 	It("should record that a job was completed, when the build sync returns StatusCompleted", func() {
-		km := &kmmv1beta1.KernelMapping{
+		mld := &api.ModuleLoaderData{
+			Name:           moduleName,
+			Namespace:      namespace,
 			ContainerImage: imageName,
-			Literal:        kernelVersion,
 			Build:          &kmmv1beta1.Build{},
-		}
-		mod := &kmmv1beta1.Module{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      moduleName,
-				Namespace: namespace,
-			},
-			Spec: kmmv1beta1.ModuleSpec{},
+			Owner:          &kmmv1beta1.Module{},
+			KernelVersion:  kernelVersion,
 		}
 		gomock.InOrder(
-			mockBM.EXPECT().ShouldSync(gomock.Any(), *mod, *km).Return(true, nil),
-			mockBM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), true, mod).Return(utils.Status(utils.StatusCompleted), nil),
-			mockMetrics.EXPECT().SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.BuildStage, true),
+			mockBM.EXPECT().ShouldSync(gomock.Any(), mld).Return(true, nil),
+			mockBM.EXPECT().Sync(gomock.Any(), mld, true, mld.Owner).Return(utils.Status(utils.StatusCompleted), nil),
+			mockMetrics.EXPECT().SetCompletedStage(mld.Name, mld.Namespace, kernelVersion, metrics.BuildStage, true),
 		)
 
 		mr := NewModuleReconciler(clnt, mockBM, mockSM, mockDC, mockKM, mockMetrics, nil, mockSU, mockCAH, namespace)
-		completed, err := mr.handleBuild(context.Background(), mod, km, kernelVersion)
+		completed, err := mr.handleBuild(context.Background(), mld)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(completed).To(BeTrue())
 	})
@@ -886,15 +892,13 @@ var _ = Describe("ModuleReconciler_handleSigning", func() {
 	)
 
 	It("should do nothing when build is skipped", func() {
-		km := &kmmv1beta1.KernelMapping{
+		mld := &api.ModuleLoaderData{
 			ContainerImage: imageName,
-			Literal:        kernelVersion,
+			KernelVersion:  kernelVersion,
 		}
 
-		mod := &kmmv1beta1.Module{}
-
 		gomock.InOrder(
-			mockSM.EXPECT().ShouldSync(gomock.Any(), *mod, *km).Return(false, nil),
+			mockSM.EXPECT().ShouldSync(gomock.Any(), mld).Return(false, nil),
 		)
 
 		mr := NewModuleReconciler(
@@ -910,29 +914,24 @@ var _ = Describe("ModuleReconciler_handleSigning", func() {
 			namespace,
 		)
 
-		completed, err := mr.handleSigning(context.Background(), mod, km, kernelVersion)
+		completed, err := mr.handleSigning(context.Background(), mld)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(completed).To(BeTrue())
 	})
 
 	It("should record that a job was created when the sign sync returns StatusCreated", func() {
-		km := &kmmv1beta1.KernelMapping{
+		mld := api.ModuleLoaderData{
+			Name:           moduleName,
+			Namespace:      namespace,
 			ContainerImage: imageName,
-			Literal:        kernelVersion,
 			Sign:           &kmmv1beta1.Sign{},
-		}
-		mod := &kmmv1beta1.Module{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      moduleName,
-				Namespace: namespace,
-			},
-			Spec: kmmv1beta1.ModuleSpec{},
+			KernelVersion:  kernelVersion,
 		}
 
 		gomock.InOrder(
-			mockSM.EXPECT().ShouldSync(gomock.Any(), *mod, *km).Return(true, nil),
-			mockSM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), "", true, mod).Return(utils.Status(utils.StatusCreated), nil),
-			mockMetrics.EXPECT().SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.SignStage, false),
+			mockSM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
+			mockSM.EXPECT().Sync(gomock.Any(), &mld, "", true, mld.Owner).Return(utils.Status(utils.StatusCreated), nil),
+			mockMetrics.EXPECT().SetCompletedStage(mld.Name, mld.Namespace, kernelVersion, metrics.SignStage, false),
 		)
 		mr := NewModuleReconciler(
 			clnt,
@@ -947,30 +946,25 @@ var _ = Describe("ModuleReconciler_handleSigning", func() {
 			namespace,
 		)
 
-		completed, err := mr.handleSigning(context.Background(), mod, km, kernelVersion)
+		completed, err := mr.handleSigning(context.Background(), &mld)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(completed).To(BeFalse())
 	})
 
 	It("should record that a job was completed when the sign sync returns StatusCompleted", func() {
-		km := &kmmv1beta1.KernelMapping{
+		mld := api.ModuleLoaderData{
+			Name:           moduleName,
+			Namespace:      namespace,
 			ContainerImage: imageName,
-			Literal:        kernelVersion,
 			Sign:           &kmmv1beta1.Sign{},
-		}
-		mod := &kmmv1beta1.Module{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      moduleName,
-				Namespace: namespace,
-			},
-			Spec: kmmv1beta1.ModuleSpec{},
+			KernelVersion:  kernelVersion,
 		}
 
 		gomock.InOrder(
-			mockSM.EXPECT().ShouldSync(gomock.Any(), *mod, *km).Return(true, nil),
-			mockSM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), "", true, mod).Return(utils.Status(utils.StatusCompleted), nil),
-			mockMetrics.EXPECT().SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.SignStage, true),
+			mockSM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
+			mockSM.EXPECT().Sync(gomock.Any(), &mld, "", true, mld.Owner).Return(utils.Status(utils.StatusCompleted), nil),
+			mockMetrics.EXPECT().SetCompletedStage(mld.Name, mld.Namespace, kernelVersion, metrics.SignStage, true),
 		)
 
 		mr := NewModuleReconciler(
@@ -986,32 +980,28 @@ var _ = Describe("ModuleReconciler_handleSigning", func() {
 			namespace,
 		)
 
-		completed, err := mr.handleSigning(context.Background(), mod, km, kernelVersion)
+		completed, err := mr.handleSigning(context.Background(), &mld)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(completed).To(BeTrue())
 	})
 
 	It("should run sign sync with the previous image as well when module build and sign are specified", func() {
-		km := &kmmv1beta1.KernelMapping{
+		mld := &api.ModuleLoaderData{
+			Name:           moduleName,
+			Namespace:      namespace,
 			ContainerImage: imageName,
-			Literal:        kernelVersion,
 			Sign:           &kmmv1beta1.Sign{},
 			Build:          &kmmv1beta1.Build{},
-		}
-		mod := &kmmv1beta1.Module{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      moduleName,
-				Namespace: namespace,
-			},
-			Spec: kmmv1beta1.ModuleSpec{},
+			Owner:          &kmmv1beta1.Module{},
+			KernelVersion:  kernelVersion,
 		}
 
 		gomock.InOrder(
-			mockSM.EXPECT().ShouldSync(gomock.Any(), *mod, *km).Return(true, nil),
-			mockSM.EXPECT().Sync(gomock.Any(), *mod, *km, gomock.Any(), imageName+":"+namespace+"_"+moduleName+"_kmm_unsigned", true, mod).
+			mockSM.EXPECT().ShouldSync(gomock.Any(), mld).Return(true, nil),
+			mockSM.EXPECT().Sync(gomock.Any(), mld, imageName+":"+namespace+"_"+moduleName+"_kmm_unsigned", true, mld.Owner).
 				Return(utils.Status(utils.StatusCompleted), nil),
-			mockMetrics.EXPECT().SetCompletedStage(mod.Name, mod.Namespace, kernelVersion, metrics.SignStage, true),
+			mockMetrics.EXPECT().SetCompletedStage(mld.Name, mld.Namespace, kernelVersion, metrics.SignStage, true),
 		)
 
 		mr := NewModuleReconciler(
@@ -1027,7 +1017,7 @@ var _ = Describe("ModuleReconciler_handleSigning", func() {
 			namespace,
 		)
 
-		completed, err := mr.handleSigning(context.Background(), mod, km, kernelVersion)
+		completed, err := mr.handleSigning(context.Background(), mld)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(completed).To(BeTrue())

--- a/internal/api/moduleloaderdata.go
+++ b/internal/api/moduleloaderdata.go
@@ -1,0 +1,53 @@
+package api
+
+import (
+	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ModuleLoaderData contains all the data needed for succesfull execution of
+// Build,Sign, ModuleLoader flow per specific kernel. It is constructed at the begining
+// of the Reconciliation loop flow.It contains all the data after merging/resolving all the
+// definitions (Build/Sign configuration from KM or from Container, ContainerImage etc').
+// From that point on , it is the only structure that is needed as input, no need for
+// Module or for KernelMapping
+type ModuleLoaderData struct {
+	// kernel version
+	KernelVersion string
+	// Repo secret for DS images
+	ImageRepoSecret *v1.LocalObjectReference
+
+	// Selector for DS
+	Selector map[string]string
+
+	// Name
+	Name string
+
+	// Namspace
+	Namespace string
+
+	// service account for DS
+	ServiceAccountName string
+
+	// Build contains build instructions.
+	Build *kmmv1beta1.Build
+
+	// Sign provides default kmod signing settings
+	Sign *kmmv1beta1.Sign
+
+	// ContainerImage is a top-level field
+	ContainerImage string
+
+	// Image pull policy.
+	ImagePullPolicy v1.PullPolicy
+
+	// Modprobe is a set of properties to customize which module modprobe loads and with which properties.
+	Modprobe kmmv1beta1.ModprobeSpec
+
+	// RegistryTLS set the TLS configs for accessing the registry of the module-loader's image.
+	RegistryTLS *kmmv1beta1.TLSOptions
+
+	// used for setting the owner field of jobs/buildconfigs
+	Owner metav1.Object
+}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/authn/kubernetes"
-	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -66,7 +66,7 @@ func (sarag *serviceAccountRegistryAuthGetter) GetKeyChain(ctx context.Context) 
 }
 
 type RegistryAuthGetterFactory interface {
-	NewRegistryAuthGetterFrom(mod *kmmv1beta1.Module) RegistryAuthGetter
+	NewRegistryAuthGetterFrom(mld *api.ModuleLoaderData) RegistryAuthGetter
 	NewClusterAuthGetter() RegistryAuthGetter
 }
 
@@ -97,16 +97,16 @@ func (af *registryAuthGetterFactory) newServiceAccountRegistryAuthGetter(namespa
 	}
 }
 
-func (af *registryAuthGetterFactory) NewRegistryAuthGetterFrom(mod *kmmv1beta1.Module) RegistryAuthGetter {
-	if mod.Spec.ImageRepoSecret != nil {
+func (af *registryAuthGetterFactory) NewRegistryAuthGetterFrom(mld *api.ModuleLoaderData) RegistryAuthGetter {
+	if mld.ImageRepoSecret != nil {
 		namespacedName := types.NamespacedName{
-			Name:      mod.Spec.ImageRepoSecret.Name,
-			Namespace: mod.Namespace,
+			Name:      mld.ImageRepoSecret.Name,
+			Namespace: mld.Namespace,
 		}
 		return af.newRegistryAuthGetter(namespacedName)
 	}
 	return af.newServiceAccountRegistryAuthGetter(
-		mod.Namespace,
+		mld.Namespace,
 		constants.OCPBuilderServiceAccountName)
 }
 

--- a/internal/auth/mock_auth.go
+++ b/internal/auth/mock_auth.go
@@ -10,7 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	authn "github.com/google/go-containerregistry/pkg/authn"
-	v1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	api "github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 )
 
 // MockRegistryAuthGetter is a mock of RegistryAuthGetter interface.
@@ -89,15 +89,15 @@ func (mr *MockRegistryAuthGetterFactoryMockRecorder) NewClusterAuthGetter() *gom
 }
 
 // NewRegistryAuthGetterFrom mocks base method.
-func (m *MockRegistryAuthGetterFactory) NewRegistryAuthGetterFrom(mod *v1beta1.Module) RegistryAuthGetter {
+func (m *MockRegistryAuthGetterFactory) NewRegistryAuthGetterFrom(mld *api.ModuleLoaderData) RegistryAuthGetter {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewRegistryAuthGetterFrom", mod)
+	ret := m.ctrl.Call(m, "NewRegistryAuthGetterFrom", mld)
 	ret0, _ := ret[0].(RegistryAuthGetter)
 	return ret0
 }
 
 // NewRegistryAuthGetterFrom indicates an expected call of NewRegistryAuthGetterFrom.
-func (mr *MockRegistryAuthGetterFactoryMockRecorder) NewRegistryAuthGetterFrom(mod interface{}) *gomock.Call {
+func (mr *MockRegistryAuthGetterFactoryMockRecorder) NewRegistryAuthGetterFrom(mld interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRegistryAuthGetterFrom", reflect.TypeOf((*MockRegistryAuthGetterFactory)(nil).NewRegistryAuthGetterFrom), mod)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRegistryAuthGetterFrom", reflect.TypeOf((*MockRegistryAuthGetterFactory)(nil).NewRegistryAuthGetterFrom), mld)
 }

--- a/internal/build/buildconfig/maker_test.go
+++ b/internal/build/buildconfig/maker_test.go
@@ -19,6 +19,7 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/build"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
@@ -80,28 +81,23 @@ var _ = Describe("Maker_MakeBuildTemplate", func() {
 
 		irs := v1.LocalObjectReference{Name: "push-secret"}
 
-		mapping := kmmv1beta1.KernelMapping{
+		mld := api.ModuleLoaderData{
+			Name:           moduleName,
+			Namespace:      namespace,
 			ContainerImage: containerImage,
 			Build: &kmmv1beta1.Build{
 				BuildArgs:           buildArgs,
 				DockerfileConfigMap: &dockerfileConfigMap,
 				Secrets:             buildSecrets,
 			},
-		}
-
-		mod := kmmv1beta1.Module{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      moduleName,
-				Namespace: namespace,
-			},
-			Spec: kmmv1beta1.ModuleSpec{
-				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
-					Container: kmmv1beta1.ModuleLoaderContainerSpec{
-						KernelMappings: []kmmv1beta1.KernelMapping{mapping},
-					},
+			ImageRepoSecret: &irs,
+			Selector:        nodeSelector,
+			KernelVersion:   targetKernel,
+			Owner: &kmmv1beta1.Module{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      moduleName,
+					Namespace: namespace,
 				},
-				ImageRepoSecret: &irs,
-				Selector:        nodeSelector,
 			},
 		}
 
@@ -166,7 +162,7 @@ var _ = Describe("Maker_MakeBuildTemplate", func() {
 		expected.SetAnnotations(annotations)
 
 		gomock.InOrder(
-			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: dockerfileConfigMap.Name, Namespace: mod.Namespace}, gomock.Any()).DoAndReturn(
+			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: dockerfileConfigMap.Name, Namespace: mld.Namespace}, gomock.Any()).DoAndReturn(
 				func(_ interface{}, _ interface{}, cm *v1.ConfigMap, _ ...ctrlclient.GetOption) error {
 					cm.Data = dockerfileCMData
 					return nil
@@ -175,7 +171,7 @@ var _ = Describe("Maker_MakeBuildTemplate", func() {
 			mockBuildHelper.EXPECT().ApplyBuildArgOverrides(buildArgs, overrides).Return(append(buildArgs, kmmv1beta1.BuildArg{Name: "KERNEL_VERSION", Value: targetKernel})),
 		)
 
-		bc, err := maker.MakeBuildTemplate(ctx, mod, mapping, targetKernel, true, &mod)
+		bc, err := maker.MakeBuildTemplate(ctx, &mld, true, mld.Owner)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(
@@ -187,9 +183,6 @@ var _ = Describe("Maker_MakeBuildTemplate", func() {
 
 	Context(fmt.Sprintf("using %s", dtkBuildArg), func() {
 		It("should fail if we couldn't get the DTK image", func() {
-			build := &kmmv1beta1.Build{
-				DockerfileConfigMap: &dockerfileConfigMap,
-			}
 
 			gomock.InOrder(
 				clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
@@ -202,18 +195,18 @@ var _ = Describe("Maker_MakeBuildTemplate", func() {
 				mockKernelOSDTKMapping.EXPECT().GetImage(gomock.Any()).Return("", errors.New("random error")),
 			)
 
-			mod := kmmv1beta1.Module{}
-			_, err := maker.MakeBuildTemplate(ctx, mod, kmmv1beta1.KernelMapping{Build: build}, "", false, &mod)
+			mld := api.ModuleLoaderData{
+				Build: &kmmv1beta1.Build{
+					DockerfileConfigMap: &dockerfileConfigMap,
+				},
+			}
+			_, err := maker.MakeBuildTemplate(ctx, &mld, false, mld.Owner)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It(fmt.Sprintf("should add a build arg if %s is used in the Dockerfile", dtkBuildArg), func() {
 
 			const dtkImage = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:111"
-
-			build := &kmmv1beta1.Build{
-				DockerfileConfigMap: &dockerfileConfigMap,
-			}
 
 			buildArgs := []kmmv1beta1.BuildArg{
 				{
@@ -234,8 +227,13 @@ var _ = Describe("Maker_MakeBuildTemplate", func() {
 				mockBuildHelper.EXPECT().ApplyBuildArgOverrides(gomock.Any(), gomock.Any()).Return(buildArgs),
 			)
 
-			mod := kmmv1beta1.Module{}
-			bct, err := maker.MakeBuildTemplate(ctx, mod, kmmv1beta1.KernelMapping{Build: build}, "", false, &mod)
+			mld := api.ModuleLoaderData{
+				Build: &kmmv1beta1.Build{
+					DockerfileConfigMap: &dockerfileConfigMap,
+				},
+				Owner: &kmmv1beta1.Module{},
+			}
+			bct, err := maker.MakeBuildTemplate(ctx, &mld, false, mld.Owner)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(bct.Spec.CommonSpec.Strategy.DockerStrategy.BuildArgs)).To(Equal(1))
 			Expect(bct.Spec.CommonSpec.Strategy.DockerStrategy.BuildArgs[0].Name).To(Equal(buildArgs[0].Name))

--- a/internal/build/buildconfig/mock_maker.go
+++ b/internal/build/buildconfig/mock_maker.go
@@ -10,7 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1 "github.com/openshift/api/build/v1"
-	v1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	api "github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	v10 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -38,16 +38,16 @@ func (m *MockMaker) EXPECT() *MockMakerMockRecorder {
 }
 
 // MakeBuildTemplate mocks base method.
-func (m *MockMaker) MakeBuildTemplate(ctx context.Context, mod v1beta1.Module, mapping v1beta1.KernelMapping, targetKernel string, pushImage bool, owner v10.Object) (*v1.Build, error) {
+func (m *MockMaker) MakeBuildTemplate(ctx context.Context, mld *api.ModuleLoaderData, pushImage bool, owner v10.Object) (*v1.Build, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MakeBuildTemplate", ctx, mod, mapping, targetKernel, pushImage, owner)
+	ret := m.ctrl.Call(m, "MakeBuildTemplate", ctx, mld, pushImage, owner)
 	ret0, _ := ret[0].(*v1.Build)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MakeBuildTemplate indicates an expected call of MakeBuildTemplate.
-func (mr *MockMakerMockRecorder) MakeBuildTemplate(ctx, mod, mapping, targetKernel, pushImage, owner interface{}) *gomock.Call {
+func (mr *MockMakerMockRecorder) MakeBuildTemplate(ctx, mld, pushImage, owner interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeBuildTemplate", reflect.TypeOf((*MockMaker)(nil).MakeBuildTemplate), ctx, mod, mapping, targetKernel, pushImage, owner)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeBuildTemplate", reflect.TypeOf((*MockMaker)(nil).MakeBuildTemplate), ctx, mld, pushImage, owner)
 }

--- a/internal/build/buildconfig/mock_manager.go
+++ b/internal/build/buildconfig/mock_manager.go
@@ -10,7 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1 "github.com/openshift/api/build/v1"
-	v1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	api "github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 )
 
 // MockOpenShiftBuildsHelper is a mock of OpenShiftBuildsHelper interface.
@@ -37,16 +37,16 @@ func (m *MockOpenShiftBuildsHelper) EXPECT() *MockOpenShiftBuildsHelperMockRecor
 }
 
 // GetBuild mocks base method.
-func (m *MockOpenShiftBuildsHelper) GetBuild(ctx context.Context, mod v1beta1.Module, targetKernel string) (*v1.Build, error) {
+func (m *MockOpenShiftBuildsHelper) GetBuild(ctx context.Context, mld *api.ModuleLoaderData) (*v1.Build, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBuild", ctx, mod, targetKernel)
+	ret := m.ctrl.Call(m, "GetBuild", ctx, mld)
 	ret0, _ := ret[0].(*v1.Build)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetBuild indicates an expected call of GetBuild.
-func (mr *MockOpenShiftBuildsHelperMockRecorder) GetBuild(ctx, mod, targetKernel interface{}) *gomock.Call {
+func (mr *MockOpenShiftBuildsHelperMockRecorder) GetBuild(ctx, mld interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBuild", reflect.TypeOf((*MockOpenShiftBuildsHelper)(nil).GetBuild), ctx, mod, targetKernel)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBuild", reflect.TypeOf((*MockOpenShiftBuildsHelper)(nil).GetBuild), ctx, mld)
 }

--- a/internal/build/helper.go
+++ b/internal/build/helper.go
@@ -4,6 +4,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 )
 
@@ -67,9 +68,9 @@ func (m *helper) GetRelevantBuild(moduleBuild *kmmv1beta1.Build, mappingBuild *k
 	return buildConfig
 }
 
-func GetBuildLabels(mod kmmv1beta1.Module, targetKernel string) map[string]string {
+func GetBuildLabels(mld *api.ModuleLoaderData) map[string]string {
 	return map[string]string{
-		constants.ModuleNameLabel:    mod.Name,
-		constants.TargetKernelTarget: targetKernel,
+		constants.ModuleNameLabel:    mld.Name,
+		constants.TargetKernelTarget: mld.KernelVersion,
 	}
 }

--- a/internal/build/manager.go
+++ b/internal/build/manager.go
@@ -5,7 +5,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 )
 
@@ -14,16 +14,11 @@ import (
 type Manager interface {
 	GarbageCollect(ctx context.Context, modName, namespace string, owner metav1.Object) ([]string, error)
 
-	ShouldSync(
-		ctx context.Context,
-		mod kmmv1beta1.Module,
-		m kmmv1beta1.KernelMapping) (bool, error)
+	ShouldSync(ctx context.Context, mld *api.ModuleLoaderData) (bool, error)
 
 	Sync(
 		ctx context.Context,
-		mod kmmv1beta1.Module,
-		m kmmv1beta1.KernelMapping,
-		targetKernel string,
+		mld *api.ModuleLoaderData,
 		pushImage bool,
 		owner metav1.Object) (utils.Status, error)
 }

--- a/internal/build/mock_manager.go
+++ b/internal/build/mock_manager.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	api "github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	utils "github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -53,31 +53,31 @@ func (mr *MockManagerMockRecorder) GarbageCollect(ctx, modName, namespace, owner
 }
 
 // ShouldSync mocks base method.
-func (m_2 *MockManager) ShouldSync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping) (bool, error) {
-	m_2.ctrl.T.Helper()
-	ret := m_2.ctrl.Call(m_2, "ShouldSync", ctx, mod, m)
+func (m *MockManager) ShouldSync(ctx context.Context, mld *api.ModuleLoaderData) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ShouldSync", ctx, mld)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ShouldSync indicates an expected call of ShouldSync.
-func (mr *MockManagerMockRecorder) ShouldSync(ctx, mod, m interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) ShouldSync(ctx, mld interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldSync", reflect.TypeOf((*MockManager)(nil).ShouldSync), ctx, mod, m)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldSync", reflect.TypeOf((*MockManager)(nil).ShouldSync), ctx, mld)
 }
 
 // Sync mocks base method.
-func (m_2 *MockManager) Sync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping, targetKernel string, pushImage bool, owner v1.Object) (utils.Status, error) {
-	m_2.ctrl.T.Helper()
-	ret := m_2.ctrl.Call(m_2, "Sync", ctx, mod, m, targetKernel, pushImage, owner)
+func (m *MockManager) Sync(ctx context.Context, mld *api.ModuleLoaderData, pushImage bool, owner v1.Object) (utils.Status, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Sync", ctx, mld, pushImage, owner)
 	ret0, _ := ret[0].(utils.Status)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Sync indicates an expected call of Sync.
-func (mr *MockManagerMockRecorder) Sync(ctx, mod, m, targetKernel, pushImage, owner interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) Sync(ctx, mld, pushImage, owner interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockManager)(nil).Sync), ctx, mod, m, targetKernel, pushImage, owner)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockManager)(nil).Sync), ctx, mld, pushImage, owner)
 }

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -15,6 +15,7 @@ import (
 
 	hubv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api-hub/v1beta1"
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/build"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/module"
@@ -88,16 +89,6 @@ func (c *clusterAPI) BuildAndSign(
 	cluster clusterv1.ManagedCluster) (bool, error) {
 
 	modSpec := mcm.Spec.ModuleSpec
-	mappings, err := c.kernelMappingsByKernelVersion(ctx, &modSpec, cluster)
-	if err != nil {
-		return false, err
-	}
-
-	// if no mappings were found, return not completed
-	if len(mappings) == 0 {
-		return false, nil
-	}
-
 	mod := kmmv1beta1.Module{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      mcm.Name,
@@ -105,12 +96,21 @@ func (c *clusterAPI) BuildAndSign(
 		},
 		Spec: modSpec,
 	}
+	mldMappings, err := c.kernelMappingsByKernelVersion(ctx, &mod, cluster)
+	if err != nil {
+		return false, err
+	}
+
+	// if no mappings were found, return not completed
+	if len(mldMappings) == 0 {
+		return false, nil
+	}
 
 	logger := log.FromContext(ctx)
 
 	completedSuccessfully := true
-	for kernelVersion, m := range mappings {
-		buildCompleted, err := c.build(ctx, mod, &mcm, m, kernelVersion)
+	for kernelVersion, mld := range mldMappings {
+		buildCompleted, err := c.build(ctx, mld, &mcm)
 		if err != nil {
 			return false, err
 		}
@@ -125,7 +125,7 @@ func (c *clusterAPI) BuildAndSign(
 			continue
 		}
 
-		signCompleted, err := c.sign(ctx, mod, &mcm, m, kernelVersion)
+		signCompleted, err := c.sign(ctx, mld, &mcm)
 		if err != nil {
 			return false, err
 		}
@@ -146,15 +146,15 @@ func (c *clusterAPI) GarbageCollectBuilds(ctx context.Context, mcm hubv1beta1.Ma
 
 func (c *clusterAPI) kernelMappingsByKernelVersion(
 	ctx context.Context,
-	modSpec *kmmv1beta1.ModuleSpec,
-	cluster clusterv1.ManagedCluster) (map[string]*kmmv1beta1.KernelMapping, error) {
+	mod *kmmv1beta1.Module,
+	cluster clusterv1.ManagedCluster) (map[string]*api.ModuleLoaderData, error) {
 
 	kernelVersions, err := c.kernelVersions(cluster)
 	if err != nil {
 		return nil, err
 	}
 
-	mappings := make(map[string]*kmmv1beta1.KernelMapping)
+	mldMappings := make(map[string]*api.ModuleLoaderData)
 	logger := log.FromContext(ctx)
 
 	for _, kernelVersion := range kernelVersions {
@@ -164,26 +164,26 @@ func (c *clusterAPI) kernelMappingsByKernelVersion(
 			"kernel version", kernelVersion,
 		)
 
-		if image, ok := mappings[kernelVersion]; ok {
-			kernelVersionLogger.V(1).Info("Using cached image", "image", image)
+		if mld, ok := mldMappings[kernelVersion]; ok {
+			kernelVersionLogger.V(1).Info("Using cached mld mapping", "mld", mld)
 			continue
 		}
 
-		m, err := c.kernelAPI.GetMergedMappingForKernel(modSpec, kernelVersion)
+		mld, err := c.kernelAPI.GetModuleLoaderDataForKernel(mod, kernelVersion)
 		if err != nil {
 			kernelVersionLogger.Info("no suitable container image found; skipping kernel version")
 			continue
 		}
 
 		kernelVersionLogger.V(1).Info("Found a valid mapping",
-			"image", m.ContainerImage,
-			"build", m.Build != nil,
+			"image", mld.ContainerImage,
+			"build", mld.Build != nil,
 		)
 
-		mappings[kernelVersion] = m
+		mldMappings[kernelVersion] = mld
 	}
 
-	return mappings, nil
+	return mldMappings, nil
 }
 
 func (c *clusterAPI) kernelVersions(cluster clusterv1.ManagedCluster) ([]string, error) {
@@ -198,12 +198,10 @@ func (c *clusterAPI) kernelVersions(cluster clusterv1.ManagedCluster) ([]string,
 
 func (c *clusterAPI) build(
 	ctx context.Context,
-	mod kmmv1beta1.Module,
-	mcm *hubv1beta1.ManagedClusterModule,
-	kernelMapping *kmmv1beta1.KernelMapping,
-	kernelVersion string) (bool, error) {
+	mld *api.ModuleLoaderData,
+	mcm *hubv1beta1.ManagedClusterModule) (bool, error) {
 
-	shouldSync, err := c.buildAPI.ShouldSync(ctx, mod, *kernelMapping)
+	shouldSync, err := c.buildAPI.ShouldSync(ctx, mld)
 	if err != nil {
 		return false, fmt.Errorf("could not check if build synchronization is needed: %v", err)
 	}
@@ -212,11 +210,11 @@ func (c *clusterAPI) build(
 	}
 
 	logger := log.FromContext(ctx).WithValues(
-		"kernel version", kernelVersion,
-		"image", kernelMapping.ContainerImage)
+		"kernel version", mld.KernelVersion,
+		"image", mld.ContainerImage)
 	buildCtx := log.IntoContext(ctx, logger)
 
-	buildStatus, err := c.buildAPI.Sync(buildCtx, mod, *kernelMapping, kernelVersion, true, mcm)
+	buildStatus, err := c.buildAPI.Sync(buildCtx, mld, true, mcm)
 	if err != nil {
 		return false, fmt.Errorf("could not synchronize the build: %w", err)
 	}
@@ -229,12 +227,10 @@ func (c *clusterAPI) build(
 
 func (c *clusterAPI) sign(
 	ctx context.Context,
-	mod kmmv1beta1.Module,
-	mcm *hubv1beta1.ManagedClusterModule,
-	kernelMapping *kmmv1beta1.KernelMapping,
-	kernelVersion string) (bool, error) {
+	mld *api.ModuleLoaderData,
+	mcm *hubv1beta1.ManagedClusterModule) (bool, error) {
 
-	shouldSync, err := c.signAPI.ShouldSync(ctx, mod, *kernelMapping)
+	shouldSync, err := c.signAPI.ShouldSync(ctx, mld)
 	if err != nil {
 		return false, fmt.Errorf("could not check if signing synchronization is needed: %v", err)
 	}
@@ -245,16 +241,16 @@ func (c *clusterAPI) sign(
 	// if we need to sign AND we've built, then we must have built
 	// the intermediate image so must figure out its name
 	previousImage := ""
-	if module.ShouldBeBuilt(*kernelMapping) {
-		previousImage = module.IntermediateImageName(mod.Name, mod.Namespace, kernelMapping.ContainerImage)
+	if module.ShouldBeBuilt(mld) {
+		previousImage = module.IntermediateImageName(mld.Name, mld.Namespace, mld.ContainerImage)
 	}
 
 	logger := log.FromContext(ctx).WithValues(
-		"kernel version", kernelVersion,
-		"image", kernelMapping.ContainerImage)
+		"kernel version", mld.KernelVersion,
+		"image", mld.ContainerImage)
 	signCtx := log.IntoContext(ctx, logger)
 
-	signStatus, err := c.signAPI.Sync(signCtx, mod, *kernelMapping, kernelVersion, previousImage, true, mcm)
+	signStatus, err := c.signAPI.Sync(signCtx, mld, previousImage, true, mcm)
 	if err != nil {
 		return false, fmt.Errorf("could not synchronize the signing: %w", err)
 	}

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -14,6 +14,7 @@ import (
 
 	hubv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api-hub/v1beta1"
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/build"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
@@ -173,11 +174,9 @@ var _ = Describe("ClusterAPI", func() {
 		)
 
 		var (
-			mappings = []kmmv1beta1.KernelMapping{
-				{
-					ContainerImage: imageName,
-					Literal:        kernelVersion,
-				},
+			mld = api.ModuleLoaderData{
+				ContainerImage: imageName,
+				KernelVersion:  kernelVersion,
 			}
 
 			mcm = &hubv1beta1.ManagedClusterModule{
@@ -186,14 +185,8 @@ var _ = Describe("ClusterAPI", func() {
 					Namespace: namespace,
 				},
 				Spec: hubv1beta1.ManagedClusterModuleSpec{
-					ModuleSpec: kmmv1beta1.ModuleSpec{
-						ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
-							Container: kmmv1beta1.ModuleLoaderContainerSpec{
-								KernelMappings: mappings,
-							},
-						},
-					},
-					Selector: map[string]string{"key": "value"},
+					ModuleSpec: kmmv1beta1.ModuleSpec{},
+					Selector:   map[string]string{"key": "value"},
 				},
 			}
 
@@ -229,7 +222,7 @@ var _ = Describe("ClusterAPI", func() {
 
 		It("should do nothing when no kernel mappings are found", func() {
 			gomock.InOrder(
-				mockKM.EXPECT().GetMergedMappingForKernel(&mcm.Spec.ModuleSpec, kernelVersion).Return(nil, errors.New("generic-error")),
+				mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(nil, errors.New("generic-error")),
 			)
 
 			c := NewClusterAPI(clnt, mockKM, mockBM, mockSM, namespace)
@@ -260,9 +253,9 @@ var _ = Describe("ClusterAPI", func() {
 
 		It("should do nothing when Build and Sign are not needed", func() {
 			gomock.InOrder(
-				mockKM.EXPECT().GetMergedMappingForKernel(&mcm.Spec.ModuleSpec, kernelVersion).Return(&mappings[0], nil),
-				mockBM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(false, nil),
-				mockSM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(false, nil),
+				mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil),
+				mockBM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(false, nil),
+				mockSM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(false, nil),
 			)
 
 			c := NewClusterAPI(clnt, mockKM, mockBM, mockSM, namespace)
@@ -274,10 +267,10 @@ var _ = Describe("ClusterAPI", func() {
 
 		It("should run build sync if needed", func() {
 			gomock.InOrder(
-				mockKM.EXPECT().GetMergedMappingForKernel(&mcm.Spec.ModuleSpec, kernelVersion).Return(&mappings[0], nil),
-				mockBM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(true, nil),
-				mockBM.EXPECT().Sync(gomock.Any(), mod, mappings[0], kernelVersion, true, mcm).Return(utils.Status(utils.StatusCompleted), nil),
-				mockSM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(false, nil),
+				mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil),
+				mockBM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
+				mockBM.EXPECT().Sync(gomock.Any(), &mld, true, mcm).Return(utils.Status(utils.StatusCompleted), nil),
+				mockSM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(false, nil),
 			)
 
 			c := NewClusterAPI(clnt, mockKM, mockBM, mockSM, namespace)
@@ -289,9 +282,9 @@ var _ = Describe("ClusterAPI", func() {
 
 		It("should return an error when build sync errors", func() {
 			gomock.InOrder(
-				mockKM.EXPECT().GetMergedMappingForKernel(&mcm.Spec.ModuleSpec, kernelVersion).Return(&mappings[0], nil),
-				mockBM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(true, nil),
-				mockBM.EXPECT().Sync(gomock.Any(), mod, mappings[0], kernelVersion, true, mcm).Return(utils.Status(""), errors.New("test-error")),
+				mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil),
+				mockBM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
+				mockBM.EXPECT().Sync(gomock.Any(), &mld, true, mcm).Return(utils.Status(""), errors.New("test-error")),
 			)
 
 			c := NewClusterAPI(clnt, mockKM, mockBM, mockSM, namespace)
@@ -303,10 +296,10 @@ var _ = Describe("ClusterAPI", func() {
 
 		It("should run sign sync if needed", func() {
 			gomock.InOrder(
-				mockKM.EXPECT().GetMergedMappingForKernel(&mcm.Spec.ModuleSpec, kernelVersion).Return(&mappings[0], nil),
-				mockBM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(false, nil),
-				mockSM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(true, nil),
-				mockSM.EXPECT().Sync(gomock.Any(), mod, mappings[0], kernelVersion, "", true, mcm).Return(utils.Status(utils.StatusInProgress), nil),
+				mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil),
+				mockBM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(false, nil),
+				mockSM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
+				mockSM.EXPECT().Sync(gomock.Any(), &mld, "", true, mcm).Return(utils.Status(utils.StatusInProgress), nil),
 			)
 
 			c := NewClusterAPI(clnt, mockKM, mockBM, mockSM, namespace)
@@ -318,10 +311,10 @@ var _ = Describe("ClusterAPI", func() {
 
 		It("should return an error when sign sync errors", func() {
 			gomock.InOrder(
-				mockKM.EXPECT().GetMergedMappingForKernel(&mcm.Spec.ModuleSpec, kernelVersion).Return(&mappings[0], nil),
-				mockBM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(false, nil),
-				mockSM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(true, nil),
-				mockSM.EXPECT().Sync(gomock.Any(), mod, mappings[0], kernelVersion, "", true, mcm).Return(utils.Status(""), errors.New("test-error")),
+				mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil),
+				mockBM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(false, nil),
+				mockSM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
+				mockSM.EXPECT().Sync(gomock.Any(), &mld, "", true, mcm).Return(utils.Status(""), errors.New("test-error")),
 			)
 
 			c := NewClusterAPI(clnt, mockKM, mockBM, mockSM, namespace)
@@ -333,9 +326,9 @@ var _ = Describe("ClusterAPI", func() {
 
 		It("should not run sign sync when build sync does not complete", func() {
 			gomock.InOrder(
-				mockKM.EXPECT().GetMergedMappingForKernel(&mcm.Spec.ModuleSpec, kernelVersion).Return(&mappings[0], nil),
-				mockBM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(true, nil),
-				mockBM.EXPECT().Sync(gomock.Any(), mod, mappings[0], kernelVersion, true, mcm).Return(utils.Status(utils.StatusInProgress), nil),
+				mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil),
+				mockBM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
+				mockBM.EXPECT().Sync(gomock.Any(), &mld, true, mcm).Return(utils.Status(utils.StatusInProgress), nil),
 			)
 
 			c := NewClusterAPI(clnt, mockKM, mockBM, mockSM, namespace)
@@ -347,11 +340,11 @@ var _ = Describe("ClusterAPI", func() {
 
 		It("should run both build sync and sign sync when build is completed", func() {
 			gomock.InOrder(
-				mockKM.EXPECT().GetMergedMappingForKernel(&mcm.Spec.ModuleSpec, kernelVersion).Return(&mappings[0], nil),
-				mockBM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(true, nil),
-				mockBM.EXPECT().Sync(gomock.Any(), mod, mappings[0], kernelVersion, true, mcm).Return(utils.Status(utils.StatusCompleted), nil),
-				mockSM.EXPECT().ShouldSync(gomock.Any(), mod, mappings[0]).Return(true, nil),
-				mockSM.EXPECT().Sync(gomock.Any(), mod, mappings[0], kernelVersion, "", true, mcm).Return(utils.Status(utils.StatusCompleted), nil),
+				mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil),
+				mockBM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
+				mockBM.EXPECT().Sync(gomock.Any(), &mld, true, mcm).Return(utils.Status(utils.StatusCompleted), nil),
+				mockSM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
+				mockSM.EXPECT().Sync(gomock.Any(), &mld, "", true, mcm).Return(utils.Status(utils.StatusCompleted), nil),
 			)
 
 			c := NewClusterAPI(clnt, mockKM, mockBM, mockSM, namespace)

--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	appsv1 "k8s.io/api/apps/v1"
@@ -34,7 +35,7 @@ const (
 type DaemonSetCreator interface {
 	GarbageCollect(ctx context.Context, existingDS map[string]*appsv1.DaemonSet, validKernels sets.String) ([]string, error)
 	ModuleDaemonSetsByKernelVersion(ctx context.Context, name, namespace string) (map[string]*appsv1.DaemonSet, error)
-	SetDriverContainerAsDesired(ctx context.Context, ds *appsv1.DaemonSet, image string, mod kmmv1beta1.Module, kernelVersion string, useDefaultSA bool) error
+	SetDriverContainerAsDesired(ctx context.Context, ds *appsv1.DaemonSet, mld *api.ModuleLoaderData, useDefaultSA bool) error
 	SetDevicePluginAsDesired(ctx context.Context, ds *appsv1.DaemonSet, mod *kmmv1beta1.Module, useDefaultSA bool) error
 	GetNodeLabelFromPod(pod *v1.Pod, moduleName string) string
 }
@@ -94,25 +95,24 @@ func (dc *daemonSetGenerator) ModuleDaemonSetsByKernelVersion(ctx context.Contex
 func (dc *daemonSetGenerator) SetDriverContainerAsDesired(
 	ctx context.Context,
 	ds *appsv1.DaemonSet,
-	image string,
-	mod kmmv1beta1.Module,
-	kernelVersion string,
+	mld *api.ModuleLoaderData,
 	useDefaultSA bool,
 ) error {
 	if ds == nil {
 		return errors.New("ds cannot be nil")
 	}
 
-	if image == "" {
-		return errors.New("image cannot be empty")
+	if mld.ContainerImage == "" {
+		return errors.New("container image cannot be empty")
 	}
 
+	kernelVersion := mld.KernelVersion
 	if kernelVersion == "" {
 		return errors.New("kernelVersion cannot be empty")
 	}
 
 	standardLabels := map[string]string{
-		constants.ModuleNameLabel: mod.Name,
+		constants.ModuleNameLabel: mld.Name,
 		dc.kernelLabel:            kernelVersion,
 	}
 
@@ -120,7 +120,7 @@ func (dc *daemonSetGenerator) SetDriverContainerAsDesired(
 		OverrideLabels(ds.GetLabels(), standardLabels),
 	)
 
-	nodeSelector := CopyMapStringString(mod.Spec.Selector)
+	nodeSelector := CopyMapStringString(mld.Selector)
 	nodeSelector[dc.kernelLabel] = kernelVersion
 
 	nodeLibModulesPath := "/lib/modules/" + kernelVersion
@@ -131,17 +131,17 @@ func (dc *daemonSetGenerator) SetDriverContainerAsDesired(
 	container := v1.Container{
 		Command:         []string{"sleep", "infinity"},
 		Name:            "module-loader",
-		Image:           image,
-		ImagePullPolicy: mod.Spec.ModuleLoader.Container.ImagePullPolicy,
+		Image:           mld.ContainerImage,
+		ImagePullPolicy: mld.ImagePullPolicy,
 		Lifecycle: &v1.Lifecycle{
 			PostStart: &v1.LifecycleHandler{
 				Exec: &v1.ExecAction{
-					Command: MakeLoadCommand(mod.Spec.ModuleLoader.Container.Modprobe, mod.Name),
+					Command: MakeLoadCommand(mld.Modprobe, mld.Name),
 				},
 			},
 			PreStop: &v1.LifecycleHandler{
 				Exec: &v1.ExecAction{
-					Command: MakeUnloadCommand(mod.Spec.ModuleLoader.Container.Modprobe, mod.Name),
+					Command: MakeUnloadCommand(mld.Modprobe, mld.Name),
 				},
 			},
 		},
@@ -176,7 +176,7 @@ func (dc *daemonSetGenerator) SetDriverContainerAsDesired(
 		},
 	}
 
-	if fw := mod.Spec.ModuleLoader.Container.Modprobe.FirmwarePath; fw != "" {
+	if fw := mld.Modprobe.FirmwarePath; fw != "" {
 		firmwareVolume := v1.Volume{
 			Name: nodeVarLibFirmwareVolumeName,
 			VolumeSource: v1.VolumeSource{
@@ -196,7 +196,7 @@ func (dc *daemonSetGenerator) SetDriverContainerAsDesired(
 		container.VolumeMounts = append(container.VolumeMounts, firmwareVolumeMount)
 	}
 
-	serviceAccountName := mod.Spec.ModuleLoader.ServiceAccountName
+	serviceAccountName := mld.ServiceAccountName
 	if serviceAccountName == "" {
 		if useDefaultSA {
 			serviceAccountName = "kmm-operator-module-loader"
@@ -213,7 +213,7 @@ func (dc *daemonSetGenerator) SetDriverContainerAsDesired(
 			},
 			Spec: v1.PodSpec{
 				Containers:         []v1.Container{container},
-				ImagePullSecrets:   GetPodPullSecrets(mod.Spec.ImageRepoSecret),
+				ImagePullSecrets:   GetPodPullSecrets(mld.ImageRepoSecret),
 				NodeSelector:       nodeSelector,
 				PriorityClassName:  "system-node-critical",
 				ServiceAccountName: serviceAccountName,
@@ -223,7 +223,7 @@ func (dc *daemonSetGenerator) SetDriverContainerAsDesired(
 		Selector: &metav1.LabelSelector{MatchLabels: standardLabels},
 	}
 
-	return controllerutil.SetControllerReference(&mod, ds, dc.scheme)
+	return controllerutil.SetControllerReference(mld.Owner, ds, dc.scheme)
 }
 
 func (dc *daemonSetGenerator) SetDevicePluginAsDesired(

--- a/internal/daemonset/mock_daemonset.go
+++ b/internal/daemonset/mock_daemonset.go
@@ -10,6 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	api "github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	v1 "k8s.io/api/apps/v1"
 	v10 "k8s.io/api/core/v1"
 	sets "k8s.io/apimachinery/pkg/util/sets"
@@ -97,15 +98,15 @@ func (mr *MockDaemonSetCreatorMockRecorder) SetDevicePluginAsDesired(ctx, ds, mo
 }
 
 // SetDriverContainerAsDesired mocks base method.
-func (m *MockDaemonSetCreator) SetDriverContainerAsDesired(ctx context.Context, ds *v1.DaemonSet, image string, mod v1beta1.Module, kernelVersion string, useDefaultSA bool) error {
+func (m *MockDaemonSetCreator) SetDriverContainerAsDesired(ctx context.Context, ds *v1.DaemonSet, mld *api.ModuleLoaderData, useDefaultSA bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetDriverContainerAsDesired", ctx, ds, image, mod, kernelVersion, useDefaultSA)
+	ret := m.ctrl.Call(m, "SetDriverContainerAsDesired", ctx, ds, mld, useDefaultSA)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetDriverContainerAsDesired indicates an expected call of SetDriverContainerAsDesired.
-func (mr *MockDaemonSetCreatorMockRecorder) SetDriverContainerAsDesired(ctx, ds, image, mod, kernelVersion, useDefaultSA interface{}) *gomock.Call {
+func (mr *MockDaemonSetCreatorMockRecorder) SetDriverContainerAsDesired(ctx, ds, mld, useDefaultSA interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDriverContainerAsDesired", reflect.TypeOf((*MockDaemonSetCreator)(nil).SetDriverContainerAsDesired), ctx, ds, image, mod, kernelVersion, useDefaultSA)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDriverContainerAsDesired", reflect.TypeOf((*MockDaemonSetCreator)(nil).SetDriverContainerAsDesired), ctx, ds, mld, useDefaultSA)
 }

--- a/internal/module/helper.go
+++ b/internal/module/helper.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/auth"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/registry"
 )
@@ -25,29 +25,27 @@ func IntermediateImageName(name, namespace, targetImage string) string {
 	return AppendToTag(targetImage, namespace+"_"+name+"_kmm_unsigned")
 }
 
-// ShouldBeBuilt indicates whether the specified KernelMapping of the
+// ShouldBeBuilt indicates whether the specified ModuleLoaderData of the
 // Module should be built or not.
-func ShouldBeBuilt(km kmmv1beta1.KernelMapping) bool {
-	return km.Build != nil
+func ShouldBeBuilt(mld *api.ModuleLoaderData) bool {
+	return mld.Build != nil
 }
 
-// ShouldBeSigned indicates whether the specified KernelMapping of the
+// ShouldBeSigned indicates whether the specified ModuleLoaderData of the
 // Module should be signed or not.
-func ShouldBeSigned(km kmmv1beta1.KernelMapping) bool {
-	return km.Sign != nil
+func ShouldBeSigned(mld *api.ModuleLoaderData) bool {
+	return mld.Sign != nil
 }
 
 func ImageExists(
 	ctx context.Context,
 	authFactory auth.RegistryAuthGetterFactory,
 	reg registry.Registry,
-	mod kmmv1beta1.Module,
-	km kmmv1beta1.KernelMapping,
+	mld *api.ModuleLoaderData,
 	imageName string) (bool, error) {
 
-	registryAuthGetter := authFactory.NewRegistryAuthGetterFrom(&mod)
-
-	tlsOptions := km.RegistryTLS
+	registryAuthGetter := authFactory.NewRegistryAuthGetterFrom(mld)
+	tlsOptions := mld.RegistryTLS
 	exists, err := reg.ImageExists(ctx, imageName, tlsOptions, registryAuthGetter)
 	if err != nil {
 		return false, fmt.Errorf("could not check if the image is available: %v", err)

--- a/internal/module/kernelmapper.go
+++ b/internal/module/kernelmapper.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/build"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/sign"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
@@ -14,7 +15,7 @@ import (
 //go:generate mockgen -source=kernelmapper.go -package=module -destination=mock_kernelmapper.go KernelMapper,kernelMapperHelperAPI
 
 type KernelMapper interface {
-	GetMergedMappingForKernel(modSpec *kmmv1beta1.ModuleSpec, kernelVersion string) (*kmmv1beta1.KernelMapping, error)
+	GetModuleLoaderDataForKernel(mod *kmmv1beta1.Module, kernelVersion string) (*api.ModuleLoaderData, error)
 }
 
 type kernelMapper struct {
@@ -27,29 +28,28 @@ func NewKernelMapper(buildHelper build.Helper, signHelper sign.Helper) KernelMap
 	}
 }
 
-func (k *kernelMapper) GetMergedMappingForKernel(modSpec *kmmv1beta1.ModuleSpec, kernelVersion string) (*kmmv1beta1.KernelMapping, error) {
-	mappings := modSpec.ModuleLoader.Container.KernelMappings
+func (k *kernelMapper) GetModuleLoaderDataForKernel(mod *kmmv1beta1.Module, kernelVersion string) (*api.ModuleLoaderData, error) {
+	mappings := mod.Spec.ModuleLoader.Container.KernelMappings
 	foundMapping, err := k.helper.findKernelMapping(mappings, kernelVersion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find mapping for kernel %s: %v", kernelVersion, err)
 	}
-	mapping := foundMapping.DeepCopy()
-	err = k.helper.mergeMappingData(mapping, modSpec, kernelVersion)
+	mld, err := k.helper.prepareModuleLoaderData(foundMapping, mod, kernelVersion)
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare module loader data for kernel %s: %v", kernelVersion, err)
 	}
 
-	err = k.helper.replaceTemplates(mapping, kernelVersion)
+	err = k.helper.replaceTemplates(mld)
 	if err != nil {
 		return nil, fmt.Errorf("failed to replace templates in module loader data for kernel %s: %v", kernelVersion, err)
 	}
-	return mapping, nil
+	return mld, nil
 }
 
 type kernelMapperHelperAPI interface {
 	findKernelMapping(mappings []kmmv1beta1.KernelMapping, kernelVersion string) (*kmmv1beta1.KernelMapping, error)
-	mergeMappingData(mapping *kmmv1beta1.KernelMapping, modSpec *kmmv1beta1.ModuleSpec, kernelVersion string) error
-	replaceTemplates(mapping *kmmv1beta1.KernelMapping, kernelVersion string) error
+	prepareModuleLoaderData(mapping *kmmv1beta1.KernelMapping, mod *kmmv1beta1.Module, kernelVersion string) (*api.ModuleLoaderData, error)
+	replaceTemplates(mld *api.ModuleLoaderData) error
 }
 
 type kernelMapperHelper struct {
@@ -84,42 +84,54 @@ func (kh *kernelMapperHelper) findKernelMapping(mappings []kmmv1beta1.KernelMapp
 	return nil, errors.New("no suitable mapping found")
 }
 
-func (kh *kernelMapperHelper) mergeMappingData(mapping *kmmv1beta1.KernelMapping, modSpec *kmmv1beta1.ModuleSpec, kernelVersion string) error {
+func (kh *kernelMapperHelper) prepareModuleLoaderData(mapping *kmmv1beta1.KernelMapping, mod *kmmv1beta1.Module, kernelVersion string) (*api.ModuleLoaderData, error) {
 	var err error
 
+	mld := &api.ModuleLoaderData{}
 	// prepare the build
-	if mapping.Build != nil || modSpec.ModuleLoader.Container.Build != nil {
-		mapping.Build = kh.buildHelper.GetRelevantBuild(modSpec.ModuleLoader.Container.Build, mapping.Build)
+	if mapping.Build != nil || mod.Spec.ModuleLoader.Container.Build != nil {
+		mld.Build = kh.buildHelper.GetRelevantBuild(mod.Spec.ModuleLoader.Container.Build, mapping.Build)
 	}
 
 	// prepare the sign
-	if mapping.Sign != nil || modSpec.ModuleLoader.Container.Sign != nil {
-		mapping.Sign, err = kh.signHelper.GetRelevantSign(modSpec.ModuleLoader.Container.Sign, mapping.Sign, kernelVersion)
+	if mapping.Sign != nil || mod.Spec.ModuleLoader.Container.Sign != nil {
+		mld.Sign, err = kh.signHelper.GetRelevantSign(mod.Spec.ModuleLoader.Container.Sign, mapping.Sign, kernelVersion)
 		if err != nil {
-			return fmt.Errorf("failed to get the relevant Sign configuration for kernel %s: %v", kernelVersion, err)
+			return nil, fmt.Errorf("failed to get the relevant Sign configuration for kernel %s: %v", kernelVersion, err)
 		}
 	}
 
 	// prepare TLS options
+	mld.RegistryTLS = mapping.RegistryTLS
 	if mapping.RegistryTLS == nil {
-		mapping.RegistryTLS = &modSpec.ModuleLoader.Container.RegistryTLS
+		mld.RegistryTLS = &mod.Spec.ModuleLoader.Container.RegistryTLS
 	}
 
 	//prepare container image
+	mld.ContainerImage = mapping.ContainerImage
 	if mapping.ContainerImage == "" {
-		mapping.ContainerImage = modSpec.ModuleLoader.Container.ContainerImage
+		mld.ContainerImage = mod.Spec.ModuleLoader.Container.ContainerImage
 	}
 
-	return nil
+	mld.KernelVersion = kernelVersion
+	mld.Name = mod.Name
+	mld.Namespace = mod.Namespace
+	mld.ImageRepoSecret = mod.Spec.ImageRepoSecret
+	mld.Selector = mod.Spec.Selector
+	mld.ServiceAccountName = mod.Spec.ModuleLoader.ServiceAccountName
+	mld.Modprobe = mod.Spec.ModuleLoader.Container.Modprobe
+	mld.Owner = mod
+
+	return mld, nil
 }
 
-func (kh *kernelMapperHelper) replaceTemplates(mapping *kmmv1beta1.KernelMapping, kernelVersion string) error {
-	osConfigEnvVars := utils.KernelComponentsAsEnvVars(kernelVersion)
-	replacedContainerImage, err := utils.ReplaceInTemplates(osConfigEnvVars, mapping.ContainerImage)
+func (kh *kernelMapperHelper) replaceTemplates(mld *api.ModuleLoaderData) error {
+	osConfigEnvVars := utils.KernelComponentsAsEnvVars(mld.KernelVersion)
+	replacedContainerImage, err := utils.ReplaceInTemplates(osConfigEnvVars, mld.ContainerImage)
 	if err != nil {
 		return fmt.Errorf("failed to substitute templates in the ContainerImage field: %v", err)
 	}
-	mapping.ContainerImage = replacedContainerImage[0]
+	mld.ContainerImage = replacedContainerImage[0]
 
 	return nil
 }

--- a/internal/module/kernelmapper_test.go
+++ b/internal/module/kernelmapper_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/build"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/sign"
 	v1 "k8s.io/api/core/v1"
@@ -17,17 +18,17 @@ var _ = Describe("GetMergedMappingForKernel", func() {
 	)
 
 	var (
-		ctrl    *gomock.Controller
-		kh      *MockkernelMapperHelperAPI
-		km      *kernelMapper
-		modSpec kmmv1beta1.ModuleSpec
+		ctrl *gomock.Controller
+		kh   *MockkernelMapperHelperAPI
+		km   *kernelMapper
+		mod  kmmv1beta1.Module
 	)
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		kh = NewMockkernelMapperHelperAPI(ctrl)
 		km = &kernelMapper{helper: kh}
-		modSpec = kmmv1beta1.ModuleSpec{}
+		mod = kmmv1beta1.Module{}
 	})
 
 	AfterEach(func() {
@@ -36,36 +37,38 @@ var _ = Describe("GetMergedMappingForKernel", func() {
 
 	It("good flow", func() {
 		mapping := kmmv1beta1.KernelMapping{}
-		kh.EXPECT().findKernelMapping(modSpec.ModuleLoader.Container.KernelMappings, kernelVersion).Return(&mapping, nil)
-		kh.EXPECT().mergeMappingData(&mapping, &modSpec, kernelVersion).Return(nil)
-		kh.EXPECT().replaceTemplates(&mapping, kernelVersion).Return(nil)
-		res, err := km.GetMergedMappingForKernel(&modSpec, kernelVersion)
+		mld := api.ModuleLoaderData{KernelVersion: kernelVersion}
+		kh.EXPECT().findKernelMapping(mod.Spec.ModuleLoader.Container.KernelMappings, kernelVersion).Return(&mapping, nil)
+		kh.EXPECT().prepareModuleLoaderData(&mapping, &mod, kernelVersion).Return(&mld, nil)
+		kh.EXPECT().replaceTemplates(&mld).Return(nil)
+		res, err := km.GetModuleLoaderDataForKernel(&mod, kernelVersion)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(res).To(Equal(&mapping))
+		Expect(res).To(Equal(&mld))
 	})
 
 	It("failed to find kernel mapping", func() {
-		kh.EXPECT().findKernelMapping(modSpec.ModuleLoader.Container.KernelMappings, kernelVersion).Return(nil, fmt.Errorf("some error"))
-		res, err := km.GetMergedMappingForKernel(&modSpec, kernelVersion)
+		kh.EXPECT().findKernelMapping(mod.Spec.ModuleLoader.Container.KernelMappings, kernelVersion).Return(nil, fmt.Errorf("some error"))
+		res, err := km.GetModuleLoaderDataForKernel(&mod, kernelVersion)
 		Expect(err).To(HaveOccurred())
 		Expect(res).To(BeNil())
 	})
 
 	It("failed to merge mapping data", func() {
 		mapping := kmmv1beta1.KernelMapping{}
-		kh.EXPECT().findKernelMapping(modSpec.ModuleLoader.Container.KernelMappings, kernelVersion).Return(&mapping, nil)
-		kh.EXPECT().mergeMappingData(&mapping, &modSpec, kernelVersion).Return(fmt.Errorf("some error"))
-		res, err := km.GetMergedMappingForKernel(&modSpec, kernelVersion)
+		kh.EXPECT().findKernelMapping(mod.Spec.ModuleLoader.Container.KernelMappings, kernelVersion).Return(&mapping, nil)
+		kh.EXPECT().prepareModuleLoaderData(&mapping, &mod, kernelVersion).Return(nil, fmt.Errorf("some error"))
+		res, err := km.GetModuleLoaderDataForKernel(&mod, kernelVersion)
 		Expect(err).To(HaveOccurred())
 		Expect(res).To(BeNil())
 	})
 
 	It("failed to replace templates", func() {
 		mapping := kmmv1beta1.KernelMapping{}
-		kh.EXPECT().findKernelMapping(modSpec.ModuleLoader.Container.KernelMappings, kernelVersion).Return(&mapping, nil)
-		kh.EXPECT().mergeMappingData(&mapping, &modSpec, kernelVersion).Return(nil)
-		kh.EXPECT().replaceTemplates(&mapping, kernelVersion).Return(fmt.Errorf("some error"))
-		res, err := km.GetMergedMappingForKernel(&modSpec, kernelVersion)
+		mld := api.ModuleLoaderData{KernelVersion: kernelVersion}
+		kh.EXPECT().findKernelMapping(mod.Spec.ModuleLoader.Container.KernelMappings, kernelVersion).Return(&mapping, nil)
+		kh.EXPECT().prepareModuleLoaderData(&mapping, &mod, kernelVersion).Return(&mld, nil)
+		kh.EXPECT().replaceTemplates(&mld).Return(fmt.Errorf("some error"))
+		res, err := km.GetModuleLoaderDataForKernel(&mod, kernelVersion)
 		Expect(err).To(HaveOccurred())
 		Expect(res).To(BeNil())
 	})
@@ -77,15 +80,13 @@ var _ = Describe("findKernelMapping", func() {
 	)
 
 	var (
-		ctrl    *gomock.Controller
-		kh      kernelMapperHelperAPI
-		modSpec kmmv1beta1.ModuleSpec
+		ctrl *gomock.Controller
+		kh   kernelMapperHelperAPI
 	)
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		kh = newKernelMapperHelper(nil, nil)
-		modSpec = kmmv1beta1.ModuleSpec{}
 	})
 
 	AfterEach(func() {
@@ -116,7 +117,6 @@ var _ = Describe("findKernelMapping", func() {
 		mapping := kmmv1beta1.KernelMapping{
 			Regexp: "invalid)",
 		}
-		modSpec.ModuleLoader.Container.KernelMappings = []kmmv1beta1.KernelMapping{mapping}
 
 		m, err := kh.findKernelMapping([]kmmv1beta1.KernelMapping{mapping}, kernelVersion)
 		Expect(err).To(HaveOccurred())
@@ -139,19 +139,18 @@ var _ = Describe("findKernelMapping", func() {
 	})
 })
 
-var _ = Describe("mergeMappingData", func() {
+var _ = Describe("prepareModuleLoaderData", func() {
 	const (
 		kernelVersion = "1.2.3"
 	)
 
 	var (
-		ctrl            *gomock.Controller
-		buildHelper     *build.MockHelper
-		signHelper      *sign.MockHelper
-		kh              kernelMapperHelperAPI
-		modSpec         kmmv1beta1.ModuleSpec
-		mapping         kmmv1beta1.KernelMapping
-		expectedMapping kmmv1beta1.KernelMapping
+		ctrl        *gomock.Controller
+		buildHelper *build.MockHelper
+		signHelper  *sign.MockHelper
+		kh          kernelMapperHelperAPI
+		mod         kmmv1beta1.Module
+		mapping     kmmv1beta1.KernelMapping
 	)
 
 	BeforeEach(func() {
@@ -159,10 +158,9 @@ var _ = Describe("mergeMappingData", func() {
 		buildHelper = build.NewMockHelper(ctrl)
 		signHelper = sign.NewMockHelper(ctrl)
 		kh = newKernelMapperHelper(buildHelper, signHelper)
-		modSpec = kmmv1beta1.ModuleSpec{}
-		modSpec.ModuleLoader.Container.ContainerImage = "spec container image"
+		mod = kmmv1beta1.Module{}
+		mod.Spec.ModuleLoader.Container.ContainerImage = "spec container image"
 		mapping = kmmv1beta1.KernelMapping{}
-		expectedMapping = kmmv1beta1.KernelMapping{}
 	})
 
 	AfterEach(func() {
@@ -182,41 +180,53 @@ var _ = Describe("mergeMappingData", func() {
 		registryTSL := &kmmv1beta1.TLSOptions{
 			Insecure: true,
 		}
+
+		mld := api.ModuleLoaderData{
+			Name:               mod.Name,
+			Namespace:          mod.Namespace,
+			ImageRepoSecret:    mod.Spec.ImageRepoSecret,
+			Owner:              &mod,
+			Selector:           mod.Spec.Selector,
+			ServiceAccountName: mod.Spec.ModuleLoader.ServiceAccountName,
+			Modprobe:           mod.Spec.ModuleLoader.Container.Modprobe,
+			KernelVersion:      kernelVersion,
+		}
+
 		if buildExistsInMapping {
 			mapping.Build = build
 		}
 		if buildExistsInModuleSpec {
-			modSpec.ModuleLoader.Container.Build = build
+			mod.Spec.ModuleLoader.Container.Build = build
 		}
 		if signExistsInMapping {
 			mapping.Sign = sign
 		}
 		if SignExistsInModuleSpec {
-			modSpec.ModuleLoader.Container.Sign = sign
+			mod.Spec.ModuleLoader.Container.Sign = sign
 		}
-		expectedMapping.RegistryTLS = &modSpec.ModuleLoader.Container.RegistryTLS
+		mld.RegistryTLS = &mod.Spec.ModuleLoader.Container.RegistryTLS
 		if registryTLSExistsInMapping {
 			mapping.RegistryTLS = registryTSL
-			expectedMapping.RegistryTLS = registryTSL
+			mld.RegistryTLS = registryTSL
 		}
-		expectedMapping.ContainerImage = modSpec.ModuleLoader.Container.ContainerImage
+		mld.ContainerImage = mod.Spec.ModuleLoader.Container.ContainerImage
 		if containerImageExistsInMapping {
 			mapping.ContainerImage = "mapping container image"
-			expectedMapping.ContainerImage = mapping.ContainerImage
+			mld.ContainerImage = mapping.ContainerImage
 		}
 
 		if buildExistsInMapping || buildExistsInModuleSpec {
-			expectedMapping.Build = build
-			buildHelper.EXPECT().GetRelevantBuild(modSpec.ModuleLoader.Container.Build, mapping.Build).Return(build)
+			mld.Build = build
+			buildHelper.EXPECT().GetRelevantBuild(mod.Spec.ModuleLoader.Container.Build, mapping.Build).Return(build)
 		}
 		if signExistsInMapping || SignExistsInModuleSpec {
-			expectedMapping.Sign = sign
-			signHelper.EXPECT().GetRelevantSign(modSpec.ModuleLoader.Container.Sign, mapping.Sign, kernelVersion).Return(sign, nil)
+			mld.Sign = sign
+			signHelper.EXPECT().GetRelevantSign(mod.Spec.ModuleLoader.Container.Sign, mapping.Sign, kernelVersion).Return(sign, nil)
 		}
 
-		err := kh.mergeMappingData(&mapping, &modSpec, kernelVersion)
+		res, err := kh.prepareModuleLoaderData(&mapping, &mod, kernelVersion)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(mapping).To(Equal(expectedMapping))
+		Expect(*res).To(Equal(mld))
 	},
 		Entry("build in mapping only", true, false, false, false, false, false),
 		Entry("build in spec only", false, true, false, false, false, false),
@@ -233,25 +243,17 @@ var _ = Describe("replaceTemplates", func() {
 	kh := newKernelMapperHelper(nil, nil)
 
 	It("error input", func() {
-		mapping := kmmv1beta1.KernelMapping{
+		mld := api.ModuleLoaderData{
 			ContainerImage: "some image:${KERNEL_XYZ",
-			Literal:        "some literal",
-			Regexp:         "regexp",
+			KernelVersion:  kernelVersion,
 		}
-		err := kh.replaceTemplates(&mapping, kernelVersion)
+		err := kh.replaceTemplates(&mld)
 		Expect(err).To(HaveOccurred())
 	})
 
 	It("should only substitute the ContainerImage field", func() {
-		const (
-			literal = "some literal:${KERNEL_XYZ"
-			regexp  = "some regexp:${KERNEL_XYZ"
-		)
-
-		mapping := kmmv1beta1.KernelMapping{
+		mld := api.ModuleLoaderData{
 			ContainerImage: "some image:${KERNEL_XYZ}",
-			Literal:        literal,
-			Regexp:         regexp,
 			Build: &kmmv1beta1.Build{
 				BuildArgs: []kmmv1beta1.BuildArg{
 					{Name: "name1", Value: "value1"},
@@ -259,11 +261,10 @@ var _ = Describe("replaceTemplates", func() {
 				},
 				DockerfileConfigMap: &v1.LocalObjectReference{},
 			},
+			KernelVersion: kernelVersion,
 		}
-		expectMapping := kmmv1beta1.KernelMapping{
+		expectMld := api.ModuleLoaderData{
 			ContainerImage: "some image:5.8.18",
-			Literal:        literal,
-			Regexp:         regexp,
 			Build: &kmmv1beta1.Build{
 				BuildArgs: []kmmv1beta1.BuildArg{
 					{Name: "name1", Value: "value1"},
@@ -271,11 +272,12 @@ var _ = Describe("replaceTemplates", func() {
 				},
 				DockerfileConfigMap: &v1.LocalObjectReference{},
 			},
+			KernelVersion: kernelVersion,
 		}
 
-		err := kh.replaceTemplates(&mapping, kernelVersion)
+		err := kh.replaceTemplates(&mld)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(mapping).To(Equal(expectMapping))
+		Expect(mld).To(Equal(expectMld))
 	})
 
 })

--- a/internal/module/mock_kernelmapper.go
+++ b/internal/module/mock_kernelmapper.go
@@ -9,6 +9,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	api "github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 )
 
 // MockKernelMapper is a mock of KernelMapper interface.
@@ -34,19 +35,19 @@ func (m *MockKernelMapper) EXPECT() *MockKernelMapperMockRecorder {
 	return m.recorder
 }
 
-// GetMergedMappingForKernel mocks base method.
-func (m *MockKernelMapper) GetMergedMappingForKernel(modSpec *v1beta1.ModuleSpec, kernelVersion string) (*v1beta1.KernelMapping, error) {
+// GetModuleLoaderDataForKernel mocks base method.
+func (m *MockKernelMapper) GetModuleLoaderDataForKernel(mod *v1beta1.Module, kernelVersion string) (*api.ModuleLoaderData, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMergedMappingForKernel", modSpec, kernelVersion)
-	ret0, _ := ret[0].(*v1beta1.KernelMapping)
+	ret := m.ctrl.Call(m, "GetModuleLoaderDataForKernel", mod, kernelVersion)
+	ret0, _ := ret[0].(*api.ModuleLoaderData)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetMergedMappingForKernel indicates an expected call of GetMergedMappingForKernel.
-func (mr *MockKernelMapperMockRecorder) GetMergedMappingForKernel(modSpec, kernelVersion interface{}) *gomock.Call {
+// GetModuleLoaderDataForKernel indicates an expected call of GetModuleLoaderDataForKernel.
+func (mr *MockKernelMapperMockRecorder) GetModuleLoaderDataForKernel(mod, kernelVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMergedMappingForKernel", reflect.TypeOf((*MockKernelMapper)(nil).GetMergedMappingForKernel), modSpec, kernelVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleLoaderDataForKernel", reflect.TypeOf((*MockKernelMapper)(nil).GetModuleLoaderDataForKernel), mod, kernelVersion)
 }
 
 // MockkernelMapperHelperAPI is a mock of kernelMapperHelperAPI interface.
@@ -87,30 +88,31 @@ func (mr *MockkernelMapperHelperAPIMockRecorder) findKernelMapping(mappings, ker
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "findKernelMapping", reflect.TypeOf((*MockkernelMapperHelperAPI)(nil).findKernelMapping), mappings, kernelVersion)
 }
 
-// mergeMappingData mocks base method.
-func (m *MockkernelMapperHelperAPI) mergeMappingData(mapping *v1beta1.KernelMapping, modSpec *v1beta1.ModuleSpec, kernelVersion string) error {
+// prepareModuleLoaderData mocks base method.
+func (m *MockkernelMapperHelperAPI) prepareModuleLoaderData(mapping *v1beta1.KernelMapping, mod *v1beta1.Module, kernelVersion string) (*api.ModuleLoaderData, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "mergeMappingData", mapping, modSpec, kernelVersion)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "prepareModuleLoaderData", mapping, mod, kernelVersion)
+	ret0, _ := ret[0].(*api.ModuleLoaderData)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
-// mergeMappingData indicates an expected call of mergeMappingData.
-func (mr *MockkernelMapperHelperAPIMockRecorder) mergeMappingData(mapping, modSpec, kernelVersion interface{}) *gomock.Call {
+// prepareModuleLoaderData indicates an expected call of prepareModuleLoaderData.
+func (mr *MockkernelMapperHelperAPIMockRecorder) prepareModuleLoaderData(mapping, mod, kernelVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "mergeMappingData", reflect.TypeOf((*MockkernelMapperHelperAPI)(nil).mergeMappingData), mapping, modSpec, kernelVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "prepareModuleLoaderData", reflect.TypeOf((*MockkernelMapperHelperAPI)(nil).prepareModuleLoaderData), mapping, mod, kernelVersion)
 }
 
 // replaceTemplates mocks base method.
-func (m *MockkernelMapperHelperAPI) replaceTemplates(mapping *v1beta1.KernelMapping, kernelVersion string) error {
+func (m *MockkernelMapperHelperAPI) replaceTemplates(mld *api.ModuleLoaderData) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "replaceTemplates", mapping, kernelVersion)
+	ret := m.ctrl.Call(m, "replaceTemplates", mld)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // replaceTemplates indicates an expected call of replaceTemplates.
-func (mr *MockkernelMapperHelperAPIMockRecorder) replaceTemplates(mapping, kernelVersion interface{}) *gomock.Call {
+func (mr *MockkernelMapperHelperAPIMockRecorder) replaceTemplates(mld interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "replaceTemplates", reflect.TypeOf((*MockkernelMapperHelperAPI)(nil).replaceTemplates), mapping, kernelVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "replaceTemplates", reflect.TypeOf((*MockkernelMapperHelperAPI)(nil).replaceTemplates), mld)
 }

--- a/internal/preflight/mock_preflight_api.go
+++ b/internal/preflight/mock_preflight_api.go
@@ -10,6 +10,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	api "github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 )
 
 // MockPreflightAPI is a mock of PreflightAPI interface.
@@ -74,46 +75,46 @@ func (m *MockpreflightHelperAPI) EXPECT() *MockpreflightHelperAPIMockRecorder {
 }
 
 // verifyBuild mocks base method.
-func (m *MockpreflightHelperAPI) verifyBuild(ctx context.Context, pv *v1beta1.PreflightValidation, mapping *v1beta1.KernelMapping, mod *v1beta1.Module) (bool, string) {
+func (m *MockpreflightHelperAPI) verifyBuild(ctx context.Context, pv *v1beta1.PreflightValidation, mld *api.ModuleLoaderData) (bool, string) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "verifyBuild", ctx, pv, mapping, mod)
+	ret := m.ctrl.Call(m, "verifyBuild", ctx, pv, mld)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(string)
 	return ret0, ret1
 }
 
 // verifyBuild indicates an expected call of verifyBuild.
-func (mr *MockpreflightHelperAPIMockRecorder) verifyBuild(ctx, pv, mapping, mod interface{}) *gomock.Call {
+func (mr *MockpreflightHelperAPIMockRecorder) verifyBuild(ctx, pv, mld interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "verifyBuild", reflect.TypeOf((*MockpreflightHelperAPI)(nil).verifyBuild), ctx, pv, mapping, mod)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "verifyBuild", reflect.TypeOf((*MockpreflightHelperAPI)(nil).verifyBuild), ctx, pv, mld)
 }
 
 // verifyImage mocks base method.
-func (m *MockpreflightHelperAPI) verifyImage(ctx context.Context, mapping *v1beta1.KernelMapping, mod *v1beta1.Module, kernelVersion string) (bool, string) {
+func (m *MockpreflightHelperAPI) verifyImage(ctx context.Context, mld *api.ModuleLoaderData) (bool, string) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "verifyImage", ctx, mapping, mod, kernelVersion)
+	ret := m.ctrl.Call(m, "verifyImage", ctx, mld)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(string)
 	return ret0, ret1
 }
 
 // verifyImage indicates an expected call of verifyImage.
-func (mr *MockpreflightHelperAPIMockRecorder) verifyImage(ctx, mapping, mod, kernelVersion interface{}) *gomock.Call {
+func (mr *MockpreflightHelperAPIMockRecorder) verifyImage(ctx, mld interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "verifyImage", reflect.TypeOf((*MockpreflightHelperAPI)(nil).verifyImage), ctx, mapping, mod, kernelVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "verifyImage", reflect.TypeOf((*MockpreflightHelperAPI)(nil).verifyImage), ctx, mld)
 }
 
 // verifySign mocks base method.
-func (m *MockpreflightHelperAPI) verifySign(ctx context.Context, pv *v1beta1.PreflightValidation, mapping *v1beta1.KernelMapping, mod *v1beta1.Module) (bool, string) {
+func (m *MockpreflightHelperAPI) verifySign(ctx context.Context, pv *v1beta1.PreflightValidation, mld *api.ModuleLoaderData) (bool, string) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "verifySign", ctx, pv, mapping, mod)
+	ret := m.ctrl.Call(m, "verifySign", ctx, pv, mld)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(string)
 	return ret0, ret1
 }
 
 // verifySign indicates an expected call of verifySign.
-func (mr *MockpreflightHelperAPIMockRecorder) verifySign(ctx, pv, mapping, mod interface{}) *gomock.Call {
+func (mr *MockpreflightHelperAPIMockRecorder) verifySign(ctx, pv, mld interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "verifySign", reflect.TypeOf((*MockpreflightHelperAPI)(nil).verifySign), ctx, pv, mapping, mod)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "verifySign", reflect.TypeOf((*MockpreflightHelperAPI)(nil).verifySign), ctx, pv, mld)
 }

--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/auth"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/build"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/module"
@@ -12,7 +13,6 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/sign"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/statusupdater"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
-
 	ctrlruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -55,42 +55,42 @@ type preflight struct {
 func (p *preflight) PreflightUpgradeCheck(ctx context.Context, pv *kmmv1beta1.PreflightValidation, mod *kmmv1beta1.Module) (bool, string) {
 	log := ctrlruntime.LoggerFrom(ctx)
 	kernelVersion := pv.Spec.KernelVersion
-	mapping, err := p.kernelAPI.GetMergedMappingForKernel(&mod.Spec, kernelVersion)
+	mld, err := p.kernelAPI.GetModuleLoaderDataForKernel(mod, kernelVersion)
 	if err != nil {
 		return false, fmt.Sprintf("failed to process kernel mapping in the module %s for kernel version %s", mod.Name, kernelVersion)
 	}
 
-	err = p.statusUpdater.PreflightSetVerificationStage(ctx, pv, mod.Name, kmmv1beta1.VerificationStageImage)
+	err = p.statusUpdater.PreflightSetVerificationStage(ctx, pv, mld.Name, kmmv1beta1.VerificationStageImage)
 	if err != nil {
-		log.Info(utils.WarnString("failed to update the stage of Module CR in preflight to image stage"), "module", mod.Name, "error", err)
+		log.Info(utils.WarnString("failed to update the stage of Module CR in preflight to image stage"), "module", mld.Name, "error", err)
 	}
 
-	verified, msg := p.helper.verifyImage(ctx, mapping, mod, kernelVersion)
+	verified, msg := p.helper.verifyImage(ctx, mld)
 	if verified {
 		return true, msg
 	}
 
-	shouldBuild := module.ShouldBeBuilt(*mapping)
-	shouldSign := module.ShouldBeSigned(*mapping)
+	shouldBuild := module.ShouldBeBuilt(mld)
+	shouldSign := module.ShouldBeSigned(mld)
 
 	if shouldBuild {
-		err = p.statusUpdater.PreflightSetVerificationStage(ctx, pv, mod.Name, kmmv1beta1.VerificationStageBuild)
+		err = p.statusUpdater.PreflightSetVerificationStage(ctx, pv, mld.Name, kmmv1beta1.VerificationStageBuild)
 		if err != nil {
-			log.Info(utils.WarnString("failed to update the stage of Module CR in preflight to build stage"), "module", mod.Name, "error", err)
+			log.Info(utils.WarnString("failed to update the stage of Module CR in preflight to build stage"), "module", mld.Name, "error", err)
 		}
 
-		verified, msg = p.helper.verifyBuild(ctx, pv, mapping, mod)
+		verified, msg = p.helper.verifyBuild(ctx, pv, mld)
 		if !verified {
 			return false, msg
 		}
 	}
 
 	if shouldSign {
-		err = p.statusUpdater.PreflightSetVerificationStage(ctx, pv, mod.Name, kmmv1beta1.VerificationStageSign)
+		err = p.statusUpdater.PreflightSetVerificationStage(ctx, pv, mld.Name, kmmv1beta1.VerificationStageSign)
 		if err != nil {
-			log.Info(utils.WarnString("failed to update the stage of Module CR in preflight to sign stage"), "module", mod.Name, "error", err)
+			log.Info(utils.WarnString("failed to update the stage of Module CR in preflight to sign stage"), "module", mld.Name, "error", err)
 		}
-		verified, msg = p.helper.verifySign(ctx, pv, mapping, mod)
+		verified, msg = p.helper.verifySign(ctx, pv, mld)
 		if !verified {
 			return false, msg
 		}
@@ -99,9 +99,9 @@ func (p *preflight) PreflightUpgradeCheck(ctx context.Context, pv *kmmv1beta1.Pr
 }
 
 type preflightHelperAPI interface {
-	verifyImage(ctx context.Context, mapping *kmmv1beta1.KernelMapping, mod *kmmv1beta1.Module, kernelVersion string) (bool, string)
-	verifyBuild(ctx context.Context, pv *kmmv1beta1.PreflightValidation, mapping *kmmv1beta1.KernelMapping, mod *kmmv1beta1.Module) (bool, string)
-	verifySign(ctx context.Context, pv *kmmv1beta1.PreflightValidation, mapping *kmmv1beta1.KernelMapping, mod *kmmv1beta1.Module) (bool, string)
+	verifyImage(ctx context.Context, mld *api.ModuleLoaderData) (bool, string)
+	verifyBuild(ctx context.Context, pv *kmmv1beta1.PreflightValidation, mld *api.ModuleLoaderData) (bool, string)
+	verifySign(ctx context.Context, pv *kmmv1beta1.PreflightValidation, mld *api.ModuleLoaderData) (bool, string)
 }
 
 type preflightHelper struct {
@@ -122,16 +122,17 @@ func newPreflightHelper(client client.Client, buildAPI build.Manager, signAPI si
 	}
 }
 
-func (p *preflightHelper) verifyImage(ctx context.Context, mapping *kmmv1beta1.KernelMapping, mod *kmmv1beta1.Module, kernelVersion string) (bool, string) {
+func (p *preflightHelper) verifyImage(ctx context.Context, mld *api.ModuleLoaderData) (bool, string) {
 	log := ctrlruntime.LoggerFrom(ctx)
-	image := mapping.ContainerImage
-	moduleFileName := mod.Spec.ModuleLoader.Container.Modprobe.ModuleName + ".ko"
-	baseDir := mod.Spec.ModuleLoader.Container.Modprobe.DirName
+	image := mld.ContainerImage
+	moduleFileName := mld.Modprobe.ModuleName + ".ko"
+	baseDir := mld.Modprobe.DirName
+	kernelVersion := mld.KernelVersion
 
-	registryAuthGetter := p.authFactory.NewRegistryAuthGetterFrom(mod)
-	digests, repoConfig, err := p.registryAPI.GetLayersDigests(ctx, image, mapping.RegistryTLS, registryAuthGetter)
+	registryAuthGetter := p.authFactory.NewRegistryAuthGetterFrom(mld)
+	digests, repoConfig, err := p.registryAPI.GetLayersDigests(ctx, image, mld.RegistryTLS, registryAuthGetter)
 	if err != nil {
-		log.Info("image layers inaccessible, image probably does not exists", "module name", mod.Name, "image", image)
+		log.Info("image layers inaccessible, image probably does not exists", "module name", mld.Name, "image", image)
 		return false, fmt.Sprintf("image %s inaccessible or does not exists", image)
 	}
 
@@ -153,15 +154,12 @@ func (p *preflightHelper) verifyImage(ctx context.Context, mapping *kmmv1beta1.K
 	return false, fmt.Sprintf("image %s does not contain kernel module for kernel %s on any layer", image, kernelVersion)
 }
 
-func (p *preflightHelper) verifyBuild(ctx context.Context,
-	pv *kmmv1beta1.PreflightValidation,
-	mapping *kmmv1beta1.KernelMapping,
-	mod *kmmv1beta1.Module) (bool, string) {
+func (p *preflightHelper) verifyBuild(ctx context.Context, pv *kmmv1beta1.PreflightValidation, mld *api.ModuleLoaderData) (bool, string) {
 	log := ctrlruntime.LoggerFrom(ctx)
 	// at this stage we know that eiher mapping Build or Container build are defined
-	buildStatus, err := p.buildAPI.Sync(ctx, *mod, *mapping, pv.Spec.KernelVersion, pv.Spec.PushBuiltImage, pv)
+	buildStatus, err := p.buildAPI.Sync(ctx, mld, pv.Spec.PushBuiltImage, pv)
 	if err != nil {
-		return false, fmt.Sprintf("Failed to verify build for module %s, kernel version %s, error %s", mod.Name, pv.Spec.KernelVersion, err)
+		return false, fmt.Sprintf("Failed to verify build for module %s, kernel version %s, error %s", mld.Name, pv.Spec.KernelVersion, err)
 	}
 
 	if buildStatus == utils.StatusCompleted {
@@ -169,27 +167,24 @@ func (p *preflightHelper) verifyBuild(ctx context.Context,
 		if pv.Spec.PushBuiltImage {
 			msg += " and image pushed"
 		}
-		log.Info("build for module during preflight has been build successfully", "module", mod.Name)
+		log.Info("build for module during preflight has been build successfully", "module", mld.Name)
 		return true, fmt.Sprintf(VerificationStatusReasonVerified, msg)
 	}
 	return false, "Waiting for build verification"
 }
 
-func (p *preflightHelper) verifySign(ctx context.Context,
-	pv *kmmv1beta1.PreflightValidation,
-	mapping *kmmv1beta1.KernelMapping,
-	mod *kmmv1beta1.Module) (bool, string) {
+func (p *preflightHelper) verifySign(ctx context.Context, pv *kmmv1beta1.PreflightValidation, mld *api.ModuleLoaderData) (bool, string) {
 	log := ctrlruntime.LoggerFrom(ctx)
 
 	previousImage := ""
-	if module.ShouldBeBuilt(*mapping) {
-		previousImage = module.IntermediateImageName(mod.Name, mod.Namespace, mapping.ContainerImage)
+	if module.ShouldBeBuilt(mld) {
+		previousImage = module.IntermediateImageName(mld.Name, mld.Namespace, mld.ContainerImage)
 	}
 
 	// at this stage we know that eiher mapping Sign or Container sign are defined
-	signStatus, err := p.signAPI.Sync(ctx, *mod, *mapping, pv.Spec.KernelVersion, previousImage, pv.Spec.PushBuiltImage, pv)
+	signStatus, err := p.signAPI.Sync(ctx, mld, previousImage, pv.Spec.PushBuiltImage, pv)
 	if err != nil {
-		return false, fmt.Sprintf("Failed to verify signing for module %s, kernel version %s, error %s", mod.Name, pv.Spec.KernelVersion, err)
+		return false, fmt.Sprintf("Failed to verify signing for module %s, kernel version %s, error %s", mld.Name, pv.Spec.KernelVersion, err)
 	}
 
 	if signStatus == utils.StatusCompleted {
@@ -197,7 +192,7 @@ func (p *preflightHelper) verifySign(ctx context.Context,
 		if pv.Spec.PushBuiltImage {
 			msg += " and image pushed"
 		}
-		log.Info("build for module during preflight has been build successfully", "module", mod.Name)
+		log.Info("build for module during preflight has been build successfully", "module", mld.Name)
 		return true, fmt.Sprintf(VerificationStatusReasonVerified, msg)
 	}
 	return false, "Waiting for sign verification"

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/auth"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/build"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
@@ -100,7 +101,7 @@ var _ = Describe("preflight_PreflightUpgradeCheck", func() {
 
 	It("Failed to process mapping", func() {
 		mod.Spec.ModuleLoader.Container.KernelMappings = []kmmv1beta1.KernelMapping{}
-		mockKernelAPI.EXPECT().GetMergedMappingForKernel(&mod.Spec, kernelVersion).Return(nil, fmt.Errorf("some error"))
+		mockKernelAPI.EXPECT().GetModuleLoaderDataForKernel(mod, kernelVersion).Return(nil, fmt.Errorf("some error"))
 
 		res, message := p.PreflightUpgradeCheck(context.Background(), pv, mod)
 
@@ -111,27 +112,32 @@ var _ = Describe("preflight_PreflightUpgradeCheck", func() {
 	DescribeTable("correct flow of the image/build/sign verification", func(buildExists, signExists, imageVerified, buildVerified, signVerified,
 		returnedResult bool, returnedMessage string) {
 		ctx := context.Background()
-		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
-		mod.Spec.ModuleLoader.Container.KernelMappings = []kmmv1beta1.KernelMapping{mapping}
+		mld := api.ModuleLoaderData{
+			Name:           mod.Name,
+			Namespace:      mod.Namespace,
+			ContainerImage: containerImage,
+			Owner:          mod,
+			KernelVersion:  kernelVersion,
+		}
 		if buildExists {
-			mapping.Build = &kmmv1beta1.Build{}
+			mld.Build = &kmmv1beta1.Build{}
 		}
 		if signExists {
-			mapping.Sign = &kmmv1beta1.Sign{}
+			mld.Sign = &kmmv1beta1.Sign{}
 		}
 
-		mockKernelAPI.EXPECT().GetMergedMappingForKernel(&mod.Spec, kernelVersion).Return(&mapping, nil)
-		mockStatusUpdater.EXPECT().PreflightSetVerificationStage(context.Background(), pv, mod.Name, kmmv1beta1.VerificationStageImage).Return(nil)
-		preflightHelper.EXPECT().verifyImage(ctx, &mapping, mod, kernelVersion).Return(imageVerified, "image message")
+		mockKernelAPI.EXPECT().GetModuleLoaderDataForKernel(mod, kernelVersion).Return(&mld, nil)
+		mockStatusUpdater.EXPECT().PreflightSetVerificationStage(context.Background(), pv, mld.Name, kmmv1beta1.VerificationStageImage).Return(nil)
+		preflightHelper.EXPECT().verifyImage(ctx, &mld).Return(imageVerified, "image message")
 		if !imageVerified {
 			if buildExists {
-				mockStatusUpdater.EXPECT().PreflightSetVerificationStage(context.Background(), pv, mod.Name, kmmv1beta1.VerificationStageBuild).Return(nil)
-				preflightHelper.EXPECT().verifyBuild(ctx, pv, &mapping, mod).Return(buildVerified, "build message")
+				mockStatusUpdater.EXPECT().PreflightSetVerificationStage(context.Background(), pv, mld.Name, kmmv1beta1.VerificationStageBuild).Return(nil)
+				preflightHelper.EXPECT().verifyBuild(ctx, pv, &mld).Return(buildVerified, "build message")
 			}
 			if signExists {
 				if buildVerified || !buildExists {
-					mockStatusUpdater.EXPECT().PreflightSetVerificationStage(context.Background(), pv, mod.Name, kmmv1beta1.VerificationStageSign).Return(nil)
-					preflightHelper.EXPECT().verifySign(ctx, pv, &mapping, mod).Return(signVerified, "sign message")
+					mockStatusUpdater.EXPECT().PreflightSetVerificationStage(context.Background(), pv, mld.Name, kmmv1beta1.VerificationStageSign).Return(nil)
+					preflightHelper.EXPECT().verifySign(ctx, pv, &mld).Return(signVerified, "sign message")
 				}
 			}
 		}
@@ -220,66 +226,80 @@ var _ = Describe("preflightHelper_verifyImage", func() {
 	})
 
 	It("good flow", func() {
-		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
+		mld := api.ModuleLoaderData{
+			ContainerImage: containerImage,
+			Modprobe:       mod.Spec.ModuleLoader.Container.Modprobe,
+			KernelVersion:  kernelVersion,
+		}
 		digests := []string{"digest0", "digest1"}
 		repoConfig := &registry.RepoPullConfig{}
 		digestLayer := v1stream.Layer{}
 		gomock.InOrder(
-			mockAuthFactory.EXPECT().NewRegistryAuthGetterFrom(mod).Return(authGetter),
+			mockAuthFactory.EXPECT().NewRegistryAuthGetterFrom(&mld).Return(authGetter),
 			mockRegistryAPI.EXPECT().GetLayersDigests(context.Background(), containerImage, gomock.Any(), gomock.Any()).Return(digests, repoConfig, nil),
 			mockRegistryAPI.EXPECT().GetLayerByDigest(digests[1], repoConfig).Return(&digestLayer, nil),
 			mockRegistryAPI.EXPECT().VerifyModuleExists(&digestLayer, "/opt", kernelVersion, "simple-kmod.ko").Return(true),
 		)
 
-		res, message := ph.verifyImage(context.Background(), &mapping, mod, kernelVersion)
+		res, message := ph.verifyImage(context.Background(), &mld)
 
 		Expect(res).To(BeTrue())
 		Expect(message).To(Equal(fmt.Sprintf(VerificationStatusReasonVerified, "image accessible and verified")))
 	})
 
 	It("get layers digest failed", func() {
-		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
+		mld := api.ModuleLoaderData{
+			ContainerImage: containerImage,
+			KernelVersion:  kernelVersion,
+		}
 
 		gomock.InOrder(
-			mockAuthFactory.EXPECT().NewRegistryAuthGetterFrom(mod).Return(authGetter),
+			mockAuthFactory.EXPECT().NewRegistryAuthGetterFrom(&mld).Return(authGetter),
 			mockRegistryAPI.EXPECT().GetLayersDigests(context.Background(), containerImage, gomock.Any(), gomock.Any()).Return(nil, nil, fmt.Errorf("some error")),
 		)
 
-		res, message := ph.verifyImage(context.Background(), &mapping, mod, kernelVersion)
+		res, message := ph.verifyImage(context.Background(), &mld)
 
 		Expect(res).To(BeFalse())
 		Expect(message).To(Equal(fmt.Sprintf("image %s inaccessible or does not exists", containerImage)))
 	})
 
 	It("failed to get specific layer", func() {
-		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
+		mld := api.ModuleLoaderData{
+			ContainerImage: containerImage,
+			KernelVersion:  kernelVersion,
+		}
 		digests := []string{"digest0", "digest1"}
 		repoConfig := &registry.RepoPullConfig{}
 		gomock.InOrder(
-			mockAuthFactory.EXPECT().NewRegistryAuthGetterFrom(mod).Return(authGetter),
+			mockAuthFactory.EXPECT().NewRegistryAuthGetterFrom(&mld).Return(authGetter),
 			mockRegistryAPI.EXPECT().GetLayersDigests(context.Background(), containerImage, gomock.Any(), gomock.Any()).Return(digests, repoConfig, nil),
 			mockRegistryAPI.EXPECT().GetLayerByDigest(digests[1], repoConfig).Return(nil, fmt.Errorf("some error")),
 		)
 
-		res, message := ph.verifyImage(context.Background(), &mapping, mod, kernelVersion)
+		res, message := ph.verifyImage(context.Background(), &mld)
 
 		Expect(res).To(BeFalse())
 		Expect(message).To(Equal(fmt.Sprintf("image %s, layer %s is inaccessible", containerImage, digests[1])))
 	})
 
 	It("kernel module not present in the correct path", func() {
-		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
+		mld := api.ModuleLoaderData{
+			ContainerImage: containerImage,
+			Modprobe:       mod.Spec.ModuleLoader.Container.Modprobe,
+			KernelVersion:  kernelVersion,
+		}
 		digests := []string{"digest0"}
 		repoConfig := &registry.RepoPullConfig{}
 		digestLayer := v1stream.Layer{}
 		gomock.InOrder(
-			mockAuthFactory.EXPECT().NewRegistryAuthGetterFrom(mod).Return(authGetter),
+			mockAuthFactory.EXPECT().NewRegistryAuthGetterFrom(&mld).Return(authGetter),
 			mockRegistryAPI.EXPECT().GetLayersDigests(context.Background(), containerImage, gomock.Any(), gomock.Any()).Return(digests, repoConfig, nil),
 			mockRegistryAPI.EXPECT().GetLayerByDigest(digests[0], repoConfig).Return(&digestLayer, nil),
 			mockRegistryAPI.EXPECT().VerifyModuleExists(&digestLayer, "/opt", kernelVersion, "simple-kmod.ko").Return(false),
 		)
 
-		res, message := ph.verifyImage(context.Background(), &mapping, mod, kernelVersion)
+		res, message := ph.verifyImage(context.Background(), &mld)
 
 		Expect(res).To(BeFalse())
 		Expect(message).To(Equal(fmt.Sprintf("image %s does not contain kernel module for kernel %s on any layer", containerImage, kernelVersion)))
@@ -311,37 +331,49 @@ var _ = Describe("preflightHelper_verifyBuild", func() {
 	})
 
 	It("sync failed", func() {
-		mod.Spec.ModuleLoader.Container.Build = &kmmv1beta1.Build{}
-		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
+		mld := api.ModuleLoaderData{
+			Name:           mod.Name,
+			ContainerImage: containerImage,
+			Build:          &kmmv1beta1.Build{},
+			KernelVersion:  kernelVersion,
+		}
 
-		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, pv.Spec.PushBuiltImage, pv).
+		mockBuildAPI.EXPECT().Sync(context.Background(), &mld, pv.Spec.PushBuiltImage, pv).
 			Return(utils.Status(""), fmt.Errorf("some error"))
 
-		res, msg := ph.verifyBuild(context.Background(), pv, &mapping, mod)
+		res, msg := ph.verifyBuild(context.Background(), pv, &mld)
 		Expect(res).To(BeFalse())
-		Expect(msg).To(Equal(fmt.Sprintf("Failed to verify build for module %s, kernel version %s, error %s", mod.Name, kernelVersion, fmt.Errorf("some error"))))
+		Expect(msg).To(Equal(fmt.Sprintf("Failed to verify build for module %s, kernel version %s, error %s", mld.Name, kernelVersion, fmt.Errorf("some error"))))
 	})
 
 	It("sync completed", func() {
-		mod.Spec.ModuleLoader.Container.Build = &kmmv1beta1.Build{}
-		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
+		mld := api.ModuleLoaderData{
+			Name:           mod.Name,
+			ContainerImage: containerImage,
+			Build:          &kmmv1beta1.Build{},
+			KernelVersion:  kernelVersion,
+		}
 
-		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, pv.Spec.PushBuiltImage, pv).
+		mockBuildAPI.EXPECT().Sync(context.Background(), &mld, pv.Spec.PushBuiltImage, pv).
 			Return(utils.Status(utils.StatusCompleted), nil)
 
-		res, msg := ph.verifyBuild(context.Background(), pv, &mapping, mod)
+		res, msg := ph.verifyBuild(context.Background(), pv, &mld)
 		Expect(res).To(BeTrue())
 		Expect(msg).To(Equal(fmt.Sprintf(VerificationStatusReasonVerified, "build compiles")))
 	})
 
 	It("sync not completed yet", func() {
-		mod.Spec.ModuleLoader.Container.Build = &kmmv1beta1.Build{}
-		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
+		mld := api.ModuleLoaderData{
+			Name:           mod.Name,
+			ContainerImage: containerImage,
+			Build:          &kmmv1beta1.Build{},
+			KernelVersion:  kernelVersion,
+		}
 
-		mockBuildAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, pv.Spec.PushBuiltImage, pv).
+		mockBuildAPI.EXPECT().Sync(context.Background(), &mld, pv.Spec.PushBuiltImage, pv).
 			Return(utils.Status(utils.StatusInProgress), nil)
 
-		res, msg := ph.verifyBuild(context.Background(), pv, &mapping, mod)
+		res, msg := ph.verifyBuild(context.Background(), pv, &mld)
 		Expect(res).To(BeFalse())
 		Expect(msg).To(Equal("Waiting for build verification"))
 	})
@@ -371,43 +403,55 @@ var _ = Describe("preflightHelper_verifySign", func() {
 	})
 
 	It("sync failed", func() {
-		mod.Spec.ModuleLoader.Container.Sign = &kmmv1beta1.Sign{}
-		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
+		mld := api.ModuleLoaderData{
+			Name:           mod.Name,
+			ContainerImage: containerImage,
+			Sign:           &kmmv1beta1.Sign{},
+			KernelVersion:  kernelVersion,
+		}
 
 		previousImage := ""
 
-		mockSignAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, previousImage, pv.Spec.PushBuiltImage, pv).
+		mockSignAPI.EXPECT().Sync(context.Background(), &mld, previousImage, pv.Spec.PushBuiltImage, pv).
 			Return(utils.Status(""), fmt.Errorf("some error"))
 
-		res, msg := ph.verifySign(context.Background(), pv, &mapping, mod)
+		res, msg := ph.verifySign(context.Background(), pv, &mld)
 		Expect(res).To(BeFalse())
-		Expect(msg).To(Equal(fmt.Sprintf("Failed to verify signing for module %s, kernel version %s, error %s", mod.Name, kernelVersion, fmt.Errorf("some error"))))
+		Expect(msg).To(Equal(fmt.Sprintf("Failed to verify signing for module %s, kernel version %s, error %s", mld.Name, kernelVersion, fmt.Errorf("some error"))))
 	})
 
 	It("sync completed", func() {
-		mod.Spec.ModuleLoader.Container.Sign = &kmmv1beta1.Sign{}
-		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
+		mld := api.ModuleLoaderData{
+			Name:           mod.Name,
+			ContainerImage: containerImage,
+			Sign:           &kmmv1beta1.Sign{},
+			KernelVersion:  kernelVersion,
+		}
 
 		previousImage := ""
 
-		mockSignAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, previousImage, pv.Spec.PushBuiltImage, pv).
+		mockSignAPI.EXPECT().Sync(context.Background(), &mld, previousImage, pv.Spec.PushBuiltImage, pv).
 			Return(utils.Status(utils.StatusCompleted), nil)
 
-		res, msg := ph.verifySign(context.Background(), pv, &mapping, mod)
+		res, msg := ph.verifySign(context.Background(), pv, &mld)
 		Expect(res).To(BeTrue())
 		Expect(msg).To(Equal(fmt.Sprintf(VerificationStatusReasonVerified, "sign completes")))
 	})
 
 	It("sync not completed yet", func() {
-		mod.Spec.ModuleLoader.Container.Sign = &kmmv1beta1.Sign{}
-		mapping := kmmv1beta1.KernelMapping{ContainerImage: containerImage}
+		mld := api.ModuleLoaderData{
+			Name:           mod.Name,
+			ContainerImage: containerImage,
+			Sign:           &kmmv1beta1.Sign{},
+			KernelVersion:  kernelVersion,
+		}
 
 		previousImage := ""
 
-		mockSignAPI.EXPECT().Sync(context.Background(), *mod, mapping, kernelVersion, previousImage, pv.Spec.PushBuiltImage, pv).
+		mockSignAPI.EXPECT().Sync(context.Background(), &mld, previousImage, pv.Spec.PushBuiltImage, pv).
 			Return(utils.Status(utils.StatusInProgress), nil)
 
-		res, msg := ph.verifySign(context.Background(), pv, &mapping, mod)
+		res, msg := ph.verifySign(context.Background(), pv, &mld)
 		Expect(res).To(BeFalse())
 		Expect(msg).To(Equal("Waiting for sign verification"))
 	})

--- a/internal/sign/job/manager_test.go
+++ b/internal/sign/job/manager_test.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/auth"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/registry"
@@ -45,10 +46,8 @@ var _ = Describe("ShouldSync", func() {
 	It("should return false if there was not sign section", func() {
 		ctx := context.Background()
 
-		mod := kmmv1beta1.Module{}
-		km := kmmv1beta1.KernelMapping{}
-
-		shouldSync, err := mgr.ShouldSync(ctx, mod, km)
+		mld := &api.ModuleLoaderData{}
+		shouldSync, err := mgr.ShouldSync(ctx, mld)
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(shouldSync).To(BeFalse())
@@ -57,27 +56,20 @@ var _ = Describe("ShouldSync", func() {
 	It("should return false if image already exists", func() {
 		ctx := context.Background()
 
-		km := kmmv1beta1.KernelMapping{
-			Sign:           &kmmv1beta1.Sign{},
-			ContainerImage: imageName,
-		}
-
-		mod := kmmv1beta1.Module{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      moduleName,
-				Namespace: namespace,
-			},
-			Spec: kmmv1beta1.ModuleSpec{
-				ImageRepoSecret: &v1.LocalObjectReference{Name: "pull-push-secret"},
-			},
+		mld := &api.ModuleLoaderData{
+			Name:            moduleName,
+			Namespace:       namespace,
+			ImageRepoSecret: &v1.LocalObjectReference{Name: "pull-push-secret"},
+			ContainerImage:  imageName,
+			Sign:            &kmmv1beta1.Sign{},
 		}
 
 		gomock.InOrder(
-			authFactory.EXPECT().NewRegistryAuthGetterFrom(&mod),
-			reg.EXPECT().ImageExists(ctx, imageName, gomock.Any(), gomock.Any()).Return(true, nil),
+			authFactory.EXPECT().NewRegistryAuthGetterFrom(mld),
+			reg.EXPECT().ImageExists(ctx, imageName, nil, gomock.Any()).Return(true, nil),
 		)
 
-		shouldSync, err := mgr.ShouldSync(ctx, mod, km)
+		shouldSync, err := mgr.ShouldSync(ctx, mld)
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(shouldSync).To(BeFalse())
@@ -86,27 +78,20 @@ var _ = Describe("ShouldSync", func() {
 	It("should return false and an error if image check fails", func() {
 		ctx := context.Background()
 
-		km := kmmv1beta1.KernelMapping{
-			Sign:           &kmmv1beta1.Sign{},
-			ContainerImage: imageName,
-		}
-
-		mod := kmmv1beta1.Module{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      moduleName,
-				Namespace: namespace,
-			},
-			Spec: kmmv1beta1.ModuleSpec{
-				ImageRepoSecret: &v1.LocalObjectReference{Name: "pull-push-secret"},
-			},
+		mld := &api.ModuleLoaderData{
+			Name:            moduleName,
+			Namespace:       namespace,
+			ImageRepoSecret: &v1.LocalObjectReference{Name: "pull-push-secret"},
+			ContainerImage:  imageName,
+			Sign:            &kmmv1beta1.Sign{},
 		}
 
 		gomock.InOrder(
-			authFactory.EXPECT().NewRegistryAuthGetterFrom(&mod),
-			reg.EXPECT().ImageExists(ctx, imageName, gomock.Any(), gomock.Any()).Return(false, errors.New("generic-registry-error")),
+			authFactory.EXPECT().NewRegistryAuthGetterFrom(mld),
+			reg.EXPECT().ImageExists(ctx, imageName, nil, gomock.Any()).Return(false, errors.New("generic-registry-error")),
 		)
 
-		shouldSync, err := mgr.ShouldSync(ctx, mod, km)
+		shouldSync, err := mgr.ShouldSync(ctx, mld)
 
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("generic-registry-error"))
@@ -116,27 +101,20 @@ var _ = Describe("ShouldSync", func() {
 	It("should return true if image does not exist", func() {
 		ctx := context.Background()
 
-		km := kmmv1beta1.KernelMapping{
-			Sign:           &kmmv1beta1.Sign{},
-			ContainerImage: imageName,
-		}
-
-		mod := kmmv1beta1.Module{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      moduleName,
-				Namespace: namespace,
-			},
-			Spec: kmmv1beta1.ModuleSpec{
-				ImageRepoSecret: &v1.LocalObjectReference{Name: "pull-push-secret"},
-			},
+		mld := &api.ModuleLoaderData{
+			Name:            moduleName,
+			Namespace:       namespace,
+			ImageRepoSecret: &v1.LocalObjectReference{Name: "pull-push-secret"},
+			ContainerImage:  imageName,
+			Sign:            &kmmv1beta1.Sign{},
 		}
 
 		gomock.InOrder(
-			authFactory.EXPECT().NewRegistryAuthGetterFrom(&mod),
-			reg.EXPECT().ImageExists(ctx, imageName, gomock.Any(), gomock.Any()).Return(false, nil),
+			authFactory.EXPECT().NewRegistryAuthGetterFrom(mld),
+			reg.EXPECT().ImageExists(ctx, imageName, nil, gomock.Any()).Return(false, nil),
 		)
 
-		shouldSync, err := mgr.ShouldSync(ctx, mod, km)
+		shouldSync, err := mgr.ShouldSync(ctx, mld)
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(shouldSync).To(BeTrue())
@@ -168,17 +146,17 @@ var _ = Describe("Sync", func() {
 		mgr = NewSignJobManager(maker, jobhelper, nil, nil)
 	})
 
-	km := kmmv1beta1.KernelMapping{
-		Build:          &kmmv1beta1.Build{},
-		ContainerImage: imageName,
-	}
 	labels := map[string]string{"kmm.node.kubernetes.io/job-type": "sign",
 		"kmm.node.kubernetes.io/module.name":   moduleName,
 		"kmm.node.kubernetes.io/target-kernel": kernelVersion,
 	}
 
-	mod := kmmv1beta1.Module{
-		ObjectMeta: metav1.ObjectMeta{Name: moduleName},
+	mld := &api.ModuleLoaderData{
+		Name:           moduleName,
+		ContainerImage: imageName,
+		Build:          &kmmv1beta1.Build{},
+		Owner:          &kmmv1beta1.Module{},
+		KernelVersion:  kernelVersion,
 	}
 
 	DescribeTable("should return the correct status depending on the job status",
@@ -213,14 +191,14 @@ var _ = Describe("Sync", func() {
 			}
 
 			gomock.InOrder(
-				jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
-				maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
-				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(&newJob, nil),
+				jobhelper.EXPECT().JobLabels(mld.Name, kernelVersion, "sign").Return(labels),
+				maker.EXPECT().MakeJobTemplate(ctx, mld, labels, previousImageName, true, mld.Owner).Return(&j, nil),
+				jobhelper.EXPECT().GetModuleJobByKernel(ctx, mld.Name, mld.Namespace, kernelVersion, utils.JobTypeSign, mld.Owner).Return(&newJob, nil),
 				jobhelper.EXPECT().IsJobChanged(&j, &newJob).Return(false, nil),
 				jobhelper.EXPECT().GetJobStatus(&newJob).Return(jobStatus, joberr),
 			)
 
-			res, err := mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod)
+			res, err := mgr.Sync(ctx, mld, previousImageName, true, mld.Owner)
 
 			if expectsErr {
 				Expect(err).To(HaveOccurred())
@@ -239,13 +217,13 @@ var _ = Describe("Sync", func() {
 		ctx := context.Background()
 
 		gomock.InOrder(
-			jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
-			maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).
+			jobhelper.EXPECT().JobLabels(mld.Name, kernelVersion, "sign").Return(labels),
+			maker.EXPECT().MakeJobTemplate(ctx, mld, labels, previousImageName, true, mld.Owner).
 				Return(nil, errors.New("random error")),
 		)
 
 		Expect(
-			mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod),
+			mgr.Sync(ctx, mld, previousImageName, true, mld.Owner),
 		).Error().To(
 			HaveOccurred(),
 		)
@@ -265,13 +243,13 @@ var _ = Describe("Sync", func() {
 		}
 
 		gomock.InOrder(
-			jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
-			maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
-			jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(nil, errors.New("random error")),
+			jobhelper.EXPECT().JobLabels(mld.Name, kernelVersion, "sign").Return(labels),
+			maker.EXPECT().MakeJobTemplate(ctx, mld, labels, previousImageName, true, mld.Owner).Return(&j, nil),
+			jobhelper.EXPECT().GetModuleJobByKernel(ctx, mld.Name, mld.Namespace, kernelVersion, utils.JobTypeSign, mld.Owner).Return(nil, errors.New("random error")),
 		)
 
 		Expect(
-			mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod),
+			mgr.Sync(ctx, mld, previousImageName, true, mld.Owner),
 		).Error().To(
 			HaveOccurred(),
 		)
@@ -291,14 +269,14 @@ var _ = Describe("Sync", func() {
 		}
 
 		gomock.InOrder(
-			jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
-			maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
-			jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(nil, utils.ErrNoMatchingJob),
+			jobhelper.EXPECT().JobLabels(mld.Name, kernelVersion, "sign").Return(labels),
+			maker.EXPECT().MakeJobTemplate(ctx, mld, labels, previousImageName, true, mld.Owner).Return(&j, nil),
+			jobhelper.EXPECT().GetModuleJobByKernel(ctx, mld.Name, mld.Namespace, kernelVersion, utils.JobTypeSign, mld.Owner).Return(nil, utils.ErrNoMatchingJob),
 			jobhelper.EXPECT().CreateJob(ctx, &j).Return(errors.New("unable to create job")),
 		)
 
 		Expect(
-			mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod),
+			mgr.Sync(ctx, mld, previousImageName, true, mld.Owner),
 		).Error().To(
 			HaveOccurred(),
 		)
@@ -319,14 +297,14 @@ var _ = Describe("Sync", func() {
 		}
 
 		gomock.InOrder(
-			jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
-			maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&j, nil),
-			jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(nil, utils.ErrNoMatchingJob),
+			jobhelper.EXPECT().JobLabels(mld.Name, kernelVersion, "sign").Return(labels),
+			maker.EXPECT().MakeJobTemplate(ctx, mld, labels, previousImageName, true, mld.Owner).Return(&j, nil),
+			jobhelper.EXPECT().GetModuleJobByKernel(ctx, mld.Name, mld.Namespace, kernelVersion, utils.JobTypeSign, mld.Owner).Return(nil, utils.ErrNoMatchingJob),
 			jobhelper.EXPECT().CreateJob(ctx, &j).Return(nil),
 		)
 
 		Expect(
-			mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod),
+			mgr.Sync(ctx, mld, previousImageName, true, mld.Owner),
 		).To(
 			Equal(utils.Status(utils.StatusCreated)),
 		)
@@ -348,15 +326,15 @@ var _ = Describe("Sync", func() {
 		}
 
 		gomock.InOrder(
-			jobhelper.EXPECT().JobLabels(mod.Name, kernelVersion, "sign").Return(labels),
-			maker.EXPECT().MakeJobTemplate(ctx, mod, km, kernelVersion, labels, previousImageName, true, &mod).Return(&newJob, nil),
-			jobhelper.EXPECT().GetModuleJobByKernel(ctx, mod.Name, mod.Namespace, kernelVersion, utils.JobTypeSign, &mod).Return(&newJob, nil),
+			jobhelper.EXPECT().JobLabels(mld.Name, kernelVersion, "sign").Return(labels),
+			maker.EXPECT().MakeJobTemplate(ctx, mld, labels, previousImageName, true, mld.Owner).Return(&newJob, nil),
+			jobhelper.EXPECT().GetModuleJobByKernel(ctx, mld.Name, mld.Namespace, kernelVersion, utils.JobTypeSign, mld.Owner).Return(&newJob, nil),
 			jobhelper.EXPECT().IsJobChanged(&newJob, &newJob).Return(true, nil),
 			jobhelper.EXPECT().DeleteJob(ctx, &newJob).Return(nil),
 		)
 
 		Expect(
-			mgr.Sync(ctx, mod, km, kernelVersion, previousImageName, true, &mod),
+			mgr.Sync(ctx, mld, previousImageName, true, mld.Owner),
 		).To(
 			Equal(utils.Status(utils.StatusInProgress)),
 		)
@@ -376,8 +354,9 @@ var _ = Describe("GarbageCollect", func() {
 		mgr = NewSignJobManager(nil, jobhelper, nil, nil)
 	})
 
-	mod := kmmv1beta1.Module{
-		ObjectMeta: metav1.ObjectMeta{Name: "moduleName"},
+	mld := api.ModuleLoaderData{
+		Name:  "moduleName",
+		Owner: &kmmv1beta1.Module{},
 	}
 
 	DescribeTable("should return the correct error and names of the collected jobs",
@@ -408,7 +387,7 @@ var _ = Describe("GarbageCollect", func() {
 				returnedError = nil
 			}
 
-			jobhelper.EXPECT().GetModuleJobs(context.Background(), mod.Name, mod.Namespace, utils.JobTypeSign, &mod).Return([]batchv1.Job{job1, job2}, returnedError)
+			jobhelper.EXPECT().GetModuleJobs(context.Background(), mld.Name, mld.Namespace, utils.JobTypeSign, mld.Owner).Return([]batchv1.Job{job1, job2}, returnedError)
 			if !expectsErr {
 				if job1.Status.Succeeded == 1 {
 					jobhelper.EXPECT().DeleteJob(context.Background(), &job1).Return(nil)
@@ -418,7 +397,7 @@ var _ = Describe("GarbageCollect", func() {
 				}
 			}
 
-			names, err := mgr.GarbageCollect(context.Background(), mod.Name, mod.Namespace, &mod)
+			names, err := mgr.GarbageCollect(context.Background(), mld.Name, mld.Namespace, mld.Owner)
 
 			if expectsErr {
 				Expect(err).To(HaveOccurred())

--- a/internal/sign/job/mock_signer.go
+++ b/internal/sign/job/mock_signer.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	api "github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	v1 "k8s.io/api/batch/v1"
 	v10 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -38,16 +38,16 @@ func (m *MockSigner) EXPECT() *MockSignerMockRecorder {
 }
 
 // MakeJobTemplate mocks base method.
-func (m *MockSigner) MakeJobTemplate(ctx context.Context, mod v1beta1.Module, km v1beta1.KernelMapping, targetKernel string, labels map[string]string, imageToSign string, pushImage bool, owner v10.Object) (*v1.Job, error) {
+func (m *MockSigner) MakeJobTemplate(ctx context.Context, mld *api.ModuleLoaderData, labels map[string]string, imageToSign string, pushImage bool, owner v10.Object) (*v1.Job, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MakeJobTemplate", ctx, mod, km, targetKernel, labels, imageToSign, pushImage, owner)
+	ret := m.ctrl.Call(m, "MakeJobTemplate", ctx, mld, labels, imageToSign, pushImage, owner)
 	ret0, _ := ret[0].(*v1.Job)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // MakeJobTemplate indicates an expected call of MakeJobTemplate.
-func (mr *MockSignerMockRecorder) MakeJobTemplate(ctx, mod, km, targetKernel, labels, imageToSign, pushImage, owner interface{}) *gomock.Call {
+func (mr *MockSignerMockRecorder) MakeJobTemplate(ctx, mld, labels, imageToSign, pushImage, owner interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeJobTemplate", reflect.TypeOf((*MockSigner)(nil).MakeJobTemplate), ctx, mod, km, targetKernel, labels, imageToSign, pushImage, owner)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MakeJobTemplate", reflect.TypeOf((*MockSigner)(nil).MakeJobTemplate), ctx, mld, labels, imageToSign, pushImage, owner)
 }

--- a/internal/sign/job/signer_test.go
+++ b/internal/sign/job/signer_test.go
@@ -19,6 +19,7 @@ import (
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
@@ -45,8 +46,8 @@ var _ = Describe("MakeJobTemplate", func() {
 	var (
 		ctrl      *gomock.Controller
 		clnt      *client.MockClient
+		mld       api.ModuleLoaderData
 		m         Signer
-		mod       kmmv1beta1.Module
 		jobhelper *utils.MockJobHelper
 		caHelper  *ca.MockHelper
 	)
@@ -57,11 +58,16 @@ var _ = Describe("MakeJobTemplate", func() {
 		jobhelper = utils.NewMockJobHelper(ctrl)
 		caHelper = ca.NewMockHelper(ctrl)
 		m = NewSigner(clnt, scheme, jobhelper, caHelper)
-		mod = kmmv1beta1.Module{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      moduleName,
-				Namespace: namespace,
+		mld = api.ModuleLoaderData{
+			Name:      moduleName,
+			Namespace: namespace,
+			Owner: &kmmv1beta1.Module{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      moduleName,
+					Namespace: namespace,
+				},
 			},
+			KernelVersion: kernelVersion,
 		}
 	})
 
@@ -83,16 +89,14 @@ var _ = Describe("MakeJobTemplate", func() {
 		ctx := context.Background()
 		nodeSelector := map[string]string{"arch": "x64"}
 
-		km := kmmv1beta1.KernelMapping{
-			Sign: &kmmv1beta1.Sign{
-				UnsignedImage: signedImage,
-				KeySecret:     &v1.LocalObjectReference{Name: "securebootkey"},
-				CertSecret:    &v1.LocalObjectReference{Name: "securebootcert"},
-				FilesToSign:   strings.Split(filesToSign, ","),
-			},
-			ContainerImage: signedImage,
-			RegistryTLS:    &kmmv1beta1.TLSOptions{},
+		mld.Sign = &kmmv1beta1.Sign{
+			UnsignedImage: signedImage,
+			KeySecret:     &v1.LocalObjectReference{Name: "securebootkey"},
+			CertSecret:    &v1.LocalObjectReference{Name: "securebootcert"},
+			FilesToSign:   strings.Split(filesToSign, ","),
 		}
+		mld.ContainerImage = signedImage
+		mld.RegistryTLS = &kmmv1beta1.TLSOptions{}
 
 		secretMount := v1.VolumeMount{
 			Name:      "secret-securebootcert",
@@ -171,7 +175,7 @@ var _ = Describe("MakeJobTemplate", func() {
 
 		expected := &batchv1.Job{
 			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: mod.Name + "-sign-",
+				GenerateName: mld.Name + "-sign-",
 				Namespace:    namespace,
 				Labels: map[string]string{
 					constants.ModuleNameLabel:    moduleName,
@@ -224,7 +228,7 @@ var _ = Describe("MakeJobTemplate", func() {
 			},
 		}
 		if imagePullSecret != nil {
-			mod.Spec.ImageRepoSecret = imagePullSecret
+			mld.ImageRepoSecret = imagePullSecret
 			expected.Spec.Template.Spec.Containers[0].VolumeMounts =
 				append(expected.Spec.Template.Spec.Containers[0].VolumeMounts,
 					v1.VolumeMount{
@@ -252,31 +256,30 @@ var _ = Describe("MakeJobTemplate", func() {
 		annotations := map[string]string{constants.JobHashAnnotation: fmt.Sprintf("%d", hash)}
 		expected.SetAnnotations(annotations)
 
-		mod := mod.DeepCopy()
-		mod.Spec.Selector = nodeSelector
+		mld.Selector = nodeSelector
 
 		gomock.InOrder(
 			caHelper.
 				EXPECT().
-				GetClusterCA(ctx, mod.Namespace).
+				GetClusterCA(ctx, mld.Namespace).
 				Return(&ca.ConfigMap{KeyName: clusterCACMKeyName, Name: clusterCACMName}, nil),
 			caHelper.
 				EXPECT().
-				GetServiceCA(ctx, mod.Namespace).
+				GetServiceCA(ctx, mld.Namespace).
 				Return(&ca.ConfigMap{KeyName: serviceCACMKeyName, Name: serviceCACMName}, nil),
-			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: "builder", Namespace: mod.Namespace}, gomock.Any()).DoAndReturn(
+			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: "builder", Namespace: mld.Namespace}, gomock.Any()).DoAndReturn(
 				func(_ interface{}, _ interface{}, svcaccnt *v1.ServiceAccount, _ ...ctrlclient.GetOption) error {
 					svcaccnt.Secrets = []v1.ObjectReference{}
 					return nil
 				},
 			),
-			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: km.Sign.KeySecret.Name, Namespace: mod.Namespace}, gomock.Any()).DoAndReturn(
+			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: mld.Sign.KeySecret.Name, Namespace: mld.Namespace}, gomock.Any()).DoAndReturn(
 				func(_ interface{}, _ interface{}, secret *v1.Secret, _ ...ctrlclient.GetOption) error {
 					secret.Data = privateSignData
 					return nil
 				},
 			),
-			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: km.Sign.CertSecret.Name, Namespace: mod.Namespace}, gomock.Any()).DoAndReturn(
+			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: mld.Sign.CertSecret.Name, Namespace: mld.Namespace}, gomock.Any()).DoAndReturn(
 				func(_ interface{}, _ interface{}, secret *v1.Secret, _ ...ctrlclient.GetOption) error {
 					secret.Data = publicSignData
 					return nil
@@ -284,7 +287,7 @@ var _ = Describe("MakeJobTemplate", func() {
 			),
 		)
 
-		actual, err := m.MakeJobTemplate(ctx, *mod, km, kernelVersion, labels, unsignedImage, true, mod)
+		actual, err := m.MakeJobTemplate(ctx, &mld, labels, unsignedImage, true, mld.Owner)
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(
@@ -305,33 +308,31 @@ var _ = Describe("MakeJobTemplate", func() {
 
 	DescribeTable("should set correct kmod-signer flags", func(filelist []string, pushImage bool) {
 		ctx := context.Background()
-		km := kmmv1beta1.KernelMapping{
-			Sign: &kmmv1beta1.Sign{
-				UnsignedImage: signedImage,
-				KeySecret:     &v1.LocalObjectReference{Name: "securebootkey"},
-				CertSecret:    &v1.LocalObjectReference{Name: "securebootcert"},
-				FilesToSign:   filelist,
-			},
-			ContainerImage: unsignedImage,
-			RegistryTLS:    &kmmv1beta1.TLSOptions{},
+		mld.Sign = &kmmv1beta1.Sign{
+			UnsignedImage: signedImage,
+			KeySecret:     &v1.LocalObjectReference{Name: "securebootkey"},
+			CertSecret:    &v1.LocalObjectReference{Name: "securebootcert"},
+			FilesToSign:   filelist,
 		}
+		mld.ContainerImage = unsignedImage
+		mld.RegistryTLS = &kmmv1beta1.TLSOptions{}
 
 		gomock.InOrder(
-			caHelper.EXPECT().GetClusterCA(ctx, mod.Namespace).Return(&ca.ConfigMap{}, nil),
-			caHelper.EXPECT().GetServiceCA(ctx, mod.Namespace).Return(&ca.ConfigMap{}, nil),
-			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: "builder", Namespace: mod.Namespace}, gomock.Any()).DoAndReturn(
+			caHelper.EXPECT().GetClusterCA(ctx, mld.Namespace).Return(&ca.ConfigMap{}, nil),
+			caHelper.EXPECT().GetServiceCA(ctx, mld.Namespace).Return(&ca.ConfigMap{}, nil),
+			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: "builder", Namespace: mld.Namespace}, gomock.Any()).DoAndReturn(
 				func(_ interface{}, _ interface{}, svcaccnt *v1.ServiceAccount, _ ...ctrlclient.GetOption) error {
 					svcaccnt.Secrets = []v1.ObjectReference{}
 					return nil
 				},
 			),
-			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: km.Sign.KeySecret.Name, Namespace: mod.Namespace}, gomock.Any()).DoAndReturn(
+			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: mld.Sign.KeySecret.Name, Namespace: mld.Namespace}, gomock.Any()).DoAndReturn(
 				func(_ interface{}, _ interface{}, secret *v1.Secret, _ ...ctrlclient.GetOption) error {
 					secret.Data = privateSignData
 					return nil
 				},
 			),
-			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: km.Sign.CertSecret.Name, Namespace: mod.Namespace}, gomock.Any()).DoAndReturn(
+			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: mld.Sign.CertSecret.Name, Namespace: mld.Namespace}, gomock.Any()).DoAndReturn(
 				func(_ interface{}, _ interface{}, secret *v1.Secret, _ ...ctrlclient.GetOption) error {
 					secret.Data = publicSignData
 					return nil
@@ -339,7 +340,7 @@ var _ = Describe("MakeJobTemplate", func() {
 			),
 		)
 
-		actual, err := m.MakeJobTemplate(ctx, mod, km, kernelVersion, labels, "", pushImage, &mod)
+		actual, err := m.MakeJobTemplate(ctx, &mld, labels, "", pushImage, mld.Owner)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(actual.Spec.Template.Spec.Containers[0].Args).To(ContainElement("-unsignedimage"))
@@ -378,32 +379,30 @@ var _ = Describe("MakeJobTemplate", func() {
 	DescribeTable("should set correct kmod-signer TLS flags", func(kmRegistryTLS,
 		unsignedImageRegistryTLS kmmv1beta1.TLSOptions, expectedFlag string) {
 		ctx := context.Background()
-		km := kmmv1beta1.KernelMapping{
-			RegistryTLS: &kmRegistryTLS,
-			Sign: &kmmv1beta1.Sign{
-				UnsignedImage:            signedImage,
-				UnsignedImageRegistryTLS: unsignedImageRegistryTLS,
-				KeySecret:                &v1.LocalObjectReference{Name: "securebootkey"},
-				CertSecret:               &v1.LocalObjectReference{Name: "securebootcert"},
-			},
+		mld.Sign = &kmmv1beta1.Sign{
+			UnsignedImage:            signedImage,
+			UnsignedImageRegistryTLS: unsignedImageRegistryTLS,
+			KeySecret:                &v1.LocalObjectReference{Name: "securebootkey"},
+			CertSecret:               &v1.LocalObjectReference{Name: "securebootcert"},
 		}
+		mld.RegistryTLS = &kmRegistryTLS
 		gomock.InOrder(
-			caHelper.EXPECT().GetClusterCA(ctx, mod.Namespace).Return(&ca.ConfigMap{}, nil),
-			caHelper.EXPECT().GetServiceCA(ctx, mod.Namespace).Return(&ca.ConfigMap{}, nil),
-			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: "builder", Namespace: mod.Namespace}, gomock.Any()).DoAndReturn(
+			caHelper.EXPECT().GetClusterCA(ctx, mld.Namespace).Return(&ca.ConfigMap{}, nil),
+			caHelper.EXPECT().GetServiceCA(ctx, mld.Namespace).Return(&ca.ConfigMap{}, nil),
+			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: "builder", Namespace: mld.Namespace}, gomock.Any()).DoAndReturn(
 				func(_ interface{}, _ interface{}, svcaccnt *v1.ServiceAccount, _ ...ctrlclient.GetOption) error {
 					svcaccnt.Secrets = []v1.ObjectReference{}
 					return nil
 				},
 			),
-			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: km.Sign.KeySecret.Name, Namespace: mod.Namespace}, gomock.Any()).DoAndReturn(
+			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: mld.Sign.KeySecret.Name, Namespace: mld.Namespace}, gomock.Any()).DoAndReturn(
 				func(_ interface{}, _ interface{}, secret *v1.Secret, _ ...ctrlclient.GetOption) error {
 					secret.Data = privateSignData
 					return nil
 				},
 			),
 
-			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: km.Sign.CertSecret.Name, Namespace: mod.Namespace}, gomock.Any()).DoAndReturn(
+			clnt.EXPECT().Get(ctx, types.NamespacedName{Name: mld.Sign.CertSecret.Name, Namespace: mld.Namespace}, gomock.Any()).DoAndReturn(
 				func(_ interface{}, _ interface{}, secret *v1.Secret, _ ...ctrlclient.GetOption) error {
 					secret.Data = publicSignData
 					return nil
@@ -411,7 +410,7 @@ var _ = Describe("MakeJobTemplate", func() {
 			),
 		)
 
-		actual, err := m.MakeJobTemplate(ctx, mod, km, kernelVersion, labels, "", true, &mod)
+		actual, err := m.MakeJobTemplate(ctx, &mld, labels, "", true, mld.Owner)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(actual.Spec.Template.Spec.Containers[0].Args).To(ContainElement(expectedFlag))

--- a/internal/sign/manager.go
+++ b/internal/sign/manager.go
@@ -5,7 +5,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 )
 
@@ -14,16 +14,11 @@ import (
 type SignManager interface {
 	GarbageCollect(ctx context.Context, modName, namespace string, owner metav1.Object) ([]string, error)
 
-	ShouldSync(
-		ctx context.Context,
-		mod kmmv1beta1.Module,
-		m kmmv1beta1.KernelMapping) (bool, error)
+	ShouldSync(ctx context.Context, mld *api.ModuleLoaderData) (bool, error)
 
 	Sync(
 		ctx context.Context,
-		mod kmmv1beta1.Module,
-		m kmmv1beta1.KernelMapping,
-		targetKernel string,
+		mld *api.ModuleLoaderData,
 		imageToSign string,
 		pushImage bool,
 		owner metav1.Object) (utils.Status, error)

--- a/internal/sign/mock_manager.go
+++ b/internal/sign/mock_manager.go
@@ -9,7 +9,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	api "github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	utils "github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -53,31 +53,31 @@ func (mr *MockSignManagerMockRecorder) GarbageCollect(ctx, modName, namespace, o
 }
 
 // ShouldSync mocks base method.
-func (m_2 *MockSignManager) ShouldSync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping) (bool, error) {
-	m_2.ctrl.T.Helper()
-	ret := m_2.ctrl.Call(m_2, "ShouldSync", ctx, mod, m)
+func (m *MockSignManager) ShouldSync(ctx context.Context, mld *api.ModuleLoaderData) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ShouldSync", ctx, mld)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ShouldSync indicates an expected call of ShouldSync.
-func (mr *MockSignManagerMockRecorder) ShouldSync(ctx, mod, m interface{}) *gomock.Call {
+func (mr *MockSignManagerMockRecorder) ShouldSync(ctx, mld interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldSync", reflect.TypeOf((*MockSignManager)(nil).ShouldSync), ctx, mod, m)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ShouldSync", reflect.TypeOf((*MockSignManager)(nil).ShouldSync), ctx, mld)
 }
 
 // Sync mocks base method.
-func (m_2 *MockSignManager) Sync(ctx context.Context, mod v1beta1.Module, m v1beta1.KernelMapping, targetKernel, imageToSign string, pushImage bool, owner v1.Object) (utils.Status, error) {
-	m_2.ctrl.T.Helper()
-	ret := m_2.ctrl.Call(m_2, "Sync", ctx, mod, m, targetKernel, imageToSign, pushImage, owner)
+func (m *MockSignManager) Sync(ctx context.Context, mld *api.ModuleLoaderData, imageToSign string, pushImage bool, owner v1.Object) (utils.Status, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Sync", ctx, mld, imageToSign, pushImage, owner)
 	ret0, _ := ret[0].(utils.Status)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Sync indicates an expected call of Sync.
-func (mr *MockSignManagerMockRecorder) Sync(ctx, mod, m, targetKernel, imageToSign, pushImage, owner interface{}) *gomock.Call {
+func (mr *MockSignManagerMockRecorder) Sync(ctx, mld, imageToSign, pushImage, owner interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockSignManager)(nil).Sync), ctx, mod, m, targetKernel, imageToSign, pushImage, owner)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Sync", reflect.TypeOf((*MockSignManager)(nil).Sync), ctx, mld, imageToSign, pushImage, owner)
 }


### PR DESCRIPTION
…low (#301)

This PR add the creation of the ModuleLoaderData structure. This struct contains all the data needed for processing the wholw flow of Build/Sign/Module loader per specific Module/KernelMapping.
The flow ass following:
1) when starting processing the Reconcile request( either in Module controller
   or in ManagedCluster controller) all the needed data from Module and KernelMapping
   is merged into a newly created ModuleLoaderData struct
2) all the following layers are working only with this structure, no need to look
   at Module or KernelMapping again.
3) This does not affect the flow of DevicePlugin