### PR TITLE
Add RT Kernel support to Preflight flow

### DIFF
--- a/api/v1beta1/preflightvalidationocp_types.go
+++ b/api/v1beta1/preflightvalidationocp_types.go
@@ -29,6 +29,11 @@ type PreflightValidationOCPSpec struct {
 	// +kubebuilder:validation:Required
 	ReleaseImage string `json:"releaseImage"`
 
+	// Boolean flag that determines whether the preflight should be checked with RT kernel version
+	// instead of Full kernel version
+	// +optional
+	UseRTKernel bool `json:"useRTKernel"`
+
 	// Boolean flag that determines whether images build during preflight must also
 	// be pushed to a defined repository
 	// +optional

--- a/bundle/manifests/kmm.sigs.x-k8s.io_preflightvalidationsocp.yaml
+++ b/bundle/manifests/kmm.sigs.x-k8s.io_preflightvalidationsocp.yaml
@@ -47,6 +47,10 @@ spec:
                 description: releaseImage describes the OCP release image that all
                   Modules need to be checked against.
                 type: string
+              useRTKernel:
+                description: Boolean flag that determines whether the preflight should
+                  be checked with RT kernel version instead of Full kernel version
+                type: boolean
             required:
             - releaseImage
             type: object

--- a/config/crd/bases/kmm.sigs.x-k8s.io_preflightvalidationsocp.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_preflightvalidationsocp.yaml
@@ -48,6 +48,10 @@ spec:
                 description: releaseImage describes the OCP release image that all
                   Modules need to be checked against.
                 type: string
+              useRTKernel:
+                description: Boolean flag that determines whether the preflight should
+                  be checked with RT kernel version instead of Full kernel version
+                type: boolean
             required:
             - releaseImage
             type: object


### PR DESCRIPTION
This PR allows customer to run Preflight validation flow on an OCP cluster with RT kernel deployed. The flow as following
1) add a boolean flag to PreflightOCP CR that allows user to specify if he wants to validate for Full kernel
   version or for RT kernel version
2) when extracting the OS configuration from the OCP DTK image, in case boolean flag in CR was set, the
   validation kernel is set to RT kernel