### PR TITLE
Use publicly available images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 # Build the manager binary
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11 as builder
-
-WORKDIR /workspace
+FROM registry.access.redhat.com/ubi8/go-toolset:1.18.9-13 as builder
 
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -29,11 +27,11 @@ ARG TARGET
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 make ${TARGET}
 
-FROM registry.redhat.io/ubi8/ubi-micro:8.7
+FROM registry.access.redhat.com/ubi8/ubi-micro:8.7
 
 ARG TARGET
 
-COPY --from=builder /workspace/${TARGET} /usr/local/bin/manager
+COPY --from=builder /opt/app-root/src/${TARGET} /usr/local/bin/manager
 USER 65534:65534
 
 ENTRYPOINT ["/usr/local/bin/manager"]

--- a/Dockerfile.must-gather
+++ b/Dockerfile.must-gather
@@ -1,6 +1,6 @@
 FROM quay.io/openshift/origin-cli:4.13.0 as builder
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-1085
 
 RUN microdnf update -y \
     && microdnf install -y tar rsync findutils gzip iproute util-linux \

--- a/Dockerfile.signimage
+++ b/Dockerfile.signimage
@@ -1,25 +1,26 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.18-openshift-4.11 as builder
-
-WORKDIR /workspace
+FROM registry.access.redhat.com/ubi8/go-toolset:1.18.9-13 as builder
 
 COPY go.mod go.mod
 COPY go.sum go.sum
+COPY vendor vendor
 COPY cmd cmd
 COPY api api
 COPY docs.mk docs.mk
 COPY internal internal
 COPY Makefile Makefile
-COPY vendor vendor
-
-# install the package that will contain the sign utilities
-RUN dnf install -y kernel-devel
 
 # Build
-RUN make signimage
+RUN ["make", "signimage"]
 
-FROM registry.redhat.io/ubi8/ubi-minimal:8.7-1107
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-1085 as ksource
 
-COPY --from=builder /workspace/signimage /usr/src/kernels/*/scripts/sign-file /usr/local/bin/
+# install the package that will contain the sign utilities
+RUN ["microdnf", "install", "kernel-devel"]
+
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-1085
+
+COPY --from=builder /opt/app-root/src/signimage /usr/local/bin/
+COPY --from=ksource /usr/src/kernels/*/scripts/sign-file /usr/local/bin/
 USER 65534:65534
 
 ENTRYPOINT ["/usr/local/bin/signimage"]


### PR DESCRIPTION
Move from `registry.redhat.io` to `registry.access.redhat.com`.