### PR TITLE
Expose module's name and namespace in build object

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ vet: ## Run go vet against code.
 
 TEST ?= ./...
 
-.PHONY: test
+.PHONY: unit-test
 unit-test: vet ## Run tests.
 	go test $(TEST) -coverprofile cover.out
 

--- a/ci/module-kmm-ci-build-sign.yaml
+++ b/ci/module-kmm-ci-build-sign.yaml
@@ -10,7 +10,7 @@ spec:
         moduleName: kmm_ci_a
       kernelMappings:
         - regexp: '^.+$'
-          containerImage: image-registry.openshift-image-registry.svc:5000/default/kmm-kmod:$KERNEL_FULL_VERSION
+          containerImage: image-registry.openshift-image-registry.svc:5000/$MOD_NAMESPACE/$MOD_NAME:$KERNEL_FULL_VERSION
           build:
             secrets:
               - name: build-secret

--- a/internal/build/buildconfig/maker.go
+++ b/internal/build/buildconfig/maker.go
@@ -74,6 +74,14 @@ func (m *maker) MakeBuildTemplate(
 			Name:  "KERNEL_VERSION",
 			Value: kernelVersion,
 		},
+		{
+			Name:  "MOD_NAME",
+			Value: mld.Name,
+		},
+		{
+			Name:  "MOD_NAMESPACE",
+			Value: mld.Namespace,
+		},
 	}
 
 	dockerfileData, err := m.getDockerfileData(ctx, kmmBuild, mld.Namespace)

--- a/internal/build/buildconfig/maker_test.go
+++ b/internal/build/buildconfig/maker_test.go
@@ -102,10 +102,9 @@ var _ = Describe("Maker_MakeBuildTemplate", func() {
 		}
 
 		overrides := []kmmv1beta1.BuildArg{
-			{
-				Name:  "KERNEL_VERSION",
-				Value: targetKernel,
-			},
+			{Name: "KERNEL_VERSION", Value: targetKernel},
+			{Name: "MOD_NAME", Value: moduleName},
+			{Name: "MOD_NAMESPACE", Value: namespace},
 		}
 
 		expected := buildv1.Build{
@@ -139,6 +138,8 @@ var _ = Describe("Maker_MakeBuildTemplate", func() {
 							BuildArgs: append(
 								envVarsFromKMMBuildArgs(buildArgs),
 								v1.EnvVar{Name: "KERNEL_VERSION", Value: targetKernel},
+								v1.EnvVar{Name: "MOD_NAME", Value: moduleName},
+								v1.EnvVar{Name: "MOD_NAMESPACE", Value: namespace},
 							),
 							Volumes: buildVolumesFromBuildSecrets(buildSecrets),
 						},
@@ -168,7 +169,12 @@ var _ = Describe("Maker_MakeBuildTemplate", func() {
 					return nil
 				},
 			),
-			mockBuildHelper.EXPECT().ApplyBuildArgOverrides(buildArgs, overrides).Return(append(buildArgs, kmmv1beta1.BuildArg{Name: "KERNEL_VERSION", Value: targetKernel})),
+			mockBuildHelper.EXPECT().ApplyBuildArgOverrides(buildArgs, overrides).Return(
+				append(buildArgs,
+					kmmv1beta1.BuildArg{Name: "KERNEL_VERSION", Value: targetKernel},
+					kmmv1beta1.BuildArg{Name: "MOD_NAME", Value: moduleName},
+					kmmv1beta1.BuildArg{Name: "MOD_NAMESPACE", Value: namespace}),
+			),
 		)
 
 		bc, err := maker.MakeBuildTemplate(ctx, &mld, true, mld.Owner)

--- a/internal/module/kernelmapper.go
+++ b/internal/module/kernelmapper.go
@@ -127,6 +127,8 @@ func (kh *kernelMapperHelper) prepareModuleLoaderData(mapping *kmmv1beta1.Kernel
 
 func (kh *kernelMapperHelper) replaceTemplates(mld *api.ModuleLoaderData) error {
 	osConfigEnvVars := utils.KernelComponentsAsEnvVars(mld.KernelVersion)
+	osConfigEnvVars = append(osConfigEnvVars, "MOD_NAME="+mld.Name, "MOD_NAMESPACE="+mld.Namespace)
+
 	replacedContainerImage, err := utils.ReplaceInTemplates(osConfigEnvVars, mld.ContainerImage)
 	if err != nil {
 		return fmt.Errorf("failed to substitute templates in the ContainerImage field: %v", err)


### PR DESCRIPTION
---

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/462.