### PR TITLE
Adding MC CR generation external package for KMM Day1 support

### DIFF
--- a/pkg/mcproducer/mcproducer.go
+++ b/pkg/mcproducer/mcproducer.go
@@ -1,0 +1,62 @@
+package mcproducer
+
+import (
+	"bytes"
+	"embed"
+	"encoding/base64"
+	"fmt"
+	"text/template"
+
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+//go:embed templates
+var templateFS embed.FS
+
+func ProduceMachineConfig(machineConfigName, machineConfigPoolRef, kernelModuleImage, kernelModuleName string) (string, error) {
+	tag, err := name.NewTag(kernelModuleImage)
+	if err != nil {
+		return "", fmt.Errorf("invalid kernelModuleImage %s, input should be repo:tag format: %v", kernelModuleImage, err)
+	}
+
+	templateParams := map[string]interface{}{
+		"Image":                tag.Repository.Name(),
+		"Tag":                  tag.Identifier(),
+		"KernelModule":         kernelModuleName,
+		"MachineConfigPoolRef": machineConfigPoolRef,
+		"MachineConfigName":    machineConfigName,
+	}
+
+	replaceKernelModuleScript, err := generateTemplate(templateFS, "templates/replace-kernel-module.gotmpl", templateParams)
+	if err != nil {
+		return "", err
+	}
+	pullKernelModuleScript, err := generateTemplate(templateFS, "templates/pull-image.gotmpl", templateParams)
+	if err != nil {
+		return "", err
+	}
+	replaceScriptBase64 := base64.StdEncoding.EncodeToString([]byte(replaceKernelModuleScript))
+	pullScriptBase64 := base64.StdEncoding.EncodeToString([]byte(pullKernelModuleScript))
+
+	templateParams["ReplaceInTreeDriverContents"] = replaceScriptBase64
+	templateParams["PullKernelModuleContents"] = pullScriptBase64
+
+	machineConfigYAMLString, err := generateTemplate(templateFS, "templates/machine-config.gotmpl", templateParams)
+	if err != nil {
+		return "", err
+	}
+	return machineConfigYAMLString, nil
+}
+
+func generateTemplate(fsys embed.FS, fileName string, params map[string]interface{}) (string, error) {
+	tmpl, err := template.ParseFS(fsys, fileName)
+	if err != nil {
+		return "", fmt.Errorf("failed to prepare template from file %s: %v", fileName, err)
+	}
+	buf := &bytes.Buffer{}
+	err = tmpl.Execute(buf, params)
+	if err != nil {
+		return "", fmt.Errorf("failed to execute template parsing for file %s: %v", fileName, err)
+	}
+	return buf.String(), nil
+}

--- a/pkg/mcproducer/mcproducer_test.go
+++ b/pkg/mcproducer/mcproducer_test.go
@@ -1,0 +1,40 @@
+package mcproducer
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"os"
+)
+
+var _ = Describe("ProduceMachineConfig", func() {
+	const (
+		name             = "name"
+		mcpRef           = "mcpRef"
+		kernelModuleName = "testKernelModuleName"
+	)
+
+	It("image name format is invalid", func() {
+		imageName := "quay.io/project/repo@sha256:1f5f1ae25db67aa82707e1b1dc96c8a53ef7094f320b7eeaef12be9a13fa251d"
+
+		res, err := ProduceMachineConfig(name, mcpRef, imageName, kernelModuleName)
+
+		Expect(err).To(HaveOccurred())
+		Expect(res).To(Equal(""))
+
+	})
+
+	// unit performs verification of the MC output vs the manually created
+	// machineconfig-test.yaml. This yaml is created by manually running bas64
+	// encoding on testdata/pull-image-test.sh and testdata/replace-kernel-module-test.sh
+	// and setting the values into the testdata/machineconfig-test.yaml
+	It("verify correct mco output", func() {
+		imageName := "quay.io/project/repo:some-tag12"
+
+		res, err := ProduceMachineConfig(name, mcpRef, imageName, kernelModuleName)
+
+		Expect(err).ToNot(HaveOccurred())
+		expectedRes, err := os.ReadFile("testdata/machineconfig-test.yaml")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(Equal(string(expectedRes)))
+	})
+})

--- a/pkg/mcproducer/suite_test.go
+++ b/pkg/mcproducer/suite_test.go
@@ -1,0 +1,23 @@
+package mcproducer
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/test"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var scheme *runtime.Scheme
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	var err error
+
+	scheme, err = test.TestScheme()
+	Expect(err).NotTo(HaveOccurred())
+
+	RunSpecs(t, "Job Suite")
+}

