### PR TITLE
Use top-level tags for all base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18.9-13 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.18 as builder
 
 # Copy the Go Modules manifests
 COPY go.mod go.mod

--- a/Dockerfile.must-gather
+++ b/Dockerfile.must-gather
@@ -1,6 +1,6 @@
-FROM quay.io/openshift/origin-cli:4.13.0 as builder
+FROM quay.io/openshift/origin-cli:4.13 as builder
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-1085
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
 
 RUN microdnf update -y \
     && microdnf install -y tar rsync findutils gzip iproute util-linux \

--- a/Dockerfile.signimage
+++ b/Dockerfile.signimage
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18.9-13 as builder
+FROM registry.access.redhat.com/ubi8/go-toolset:1.18 as builder
 
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -12,12 +12,12 @@ COPY Makefile Makefile
 # Build
 RUN ["make", "signimage"]
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-1085 as ksource
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7 as ksource
 
 # install the package that will contain the sign utilities
 RUN ["microdnf", "install", "kernel-devel"]
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7-1085
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
 
 COPY --from=builder /opt/app-root/src/signimage /usr/local/bin/
 COPY --from=ksource /usr/src/kernels/*/scripts/sign-file /usr/local/bin/


### PR DESCRIPTION
This triggers less dependabot updates and makes things simpler in CI.

Requires https://github.com/openshift/release/pull/38765
Fixes #501
Fixes #502

/cc @mresvanis 