### PR TITLE
Parse templates only once

### DIFF
--- a/pkg/mcproducer/mcproducer.go
+++ b/pkg/mcproducer/mcproducer.go
@@ -10,8 +10,22 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 )
 
-//go:embed templates
-var templateFS embed.FS
+var (
+	//go:embed templates
+	templateFS embed.FS
+
+	machineConfigTemplate = template.Must(
+		template.ParseFS(templateFS, "templates/machine-config.gotmpl"),
+	)
+
+	scriptPullImage = template.Must(
+		template.ParseFS(templateFS, "templates/pull-image.gotmpl"),
+	)
+
+	scriptReplaceKmod = template.Must(
+		template.ParseFS(templateFS, "templates/replace-kernel-module.gotmpl"),
+	)
+)
 
 func ProduceMachineConfig(machineConfigName, machineConfigPoolRef, kernelModuleImage, kernelModuleName string) (string, error) {
 	tag, err := name.NewTag(kernelModuleImage)
@@ -19,7 +33,7 @@ func ProduceMachineConfig(machineConfigName, machineConfigPoolRef, kernelModuleI
 		return "", fmt.Errorf("invalid kernelModuleImage %s, input should be repo:tag format: %v", kernelModuleImage, err)
 	}
 
-	templateParams := map[string]interface{}{
+	templateParams := map[string]any{
 		"Image":                tag.Repository.Name(),
 		"Tag":                  tag.Identifier(),
 		"KernelModule":         kernelModuleName,
@@ -27,36 +41,37 @@ func ProduceMachineConfig(machineConfigName, machineConfigPoolRef, kernelModuleI
 		"MachineConfigName":    machineConfigName,
 	}
 
-	replaceKernelModuleScript, err := generateTemplate(templateFS, "templates/replace-kernel-module.gotmpl", templateParams)
+	templateParams["ReplaceInTreeDriverContents"], err = executeIntoBase64(scriptReplaceKmod, templateParams)
 	if err != nil {
 		return "", err
 	}
-	pullKernelModuleScript, err := generateTemplate(templateFS, "templates/pull-image.gotmpl", templateParams)
-	if err != nil {
-		return "", err
-	}
-	replaceScriptBase64 := base64.StdEncoding.EncodeToString([]byte(replaceKernelModuleScript))
-	pullScriptBase64 := base64.StdEncoding.EncodeToString([]byte(pullKernelModuleScript))
 
-	templateParams["ReplaceInTreeDriverContents"] = replaceScriptBase64
-	templateParams["PullKernelModuleContents"] = pullScriptBase64
-
-	machineConfigYAMLString, err := generateTemplate(templateFS, "templates/machine-config.gotmpl", templateParams)
+	templateParams["PullKernelModuleContents"], err = executeIntoBase64(scriptPullImage, templateParams)
 	if err != nil {
 		return "", err
 	}
-	return machineConfigYAMLString, nil
+
+	var machineConfig bytes.Buffer
+
+	if err = machineConfigTemplate.Execute(&machineConfig, templateParams); err != nil {
+		return "", fmt.Errorf("could not render the MachineConfig: %v", err)
+	}
+
+	return machineConfig.String(), nil
 }
 
-func generateTemplate(fsys embed.FS, fileName string, params map[string]interface{}) (string, error) {
-	tmpl, err := template.ParseFS(fsys, fileName)
-	if err != nil {
-		return "", fmt.Errorf("failed to prepare template from file %s: %v", fileName, err)
+func executeIntoBase64(tmpl *template.Template, params map[string]any) (string, error) {
+	var buf bytes.Buffer
+
+	enc := base64.NewEncoder(base64.StdEncoding, &buf)
+
+	if err := tmpl.Execute(enc, params); err != nil {
+		return "", fmt.Errorf("could not render %s: %v", tmpl.Name(), err)
 	}
-	buf := &bytes.Buffer{}
-	err = tmpl.Execute(buf, params)
-	if err != nil {
-		return "", fmt.Errorf("failed to execute template parsing for file %s: %v", fileName, err)
+
+	if err := enc.Close(); err != nil {
+		return "", err
 	}
+
 	return buf.String(), nil
 }


### PR DESCRIPTION
Write template output directly into the base64 encoder to avoid copying data.

/cc @yevgeny-shnaidman 