--- a/pkg/mcproducer/templates/machine-config.gotmpl
+++ b/pkg/mcproducer/templates/machine-config.gotmpl
@@ -1,0 +1,67 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: {{.MachineConfigPoolRef}}
+  name: {{.MachineConfigName}}
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+        - contents: |
+            [Unit]
+            Description=Replace in-tree kernel module with oot kernel module
+            Before=network-pre.target
+            Wants=network-pre.target
+            DefaultDependencies=no
+            [Service]
+            User=root
+            Type=oneshot
+            TimeoutSec=10
+            ExecStartPre=ls /usr/local/bin
+            ExecStart=/usr/local/bin/replace-kernel-module.sh
+            PrivateTmp=yes
+            RemainAfterExit=no
+            TimeoutSec=60
+            [Install]
+            WantedBy=multi-user.target
+          enabled: true
+          name: "replace-kernel-module.service"
+        - contents: |
+            [Unit]
+            Description=Pull oot kernel module image
+            After=network-online.target
+            Wants=network-online.target
+            DefaultDependencies=no
+            [Service]
+            User=root
+            Type=oneshot
+            ExecStart=/usr/local/bin/pull-kernel-module-image.sh
+            PrivateTmp=yes
+            RemainAfterExit=no
+            TimeoutSec=900
+            [Install]
+            WantedBy=multi-user.target
+          enabled: true
+          name: "pull-kernel-module-image.service"
+        - enabled: false
+          mask: true
+          name: crio-wipe.service
+    storage:
+      files:
+        - path: "/usr/local/bin/replace-kernel-module.sh"
+          mode: 511
+          overwrite: true
+          user:
+            name: "root"
+          contents:
+            source: "data:text/plain;base64,{{.ReplaceInTreeDriverContents}}"
+        - path: "/usr/local/bin/pull-kernel-module-image.sh"
+          mode: 493
+          overwrite: true
+          user:
+            name: "root"
+          contents:
+            source: "data:text/plain;base64,{{.PullKernelModuleContents}}"

--- a/pkg/mcproducer/templates/pull-image.gotmpl
+++ b/pkg/mcproducer/templates/pull-image.gotmpl
@@ -1,0 +1,13 @@
+#!/bin/bash
+if podman image list | grep {{.Image}} | grep -q {{.Tag}}; then
+    echo "Image {{.Image}}:{{.Tag}} found in the local registry.Nothing to do"
+else
+    echo "Image {{.Image}}:{{.Tag}} not found in the local registry, pulling"
+    podman pull --authfile /var/lib/kubelet/config.json {{.Image}}:{{.Tag}}
+    if [ $? -eq 0 ]; then
+        echo "Image {{.Image}}:{{.Tag}} has been successfully pulled, rebooting.."
+        reboot
+    else
+        echo "Failed to pull image {{.Image}}:{{.Tag}}"
+    fi
+fi

--- a/pkg/mcproducer/templates/replace-kernel-module.gotmpl
+++ b/pkg/mcproducer/templates/replace-kernel-module.gotmpl
@@ -1,0 +1,20 @@
+#!/bin/bash
+echo "before checking podman images"
+if podman images list | grep {{.Image}} | grep -q {{.Tag}}; then
+    echo "Image {{.Image}}:{{.Tag}} found in the local registry, removing in-tree kernel module"
+    podman run --privileged --entrypoint modprobe {{.Image}}:{{.Tag}} -rd /opt {{.KernelModule}}
+    if [ $? -eq 0 ]; then
+            echo "Succesffully removed the in-tree kernel module {{.KernelModule}}"
+    else
+            echo "failed to remove in-tree kernel module {{.KernelModule}}"
+    fi
+    echo "Running container image to insert the oot kernel module {{.KernelModule}}"
+    podman run --privileged --entrypoint modprobe {{.Image}}:{{.Tag}} -d /opt {{.KernelModule}}
+    if [ $? -eq 0 ]; then
+            echo "OOT kernel module {{.KernelModule}} is inserted"
+    else
+            echo "failed to insert OOT kernel module {{.KernelModule}}"
+    fi
+else
+   echo "Image {{.Image}}:{{.Tag}} is not present in local registry, will try after reboot"
+fi

