### PR TITLE
Changing the metrics flow (#307)

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -160,7 +160,7 @@ func main() {
 		kernelAPI,
 		metricsAPI,
 		filterAPI,
-		statusupdater.NewModuleStatusUpdater(client, metricsAPI),
+		statusupdater.NewModuleStatusUpdater(client),
 		caHelper,
 		operatorNamespace,
 	)
@@ -183,7 +183,7 @@ func main() {
 	preflightOCPStatusUpdaterAPI := statusupdater.NewPreflightOCPStatusUpdater(client)
 	preflightAPI := preflight.NewPreflightAPI(client, buildAPI, signAPI, registryAPI, kernelAPI, preflightStatusUpdaterAPI, authFactory)
 
-	if err = controllers.NewPreflightValidationReconciler(client, filterAPI, preflightStatusUpdaterAPI, preflightAPI).SetupWithManager(mgr); err != nil {
+	if err = controllers.NewPreflightValidationReconciler(client, filterAPI, metricsAPI, preflightStatusUpdaterAPI, preflightAPI).SetupWithManager(mgr); err != nil {
 		cmd.FatalError(setupLogger, err, "unable to create controller", "name", controllers.PreflightValidationReconcilerName)
 	}
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -16,6 +16,7 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
+- ../prometheus
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook

--- a/config/manager-base/manager.yaml
+++ b/config/manager-base/manager.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     control-plane: controller-manager
     security.openshift.io/scc.podSecurityLabelSync: 'true'
+    openshift.io/cluster-monitoring: "true"
   name: system
 ---
 apiVersion: apps/v1

--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -312,11 +312,8 @@ func (mrh *moduleReconcilerHelper) handleBuild(ctx context.Context, mld *api.Mod
 
 	completedSuccessfully := false
 	switch buildStatus {
-	case utils.StatusCreated:
-		mrh.metricsAPI.SetCompletedStage(mld.Name, mld.Namespace, mld.KernelVersion, metrics.BuildStage, false)
 	case utils.StatusCompleted:
 		completedSuccessfully = true
-		mrh.metricsAPI.SetCompletedStage(mld.Name, mld.Namespace, mld.KernelVersion, metrics.BuildStage, true)
 	case utils.StatusFailed:
 		logger.Info(utils.WarnString("Build job has failed. If the fix is not in Module CR, then delete job after the fix in order to restart the job"))
 	}
@@ -350,11 +347,8 @@ func (mrh *moduleReconcilerHelper) handleSigning(ctx context.Context, mld *api.M
 
 	completedSuccessfully := false
 	switch signStatus {
-	case utils.StatusCreated:
-		mrh.metricsAPI.SetCompletedStage(mld.Name, mld.Namespace, mld.KernelVersion, metrics.SignStage, false)
 	case utils.StatusCompleted:
 		completedSuccessfully = true
-		mrh.metricsAPI.SetCompletedStage(mld.Name, mld.Namespace, mld.KernelVersion, metrics.SignStage, true)
 	case utils.StatusFailed:
 		logger.Info(utils.WarnString("Sign job has failed. If the fix is not in Module CR, then delete job after the fix in order to restart the job"))
 	}
@@ -383,9 +377,6 @@ func (mrh *moduleReconcilerHelper) handleDriverContainer(ctx context.Context,
 	})
 
 	if err == nil {
-		if opRes == controllerutil.OperationResultCreated {
-			mrh.metricsAPI.SetCompletedStage(mld.Name, mld.Namespace, mld.KernelVersion, metrics.ModuleLoaderStage, false)
-		}
 		logger.Info("Reconciled Driver Container", "name", ds.Name, "result", opRes)
 	}
 
@@ -407,9 +398,6 @@ func (mrh *moduleReconcilerHelper) handleDevicePlugin(ctx context.Context, mod *
 	})
 
 	if err == nil {
-		if opRes == controllerutil.OperationResultCreated {
-			mrh.metricsAPI.SetCompletedStage(mod.Name, mod.Namespace, "", metrics.DevicePluginStage, false)
-		}
 		logger.Info("Reconciled Device Plugin", "name", ds.Name, "result", opRes)
 	}
 
@@ -457,9 +445,38 @@ func (mrh *moduleReconcilerHelper) setKMMOMetrics(ctx context.Context) {
 	err := mrh.client.List(ctx, &mods)
 	if err != nil {
 		logger.V(1).Info("failed to list KMMomodules for metrics", "error", err)
+		return
 	}
 
-	mrh.metricsAPI.SetExistingKMMOModules(len(mods.Items))
+	numModules := len(mods.Items)
+	numModulesWithBuild := 0
+	numModulesWithSign := 0
+	numModulesWithDevicePlugin := 0
+	for _, mod := range mods.Items {
+		if mod.Spec.DevicePlugin != nil {
+			numModulesWithDevicePlugin += 1
+		}
+		buildCapable, signCapable := isModuleBuildAndSignCapable(&mod)
+		if buildCapable {
+			numModulesWithBuild += 1
+		}
+		if signCapable {
+			numModulesWithSign += 1
+		}
+
+		if mod.Spec.ModuleLoader.Container.Modprobe.Args != nil {
+			modprobeArgs := strings.Join(mod.Spec.ModuleLoader.Container.Modprobe.Args.Load, ",")
+			mrh.metricsAPI.SetKMMModprobeArgs(mod.Name, mod.Namespace, modprobeArgs)
+		}
+		if mod.Spec.ModuleLoader.Container.Modprobe.RawArgs != nil {
+			modprobeRawArgs := strings.Join(mod.Spec.ModuleLoader.Container.Modprobe.RawArgs.Load, ",")
+			mrh.metricsAPI.SetKMMModprobeRawArgs(mod.Name, mod.Namespace, modprobeRawArgs)
+		}
+	}
+	mrh.metricsAPI.SetKMMModulesNum(numModules)
+	mrh.metricsAPI.SetKMMInClusterBuildNum(numModulesWithBuild)
+	mrh.metricsAPI.SetKMMInClusterSignNum(numModulesWithSign)
+	mrh.metricsAPI.SetKMMDevicePluginNum(numModulesWithDevicePlugin)
 }
 
 func (mrh *moduleReconcilerHelper) getRequestedModule(ctx context.Context, namespacedName types.NamespacedName) (*kmmv1beta1.Module, error) {
@@ -496,4 +513,21 @@ func isNodeSchedulable(node *v1.Node) bool {
 		}
 	}
 	return true
+}
+
+func isModuleBuildAndSignCapable(mod *kmmv1beta1.Module) (bool, bool) {
+	buildCapable := mod.Spec.ModuleLoader.Container.Build != nil
+	signCapable := mod.Spec.ModuleLoader.Container.Sign != nil
+	if buildCapable && signCapable {
+		return true, true
+	}
+	for _, mapping := range mod.Spec.ModuleLoader.Container.KernelMappings {
+		if mapping.Sign != nil {
+			signCapable = true
+		}
+		if mapping.Build != nil {
+			buildCapable = true
+		}
+	}
+	return buildCapable, signCapable
 }

--- a/controllers/module_reconciler_test.go
+++ b/controllers/module_reconciler_test.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
@@ -429,7 +430,6 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 		gomock.InOrder(
 			mockBM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
 			mockBM.EXPECT().Sync(gomock.Any(), &mld, true, mld.Owner).Return(utils.Status(utils.StatusCreated), nil),
-			mockMetrics.EXPECT().SetCompletedStage(mld.Name, mld.Namespace, kernelVersion, metrics.BuildStage, false),
 		)
 
 		completed, err := mhr.handleBuild(context.Background(), &mld)
@@ -450,7 +450,6 @@ var _ = Describe("ModuleReconciler_handleBuild", func() {
 		gomock.InOrder(
 			mockBM.EXPECT().ShouldSync(gomock.Any(), mld).Return(true, nil),
 			mockBM.EXPECT().Sync(gomock.Any(), mld, true, mld.Owner).Return(utils.Status(utils.StatusCompleted), nil),
-			mockMetrics.EXPECT().SetCompletedStage(mld.Name, mld.Namespace, kernelVersion, metrics.BuildStage, true),
 		)
 
 		completed, err := mhr.handleBuild(context.Background(), mld)
@@ -509,7 +508,6 @@ var _ = Describe("ModuleReconciler_handleSigning", func() {
 		gomock.InOrder(
 			mockSM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
 			mockSM.EXPECT().Sync(gomock.Any(), &mld, "", true, mld.Owner).Return(utils.Status(utils.StatusCreated), nil),
-			mockMetrics.EXPECT().SetCompletedStage(mld.Name, mld.Namespace, kernelVersion, metrics.SignStage, false),
 		)
 
 		completed, err := mhr.handleSigning(context.Background(), &mld)
@@ -530,7 +528,6 @@ var _ = Describe("ModuleReconciler_handleSigning", func() {
 		gomock.InOrder(
 			mockSM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
 			mockSM.EXPECT().Sync(gomock.Any(), &mld, "", true, mld.Owner).Return(utils.Status(utils.StatusCompleted), nil),
-			mockMetrics.EXPECT().SetCompletedStage(mld.Name, mld.Namespace, kernelVersion, metrics.SignStage, true),
 		)
 
 		completed, err := mhr.handleSigning(context.Background(), &mld)
@@ -554,7 +551,6 @@ var _ = Describe("ModuleReconciler_handleSigning", func() {
 			mockSM.EXPECT().ShouldSync(gomock.Any(), mld).Return(true, nil),
 			mockSM.EXPECT().Sync(gomock.Any(), mld, imageName+":"+namespace+"_"+moduleName+"_kmm_unsigned", true, mld.Owner).
 				Return(utils.Status(utils.StatusCompleted), nil),
-			mockMetrics.EXPECT().SetCompletedStage(mld.Name, mld.Namespace, kernelVersion, metrics.SignStage, true),
 		)
 
 		completed, err := mhr.handleSigning(context.Background(), mld)
@@ -599,7 +595,6 @@ var _ = Describe("ModuleReconciler_handleDriverContainer", func() {
 			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
 			mockDC.EXPECT().SetDriverContainerAsDesired(ctx, newDS, &mld, true).Return(nil),
 			clnt.EXPECT().Create(ctx, gomock.Any()).Return(nil),
-			mockMetrics.EXPECT().SetCompletedStage(mld.Name, mld.Namespace, mld.KernelVersion, metrics.ModuleLoaderStage, false),
 		)
 
 		err := mhr.handleDriverContainer(ctx, &mld, existingDS)
@@ -680,7 +675,6 @@ var _ = Describe("ModuleReconciler_handleDevicePlugin", func() {
 			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
 			mockDC.EXPECT().SetDevicePluginAsDesired(ctx, newDS, &mod, true).Return(nil),
 			clnt.EXPECT().Create(ctx, gomock.Any()).Return(nil),
-			mockMetrics.EXPECT().SetCompletedStage(mod.Name, mod.Namespace, "", metrics.DevicePluginStage, false),
 		)
 
 		err := mhr.handleDevicePlugin(ctx, &mod)
@@ -756,4 +750,102 @@ var _ = Describe("ModuleReconciler_garbageCollect", func() {
 
 		Expect(err).NotTo(HaveOccurred())
 	})
+})
+
+var _ = Describe("ModuleReconciler_setKMMOMetrics", func() {
+	var (
+		ctrl        *gomock.Controller
+		clnt        *client.MockClient
+		mockMetrics *metrics.MockMetrics
+		mhr         moduleReconcilerHelperAPI
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		mockMetrics = metrics.NewMockMetrics(ctrl)
+		mhr = newModuleReconcilerHelper(clnt, nil, nil, nil, nil, mockMetrics, "")
+	})
+
+	ctx := context.Background()
+
+	It("failed to list Modules", func() {
+		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
+
+		mhr.setKMMOMetrics(ctx)
+	})
+
+	DescribeTable("getting metrics data", func(buildInContainer, buildInKM, signInContainer, signInKM, devicePlugin bool, modprobeArg, modprobeRawArg []string) {
+		km := kmmv1beta1.KernelMapping{}
+		mod1 := kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "moduleName",
+				Namespace: "namespace",
+			},
+		}
+		mod2 := kmmv1beta1.Module{}
+		mod3 := kmmv1beta1.Module{}
+		numBuild := 0
+		numSign := 0
+		numDevicePlugin := 0
+		if buildInContainer {
+			mod1.Spec.ModuleLoader.Container.Build = &kmmv1beta1.Build{}
+			numBuild = 1
+		}
+		if buildInKM {
+			km.Build = &kmmv1beta1.Build{}
+			numBuild = 1
+		}
+		if signInContainer {
+			mod1.Spec.ModuleLoader.Container.Sign = &kmmv1beta1.Sign{}
+			numSign = 1
+		}
+		if signInKM {
+			km.Sign = &kmmv1beta1.Sign{}
+			numSign = 1
+		}
+		if devicePlugin {
+			mod1.Spec.DevicePlugin = &kmmv1beta1.DevicePluginSpec{}
+			numDevicePlugin = 1
+		}
+		if modprobeArg != nil {
+			mod1.Spec.ModuleLoader.Container.Modprobe.Args = &kmmv1beta1.ModprobeArgs{Load: modprobeArg}
+		}
+		if modprobeRawArg != nil {
+			mod1.Spec.ModuleLoader.Container.Modprobe.RawArgs = &kmmv1beta1.ModprobeArgs{Load: modprobeRawArg}
+		}
+		mod1.Spec.ModuleLoader.Container.KernelMappings = []kmmv1beta1.KernelMapping{km}
+
+		clnt.EXPECT().List(context.Background(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ interface{}, list *kmmv1beta1.ModuleList, _ ...interface{}) error {
+				list.Items = []kmmv1beta1.Module{mod1, mod2, mod3}
+				return nil
+			},
+		)
+
+		if modprobeArg != nil {
+			mockMetrics.EXPECT().SetKMMModprobeArgs(mod1.Name, mod1.Namespace, strings.Join(modprobeArg, ","))
+		}
+		if modprobeRawArg != nil {
+			mockMetrics.EXPECT().SetKMMModprobeRawArgs(mod1.Name, mod1.Namespace, strings.Join(modprobeRawArg, ","))
+		}
+
+		mockMetrics.EXPECT().SetKMMModulesNum(3)
+		mockMetrics.EXPECT().SetKMMInClusterBuildNum(numBuild)
+		mockMetrics.EXPECT().SetKMMInClusterSignNum(numSign)
+		mockMetrics.EXPECT().SetKMMDevicePluginNum(numDevicePlugin)
+
+		mhr.setKMMOMetrics(ctx)
+	},
+		Entry("build in container", true, false, false, false, false, nil, nil),
+		Entry("build in KM", false, true, false, false, false, nil, nil),
+		Entry("build in container and KM", true, true, false, false, false, nil, nil),
+		Entry("sign in container", false, false, true, false, false, nil, nil),
+		Entry("sign in KM", false, false, false, true, false, nil, nil),
+		Entry("sign in container and KM", false, false, true, true, false, nil, nil),
+		Entry("device plugin", false, false, false, false, true, nil, nil),
+		Entry("modprobe args", false, false, false, false, false, []string{"param1", "param2"}, nil),
+		Entry("modprobe raw args", false, false, false, false, false, nil, []string{"rawparam1", "rawparam2"}),
+		Entry("altogether", true, true, true, true, true, []string{"param1", "param2"}, []string{"rawparam1", "rawparam2"}),
+	)
 })

--- a/controllers/preflightvalidation_reconciler_test.go
+++ b/controllers/preflightvalidation_reconciler_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/gomega"
 	v1beta12 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/metrics"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/preflight"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/statusupdater"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -29,6 +30,7 @@ var _ = Describe("PreflightValidationReconciler_Reconcile", func() {
 	var (
 		ctrl          *gomock.Controller
 		clnt          *client.MockClient
+		mockMetrics   *metrics.MockMetrics
 		mockSU        *statusupdater.MockPreflightStatusUpdater
 		mockPreflight *preflight.MockPreflightAPI
 		req           reconcile.Request
@@ -40,6 +42,7 @@ var _ = Describe("PreflightValidationReconciler_Reconcile", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
+		mockMetrics = metrics.NewMockMetrics(ctrl)
 		mockSU = statusupdater.NewMockPreflightStatusUpdater(ctrl)
 		mockPreflight = preflight.NewMockPreflightAPI(ctrl)
 		nsn = types.NamespacedName{
@@ -48,7 +51,7 @@ var _ = Describe("PreflightValidationReconciler_Reconcile", func() {
 		}
 		req = reconcile.Request{NamespacedName: nsn}
 		ctx = context.Background()
-		pr = NewPreflightValidationReconciler(clnt, nil, mockSU, mockPreflight)
+		pr = NewPreflightValidationReconciler(clnt, nil, mockMetrics, mockSU, mockPreflight)
 	})
 
 	It("should do nothing if the Preflight is not available anymore", func() {
@@ -96,6 +99,7 @@ var _ = Describe("PreflightValidationReconciler_Reconcile", func() {
 					return nil
 				},
 			),
+			mockMetrics.EXPECT().SetKMMPreflightsNum(1),
 			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
 				func(_ interface{}, list *v1beta12.ModuleList, _ ...interface{}) error {
 					list.Items = []v1beta12.Module{mod}
@@ -147,6 +151,7 @@ var _ = Describe("PreflightValidationReconciler_Reconcile", func() {
 					return nil
 				},
 			),
+			mockMetrics.EXPECT().SetKMMPreflightsNum(1),
 			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
 				func(_ interface{}, list *v1beta12.ModuleList, _ ...interface{}) error {
 					list.Items = []v1beta12.Module{mod}
@@ -189,7 +194,7 @@ var _ = Describe("PreflightValidationReconciler_getModulesCheck", func() {
 		mockSU = statusupdater.NewMockPreflightStatusUpdater(ctrl)
 		mockPreflight = preflight.NewMockPreflightAPI(ctrl)
 		ctx = context.Background()
-		pr = NewPreflightValidationReconciler(clnt, nil, mockSU, mockPreflight)
+		pr = NewPreflightValidationReconciler(clnt, nil, nil, mockSU, mockPreflight)
 	})
 
 	It("multiple modules, statuses exist, none deleted", func() {
@@ -348,7 +353,7 @@ var _ = Describe("PreflightValidationReconciler_updatePreflightStatus", func() {
 		mockSU = statusupdater.NewMockPreflightStatusUpdater(ctrl)
 		mockPreflight = preflight.NewMockPreflightAPI(ctrl)
 		ctx = context.Background()
-		pr = NewPreflightValidationReconciler(clnt, nil, mockSU, mockPreflight)
+		pr = NewPreflightValidationReconciler(clnt, nil, nil, mockSU, mockPreflight)
 	})
 
 	It("status verified", func() {
@@ -401,7 +406,7 @@ var _ = Describe("PreflightValidationReconciler_checkPreflightCompletion", func(
 			Name:      preflightName,
 			Namespace: namespace,
 		}
-		pr = NewPreflightValidationReconciler(clnt, nil, mockSU, mockPreflight)
+		pr = NewPreflightValidationReconciler(clnt, nil, nil, mockSU, mockPreflight)
 	})
 
 	It("Get preflight failed", func() {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -7,12 +7,13 @@ import (
 
 // When adding metric names, see https://prometheus.io/docs/practices/naming/#metric-names
 const (
-	existingKMMOModulesQuery = "kmmo_module_total"
-	completedKMMOStageQuery  = "kmmo_completed_stage"
-	BuildStage               = "build"
-	SignStage                = "sign"
-	ModuleLoaderStage        = "module-loader"
-	DevicePluginStage        = "device-plugin"
+	kmmModulesQuery         = "kmm_module_num"
+	kmmInClusterBuildQuery  = "kmm_in_cluster_build_num"
+	kmmInClusterSignQuery   = "kmm_in_cluster_sign_num"
+	kmmDevicePluginQuery    = "kmm_device_plugin_num"
+	kmmPreflightQuery       = "kmm_preflight_num"
+	kmmModprobeArgsQuery    = "kmm_modprobe_args"
+	kmmModprobeRawArgsQuery = "kmm_modprobe_raw_args"
 )
 
 //go:generate mockgen -source=metrics.go -package=metrics -destination=mock_metrics_api.go
@@ -20,52 +21,124 @@ const (
 // Metrics is an interface representing a prometheus client for the Kernel Module Management Operator
 type Metrics interface {
 	Register()
-	SetExistingKMMOModules(value int)
-	SetCompletedStage(kmmoName, kmmoNamespace, kernelVersion, stage string, completed bool)
+	SetKMMModulesNum(value int)
+	SetKMMInClusterBuildNum(value int)
+	SetKMMInClusterSignNum(value int)
+	SetKMMDevicePluginNum(value int)
+	SetKMMPreflightsNum(value int)
+	SetKMMModprobeArgs(modName, namespace, modprobeArgs string)
+	SetKMMModprobeRawArgs(modName, namespace, modprobeArgs string)
 }
 
 type metrics struct {
-	kmmoResourcesNum   prometheus.Gauge
-	kmmoCompletedStage *prometheus.GaugeVec
+	kmmModuleResourcesNum       prometheus.Gauge
+	kmmInClusterBuildNum        prometheus.Gauge
+	kmmInClusterSignNum         prometheus.Gauge
+	kmmDevicePluginResourcesNum prometheus.Gauge
+	kmmPreflightResourceNum     prometheus.Gauge
+	kmmModprobeArgs             *prometheus.GaugeVec
+	kmmModprobeRawArgs          *prometheus.GaugeVec
 }
 
 func New() Metrics {
 
-	kmmoResourcesNum := prometheus.NewGauge(
+	kmmModuleResourcesNum := prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: existingKMMOModulesQuery,
+			Name: kmmModulesQuery,
 			Help: "Number of existing KMMO Modules",
 		},
 	)
-	completedStages := prometheus.NewGaugeVec(
+
+	kmmInClusterBuildNum := prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: completedKMMOStageQuery,
-			Help: "For a given kmmo,namespace, kernel version, stage(device-plugin, module-loader, build), 1 if the stage is completed, 0 if it is not.",
+			Name: kmmInClusterBuildQuery,
+			Help: "Number of existing KMMO Modules with in-cluster Build defined",
 		},
-		[]string{"kmmo", "namespace", "kernel", "stage"},
+	)
+
+	kmmInClusterSignNum := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: kmmInClusterSignQuery,
+			Help: "Number of existing KMMO Modules with in-cluster Sign defined",
+		},
+	)
+
+	kmmDevicePluginResourcesNum := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: kmmDevicePluginQuery,
+			Help: "Number of existing KMMO Modules with DevicePlugin defined",
+		},
+	)
+
+	kmmPreflightResourceNum := prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: kmmPreflightQuery,
+			Help: "Number of existing KMMO Preflights",
+		},
+	)
+
+	kmmModprobeArgs := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: kmmModprobeArgsQuery,
+			Help: "for a given kernel version, describe which modprobe args used (if at all)",
+		},
+		[]string{"name", "namespace", "modprobeArgs"},
+	)
+
+	kmmModprobeRawArgs := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: kmmModprobeRawArgsQuery,
+			Help: "for a given kernel version, describe which modprobe raw args used (if at all)",
+		},
+		[]string{"name", "namespace", "modprobeRawArgs"},
 	)
 
 	return &metrics{
-		kmmoResourcesNum:   kmmoResourcesNum,
-		kmmoCompletedStage: completedStages,
+		kmmModuleResourcesNum:       kmmModuleResourcesNum,
+		kmmInClusterBuildNum:        kmmInClusterBuildNum,
+		kmmInClusterSignNum:         kmmInClusterSignNum,
+		kmmDevicePluginResourcesNum: kmmDevicePluginResourcesNum,
+		kmmPreflightResourceNum:     kmmPreflightResourceNum,
+		kmmModprobeArgs:             kmmModprobeArgs,
+		kmmModprobeRawArgs:          kmmModprobeRawArgs,
 	}
 }
 
 func (m *metrics) Register() {
 	runtimemetrics.Registry.MustRegister(
-		m.kmmoResourcesNum,
-		m.kmmoCompletedStage,
+		m.kmmModuleResourcesNum,
+		m.kmmInClusterBuildNum,
+		m.kmmInClusterSignNum,
+		m.kmmDevicePluginResourcesNum,
+		m.kmmPreflightResourceNum,
+		m.kmmModprobeArgs,
 	)
 }
 
-func (m *metrics) SetExistingKMMOModules(value int) {
-	m.kmmoResourcesNum.Set(float64(value))
+func (m *metrics) SetKMMModulesNum(value int) {
+	m.kmmModuleResourcesNum.Set(float64(value))
 }
 
-func (m *metrics) SetCompletedStage(kmmoName, kmmoNamespace, kernelVersion, stage string, completed bool) {
-	var value float64
-	if completed {
-		value = 1
-	}
-	m.kmmoCompletedStage.WithLabelValues(kmmoName, kmmoNamespace, kernelVersion, stage).Set(value)
+func (m *metrics) SetKMMInClusterBuildNum(value int) {
+	m.kmmInClusterBuildNum.Set(float64(value))
+}
+
+func (m *metrics) SetKMMInClusterSignNum(value int) {
+	m.kmmInClusterSignNum.Set(float64(value))
+}
+
+func (m *metrics) SetKMMDevicePluginNum(value int) {
+	m.kmmDevicePluginResourcesNum.Set(float64(value))
+}
+
+func (m *metrics) SetKMMPreflightsNum(value int) {
+	m.kmmPreflightResourceNum.Set(float64(value))
+}
+
+func (m *metrics) SetKMMModprobeArgs(modName, namespace, modprobeArgs string) {
+	m.kmmModprobeArgs.WithLabelValues(modName, namespace, modprobeArgs).Set(float64(1))
+}
+
+func (m *metrics) SetKMMModprobeRawArgs(modName, namespace, modprobeRawArgs string) {
+	m.kmmModprobeRawArgs.WithLabelValues(modName, namespace, modprobeRawArgs).Set(float64(1))
 }

--- a/internal/metrics/mock_metrics_api.go
+++ b/internal/metrics/mock_metrics_api.go
@@ -45,26 +45,86 @@ func (mr *MockMetricsMockRecorder) Register() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockMetrics)(nil).Register))
 }
 
-// SetCompletedStage mocks base method.
-func (m *MockMetrics) SetCompletedStage(kmmoName, kmmoNamespace, kernelVersion, stage string, completed bool) {
+// SetKMMDevicePluginNum mocks base method.
+func (m *MockMetrics) SetKMMDevicePluginNum(value int) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetCompletedStage", kmmoName, kmmoNamespace, kernelVersion, stage, completed)
+	m.ctrl.Call(m, "SetKMMDevicePluginNum", value)
 }
 
-// SetCompletedStage indicates an expected call of SetCompletedStage.
-func (mr *MockMetricsMockRecorder) SetCompletedStage(kmmoName, kmmoNamespace, kernelVersion, stage, completed interface{}) *gomock.Call {
+// SetKMMDevicePluginNum indicates an expected call of SetKMMDevicePluginNum.
+func (mr *MockMetricsMockRecorder) SetKMMDevicePluginNum(value interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCompletedStage", reflect.TypeOf((*MockMetrics)(nil).SetCompletedStage), kmmoName, kmmoNamespace, kernelVersion, stage, completed)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetKMMDevicePluginNum", reflect.TypeOf((*MockMetrics)(nil).SetKMMDevicePluginNum), value)
 }
 
-// SetExistingKMMOModules mocks base method.
-func (m *MockMetrics) SetExistingKMMOModules(value int) {
+// SetKMMInClusterBuildNum mocks base method.
+func (m *MockMetrics) SetKMMInClusterBuildNum(value int) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetExistingKMMOModules", value)
+	m.ctrl.Call(m, "SetKMMInClusterBuildNum", value)
 }
 
-// SetExistingKMMOModules indicates an expected call of SetExistingKMMOModules.
-func (mr *MockMetricsMockRecorder) SetExistingKMMOModules(value interface{}) *gomock.Call {
+// SetKMMInClusterBuildNum indicates an expected call of SetKMMInClusterBuildNum.
+func (mr *MockMetricsMockRecorder) SetKMMInClusterBuildNum(value interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetExistingKMMOModules", reflect.TypeOf((*MockMetrics)(nil).SetExistingKMMOModules), value)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetKMMInClusterBuildNum", reflect.TypeOf((*MockMetrics)(nil).SetKMMInClusterBuildNum), value)
+}
+
+// SetKMMInClusterSignNum mocks base method.
+func (m *MockMetrics) SetKMMInClusterSignNum(value int) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetKMMInClusterSignNum", value)
+}
+
+// SetKMMInClusterSignNum indicates an expected call of SetKMMInClusterSignNum.
+func (mr *MockMetricsMockRecorder) SetKMMInClusterSignNum(value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetKMMInClusterSignNum", reflect.TypeOf((*MockMetrics)(nil).SetKMMInClusterSignNum), value)
+}
+
+// SetKMMModprobeArgs mocks base method.
+func (m *MockMetrics) SetKMMModprobeArgs(modName, namespace, modprobeArgs string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetKMMModprobeArgs", modName, namespace, modprobeArgs)
+}
+
+// SetKMMModprobeArgs indicates an expected call of SetKMMModprobeArgs.
+func (mr *MockMetricsMockRecorder) SetKMMModprobeArgs(modName, namespace, modprobeArgs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetKMMModprobeArgs", reflect.TypeOf((*MockMetrics)(nil).SetKMMModprobeArgs), modName, namespace, modprobeArgs)
+}
+
+// SetKMMModprobeRawArgs mocks base method.
+func (m *MockMetrics) SetKMMModprobeRawArgs(modName, namespace, modprobeArgs string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetKMMModprobeRawArgs", modName, namespace, modprobeArgs)
+}
+
+// SetKMMModprobeRawArgs indicates an expected call of SetKMMModprobeRawArgs.
+func (mr *MockMetricsMockRecorder) SetKMMModprobeRawArgs(modName, namespace, modprobeArgs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetKMMModprobeRawArgs", reflect.TypeOf((*MockMetrics)(nil).SetKMMModprobeRawArgs), modName, namespace, modprobeArgs)
+}
+
+// SetKMMModulesNum mocks base method.
+func (m *MockMetrics) SetKMMModulesNum(value int) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetKMMModulesNum", value)
+}
+
+// SetKMMModulesNum indicates an expected call of SetKMMModulesNum.
+func (mr *MockMetricsMockRecorder) SetKMMModulesNum(value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetKMMModulesNum", reflect.TypeOf((*MockMetrics)(nil).SetKMMModulesNum), value)
+}
+
+// SetKMMPreflightsNum mocks base method.
+func (m *MockMetrics) SetKMMPreflightsNum(value int) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetKMMPreflightsNum", value)
+}
+
+// SetKMMPreflightsNum indicates an expected call of SetKMMPreflightsNum.
+func (mr *MockMetricsMockRecorder) SetKMMPreflightsNum(value interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetKMMPreflightsNum", reflect.TypeOf((*MockMetrics)(nil).SetKMMPreflightsNum), value)
 }


### PR DESCRIPTION
Up to now, the metric were mainly refelcting the current progress of customer's Module, which was not very useful, since customers do not look at them. This PR changes the metrics so as to supply the info regarding KMMO usage by the customer. The following metrics are gathered: 1) number of Modules deployed on the cluster
2) number of modules with in-cluster build capabilty 3) number of module with in-cluster sign capability 4) number of modules deploying device plugin
5) if the preflight capability is used on the cluster 6) modules that are using Morprobe arg configuration ( raw and non-raw)
   and which configuration they are using

---

Fixes[#452 ]