### PR TITLE
Fix ansible dependency on README.md

### DIFF
--- a/tools/sro2kmm/README.md
+++ b/tools/sro2kmm/README.md
@@ -16,7 +16,7 @@ A computer with:
 - Openshift Client (`oc`) with access to OpenShift cluster.
 - SSH access to OpenShift cluster nodes.
 - Kubernetes python packages installed: `python3.8 -m pip install kubernetes --user`
-- Ansible installed: `dnf install ansible`
+- Ansible installed: `dnf install ansible-core`
 (Tested on Ansible 2.13.7 and Python 3.8.15.). Further info at [Ansible Documentation](https://docs.ansible.com/ansible/latest/installation_guide/index.html).
 
 ## Configuration


### PR DESCRIPTION
Package ansible does not include ansible-playbook. It was deprecated in favour of package ansible-core which does include the necessary binary.