--- a/pkg/mcproducer/testdata/machineconfig-test.yaml
+++ b/pkg/mcproducer/testdata/machineconfig-test.yaml
@@ -1,0 +1,67 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: mcpRef
+  name: name
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+        - contents: |
+            [Unit]
+            Description=Replace in-tree kernel module with oot kernel module
+            Before=network-pre.target
+            Wants=network-pre.target
+            DefaultDependencies=no
+            [Service]
+            User=root
+            Type=oneshot
+            TimeoutSec=10
+            ExecStartPre=ls /usr/local/bin
+            ExecStart=/usr/local/bin/replace-kernel-module.sh
+            PrivateTmp=yes
+            RemainAfterExit=no
+            TimeoutSec=60
+            [Install]
+            WantedBy=multi-user.target
+          enabled: true
+          name: "replace-kernel-module.service"
+        - contents: |
+            [Unit]
+            Description=Pull oot kernel module image
+            After=network-online.target
+            Wants=network-online.target
+            DefaultDependencies=no
+            [Service]
+            User=root
+            Type=oneshot
+            ExecStart=/usr/local/bin/pull-kernel-module-image.sh
+            PrivateTmp=yes
+            RemainAfterExit=no
+            TimeoutSec=900
+            [Install]
+            WantedBy=multi-user.target
+          enabled: true
+          name: "pull-kernel-module-image.service"
+        - enabled: false
+          mask: true
+          name: crio-wipe.service
+    storage:
+      files:
+        - path: "/usr/local/bin/replace-kernel-module.sh"
+          mode: 511
+          overwrite: true
+          user:
+            name: "root"
+          contents:
+            source: "data:text/plain;base64,IyEvYmluL2Jhc2gKZWNobyAiYmVmb3JlIGNoZWNraW5nIHBvZG1hbiBpbWFnZXMiCmlmIHBvZG1hbiBpbWFnZXMgbGlzdCB8IGdyZXAgcXVheS5pby9wcm9qZWN0L3JlcG8gfCBncmVwIC1xIHNvbWUtdGFnMTI7IHRoZW4KICAgIGVjaG8gIkltYWdlIHF1YXkuaW8vcHJvamVjdC9yZXBvOnNvbWUtdGFnMTIgZm91bmQgaW4gdGhlIGxvY2FsIHJlZ2lzdHJ5LCByZW1vdmluZyBpbi10cmVlIGtlcm5lbCBtb2R1bGUiCiAgICBwb2RtYW4gcnVuIC0tcHJpdmlsZWdlZCAtLWVudHJ5cG9pbnQgbW9kcHJvYmUgcXVheS5pby9wcm9qZWN0L3JlcG86c29tZS10YWcxMiAtcmQgL29wdCB0ZXN0S2VybmVsTW9kdWxlTmFtZQogICAgaWYgWyAkPyAtZXEgMCBdOyB0aGVuCiAgICAgICAgICAgIGVjaG8gIlN1Y2Nlc2ZmdWxseSByZW1vdmVkIHRoZSBpbi10cmVlIGtlcm5lbCBtb2R1bGUgdGVzdEtlcm5lbE1vZHVsZU5hbWUiCiAgICBlbHNlCiAgICAgICAgICAgIGVjaG8gImZhaWxlZCB0byByZW1vdmUgaW4tdHJlZSBrZXJuZWwgbW9kdWxlIHRlc3RLZXJuZWxNb2R1bGVOYW1lIgogICAgZmkKICAgIGVjaG8gIlJ1bm5pbmcgY29udGFpbmVyIGltYWdlIHRvIGluc2VydCB0aGUgb290IGtlcm5lbCBtb2R1bGUgdGVzdEtlcm5lbE1vZHVsZU5hbWUiCiAgICBwb2RtYW4gcnVuIC0tcHJpdmlsZWdlZCAtLWVudHJ5cG9pbnQgbW9kcHJvYmUgcXVheS5pby9wcm9qZWN0L3JlcG86c29tZS10YWcxMiAtZCAvb3B0IHRlc3RLZXJuZWxNb2R1bGVOYW1lCiAgICBpZiBbICQ/IC1lcSAwIF07IHRoZW4KICAgICAgICAgICAgZWNobyAiT09UIGtlcm5lbCBtb2R1bGUgdGVzdEtlcm5lbE1vZHVsZU5hbWUgaXMgaW5zZXJ0ZWQiCiAgICBlbHNlCiAgICAgICAgICAgIGVjaG8gImZhaWxlZCB0byBpbnNlcnQgT09UIGtlcm5lbCBtb2R1bGUgdGVzdEtlcm5lbE1vZHVsZU5hbWUiCiAgICBmaQplbHNlCiAgIGVjaG8gIkltYWdlIHF1YXkuaW8vcHJvamVjdC9yZXBvOnNvbWUtdGFnMTIgaXMgbm90IHByZXNlbnQgaW4gbG9jYWwgcmVnaXN0cnksIHdpbGwgdHJ5IGFmdGVyIHJlYm9vdCIKZmkK"
+        - path: "/usr/local/bin/pull-kernel-module-image.sh"
+          mode: 493
+          overwrite: true
+          user:
+            name: "root"
+          contents:
+            source: "data:text/plain;base64,IyEvYmluL2Jhc2gKaWYgcG9kbWFuIGltYWdlIGxpc3QgfCBncmVwIHF1YXkuaW8vcHJvamVjdC9yZXBvIHwgZ3JlcCAtcSBzb21lLXRhZzEyOyB0aGVuCiAgICBlY2hvICJJbWFnZSBxdWF5LmlvL3Byb2plY3QvcmVwbzpzb21lLXRhZzEyIGZvdW5kIGluIHRoZSBsb2NhbCByZWdpc3RyeS5Ob3RoaW5nIHRvIGRvIgplbHNlCiAgICBlY2hvICJJbWFnZSBxdWF5LmlvL3Byb2plY3QvcmVwbzpzb21lLXRhZzEyIG5vdCBmb3VuZCBpbiB0aGUgbG9jYWwgcmVnaXN0cnksIHB1bGxpbmciCiAgICBwb2RtYW4gcHVsbCAtLWF1dGhmaWxlIC92YXIvbGliL2t1YmVsZXQvY29uZmlnLmpzb24gcXVheS5pby9wcm9qZWN0L3JlcG86c29tZS10YWcxMgogICAgaWYgWyAkPyAtZXEgMCBdOyB0aGVuCiAgICAgICAgZWNobyAiSW1hZ2UgcXVheS5pby9wcm9qZWN0L3JlcG86c29tZS10YWcxMiBoYXMgYmVlbiBzdWNjZXNzZnVsbHkgcHVsbGVkLCByZWJvb3RpbmcuLiIKICAgICAgICByZWJvb3QKICAgIGVsc2UKICAgICAgICBlY2hvICJGYWlsZWQgdG8gcHVsbCBpbWFnZSBxdWF5LmlvL3Byb2plY3QvcmVwbzpzb21lLXRhZzEyIgogICAgZmkKZmkK"

