### PR TITLE
Enable Pod Security sync for openshift-kmm

### DIFF
--- a/config/manager-base/manager.yaml
+++ b/config/manager-base/manager.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   labels:
     control-plane: controller-manager
+    security.openshift.io/scc.podSecurityLabelSync: 'true'
   name: system
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
OLM adds that label in any `openshift-*` namespace not part of the release bundle: [docs](https://docs.openshift.com/container-platform/4.12/authentication/understanding-and-managing-pod-security-admission.html#security-context-constraints-psa-opting_understanding-and-managing-pod-security-admission).
When installing KMM with `oc apply -k`, that label is not present.

This PR fixes that problem by adding that label in the namespace defined in the kustomize manifests.

/cc @yevgeny-shnaidman @mresvanis 