--- a/pkg/mcproducer/testdata/pull-image-test.sh
+++ b/pkg/mcproducer/testdata/pull-image-test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+if podman image list | grep quay.io/project/repo | grep -q some-tag12; then
+    echo "Image quay.io/project/repo:some-tag12 found in the local registry.Nothing to do"
+else
+    echo "Image quay.io/project/repo:some-tag12 not found in the local registry, pulling"
+    podman pull --authfile /var/lib/kubelet/config.json quay.io/project/repo:some-tag12
+    if [ $? -eq 0 ]; then
+        echo "Image quay.io/project/repo:some-tag12 has been successfully pulled, rebooting.."
+        reboot
+    else
+        echo "Failed to pull image quay.io/project/repo:some-tag12"
+    fi
+fi

--- a/pkg/mcproducer/testdata/replace-kernel-module-test.sh
+++ b/pkg/mcproducer/testdata/replace-kernel-module-test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+echo "before checking podman images"
+if podman images list | grep quay.io/project/repo | grep -q some-tag12; then
+    echo "Image quay.io/project/repo:some-tag12 found in the local registry, removing in-tree kernel module"
+    podman run --privileged --entrypoint modprobe quay.io/project/repo:some-tag12 -rd /opt testKernelModuleName
+    if [ $? -eq 0 ]; then
+            echo "Succesffully removed the in-tree kernel module testKernelModuleName"
+    else
+            echo "failed to remove in-tree kernel module testKernelModuleName"
+    fi
+    echo "Running container image to insert the oot kernel module testKernelModuleName"
+    podman run --privileged --entrypoint modprobe quay.io/project/repo:some-tag12 -d /opt testKernelModuleName
+    if [ $? -eq 0 ]; then
+            echo "OOT kernel module testKernelModuleName is inserted"
+    else
+            echo "failed to insert OOT kernel module testKernelModuleName"
+    fi
+else
+   echo "Image quay.io/project/repo:some-tag12 is not present in local registry, will try after reboot"
+fi


### PR DESCRIPTION
This PR add am external package that will allow user to generate an MC CR yaml file. When applied , the MCO will cause a kernel module to be replaced with a customer's image before NetworkManager service starts running ( basically Day1). Pre-requisite: at least one valid network interface should be running on the node without MCO interference
The produced MC CR defines 2 systemd services:
1) pull service: executes after network interface (NM) is configured, and is responsible for pull
    kernel module image, based on DTK, into the node. Once successfull, it reboots the node
2) replace kernel module service: executes before NM is configured ( no network). In case the image is already
   present on the node, it will remove the in-tree kernel module, and will replce it with the kernel module
   stored in the DTK-based image

The input to function that produce MC CR yaml is:
1) MC CR name - the name that will be set into the MC.name
2) MCP reference - reference to the MachineConfigPool, which will define which nodes this MC CR will affect.
3) image name - DriverContainer image, that will contain the needed kerne module driver 4) the name of the kernel driver - which kernel driver to remove/insert