### PR TITLE
Adding the namespace to the `<module>.ready` label.

### DIFF
--- a/controllers/pod_node_module_reconciler_test.go
+++ b/controllers/pod_node_module_reconciler_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"errors"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
@@ -19,11 +20,12 @@ import (
 var _ = Describe("PodNodeModuleReconciler", func() {
 	Describe("Reconcile", func() {
 		const (
-			moduleName   = "module-name"
-			nodeName     = "node-name"
-			podName      = "pod-name"
-			podNamespace = "pod-namespace"
-			nodeLabel    = "some node label"
+			moduleName          = "module-name"
+			nodeName            = "node-name"
+			podName             = "pod-name"
+			podNamespace        = "pod-namespace"
+			nodeLabel           = "some node label"
+			deprecatedNodeLabel = "some deprecated node label"
 		)
 
 		var (
@@ -55,43 +57,93 @@ var _ = Describe("PodNodeModuleReconciler", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("should unlabel the node when a Pod is not ready", func() {
-			pod := v1.Pod{}
-			podWithModuleName := v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{constants.ModuleNameLabel: moduleName}},
-				Spec:       v1.PodSpec{NodeName: nodeName},
-			}
-			node := v1.Node{}
-			nodeWithEmptyLabels := v1.Node{
-				ObjectMeta: metav1.ObjectMeta{Labels: make(map[string]string)},
-			}
+		It("should return an error if we failed to get the list of pods", func() {
 
 			gomock.InOrder(
-				kubeClient.
-					EXPECT().
-					Get(ctx, nn, &pod).
-					Do(func(_ context.Context, _ types.NamespacedName, o client.Object, _ ...client.GetOption) {
-						o.SetLabels(map[string]string{constants.ModuleNameLabel: moduleName})
-						o.(*v1.Pod).Spec.NodeName = nodeName
-					}),
-				mockDC.EXPECT().GetNodeLabelFromPod(&podWithModuleName, moduleName).Return(nodeLabel),
-				kubeClient.
-					EXPECT().
-					Get(ctx, types.NamespacedName{Name: nodeName}, &node).
-					Do(func(_ context.Context, _ types.NamespacedName, o client.Object, _ ...client.GetOption) {
-						o.SetLabels(map[string]string{nodeLabel: ""})
-					}),
-				kubeClient.
-					EXPECT().
-					Patch(ctx, &nodeWithEmptyLabels, gomock.Any()).
-					Do(func(_ context.Context, n client.Object, p client.Patch, _ ...client.PatchOption) {
+				kubeClient.EXPECT().Get(ctx, req.NamespacedName, gomock.Any()).Do(
+					func(_ interface{}, _ interface{}, pod *v1.Pod, _ ...client.GetOption) {
+						pod.SetLabels(map[string]string{constants.ModuleNameLabel: moduleName})
+						pod.Spec.NodeName = nodeName
+						pod.Name = podName
+					},
+				),
+				mockDC.EXPECT().GetNodeLabelFromPod(gomock.Any(), moduleName, false).Return(nodeLabel),
+				mockDC.EXPECT().GetNodeLabelFromPod(gomock.Any(), moduleName, true).Return(deprecatedNodeLabel),
+				kubeClient.EXPECT().List(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("some error")),
+			)
+
+			_, err := r.Reconcile(ctx, req)
+			Expect(err).To(HaveOccurred())
+
+		})
+
+		It("should unlabel the node when a Pod is not ready", func() {
+
+			var (
+				labelSelector = client.MatchingLabels{constants.ModuleNameLabel: moduleName}
+				fieldSelector = client.MatchingFields{"spec.nodeName": nodeName}
+			)
+
+			gomock.InOrder(
+				kubeClient.EXPECT().Get(ctx, req.NamespacedName, gomock.Any()).Do(
+					func(_ interface{}, _ interface{}, pod *v1.Pod, _ ...client.GetOption) {
+						pod.SetLabels(map[string]string{constants.ModuleNameLabel: moduleName})
+						pod.Spec.NodeName = nodeName
+						pod.Name = podName
+					},
+				),
+				mockDC.EXPECT().GetNodeLabelFromPod(gomock.Any(), moduleName, false).Return(nodeLabel),
+				mockDC.EXPECT().GetNodeLabelFromPod(gomock.Any(), moduleName, true).Return(deprecatedNodeLabel),
+				kubeClient.EXPECT().List(ctx, gomock.Any(), labelSelector, fieldSelector).Return(nil),
+				kubeClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Do(
+					func(_ interface{}, _ interface{}, node *v1.Node, _ ...client.GetOption) {
+						node.SetLabels(map[string]string{nodeLabel: "", deprecatedNodeLabel: ""})
+					},
+				),
+				kubeClient.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Do(
+					func(_ interface{}, node *v1.Node, p client.Patch, _ ...client.GetOption) {
 						Expect(p.Type()).To(Equal(types.MergePatchType))
-						Expect(p.Data(n)).To(
-							Equal(
-								[]byte(`{"metadata":{"labels":null}}`),
-							),
-						)
-					}),
+						Expect(p.Data(node)).To(Equal([]byte(`{"metadata":{"labels":null}}`)))
+					},
+				),
+			)
+
+			_, err := r.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should NOT unlabel the node when a Pod is not ready but there is a new running pod", func() {
+
+			var (
+				labelSelector = client.MatchingLabels{constants.ModuleNameLabel: moduleName}
+				fieldSelector = client.MatchingFields{"spec.nodeName": nodeName}
+			)
+
+			gomock.InOrder(kubeClient.EXPECT().Get(ctx, req.NamespacedName, gomock.Any()).Do(
+				func(_ interface{}, _ interface{}, pod *v1.Pod, _ ...client.GetOption) {
+					pod.SetLabels(map[string]string{constants.ModuleNameLabel: moduleName})
+					pod.Spec.NodeName = nodeName
+					pod.Name = podName
+				},
+			),
+				mockDC.EXPECT().GetNodeLabelFromPod(gomock.Any(), moduleName, false).Return(nodeLabel),
+				mockDC.EXPECT().GetNodeLabelFromPod(gomock.Any(), moduleName, true).Return(deprecatedNodeLabel),
+				kubeClient.EXPECT().List(ctx, gomock.Any(), labelSelector, fieldSelector).Do(
+					func(_ interface{}, modulePodsList *v1.PodList, _ ...client.ListOption) {
+						modulePodsList.Items = []v1.Pod{
+							{
+								Status: v1.PodStatus{
+									Conditions: []v1.PodCondition{
+										{
+											Type:   v1.PodReady,
+											Status: v1.ConditionTrue,
+										},
+									},
+								},
+							},
+						}
+					},
+				),
 			)
 
 			_, err := r.Reconcile(ctx, req)
@@ -99,122 +151,75 @@ var _ = Describe("PodNodeModuleReconciler", func() {
 		})
 
 		It("should label the node when a Pod is ready", func() {
-			pod := v1.Pod{}
-			readyPod := v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{constants.ModuleNameLabel: moduleName}},
-				Spec:       v1.PodSpec{NodeName: nodeName},
-				Status: v1.PodStatus{
-					Conditions: []v1.PodCondition{
-						{
-							Type:   v1.PodReady,
-							Status: v1.ConditionTrue,
-						},
-					},
-				},
-			}
-			node := v1.Node{}
-			nodeWithLabel := node
-			nodeWithLabel.SetLabels(map[string]string{nodeLabel: ""})
-			patch := client.MergeFrom(&node)
 
 			gomock.InOrder(
-				kubeClient.
-					EXPECT().
-					Get(ctx, nn, &pod).
-					Do(func(_ context.Context, _ types.NamespacedName, o client.Object, _ ...client.GetOption) {
-						o.SetLabels(map[string]string{constants.ModuleNameLabel: moduleName})
-						o.(*v1.Pod).Spec.NodeName = nodeName
-						o.(*v1.Pod).Status.Conditions = []v1.PodCondition{
-							{
-								Type:   v1.PodReady,
-								Status: v1.ConditionTrue,
+				kubeClient.EXPECT().Get(ctx, req.NamespacedName, gomock.Any()).Do(
+					func(_ interface{}, _ interface{}, pod *v1.Pod, _ ...client.GetOption) {
+						pod.Name = podName
+						pod.SetLabels(map[string]string{constants.ModuleNameLabel: moduleName})
+						pod.Spec.NodeName = nodeName
+						pod.Status = v1.PodStatus{
+							Conditions: []v1.PodCondition{
+								{
+									Type:   v1.PodReady,
+									Status: v1.ConditionTrue,
+								},
 							},
 						}
-					}),
-				mockDC.EXPECT().GetNodeLabelFromPod(&readyPod, moduleName).Return(nodeLabel),
-				kubeClient.EXPECT().Get(ctx, types.NamespacedName{Name: nodeName}, &node),
-				kubeClient.
-					EXPECT().
-					Patch(ctx, &nodeWithLabel, gomock.AssignableToTypeOf(patch)).
-					Do(func(_ context.Context, n client.Object, p client.Patch, _ ...client.PatchOption) {
+					},
+				),
+				mockDC.EXPECT().GetNodeLabelFromPod(gomock.Any(), moduleName, false).Return(nodeLabel),
+				mockDC.EXPECT().GetNodeLabelFromPod(gomock.Any(), moduleName, true).Return(deprecatedNodeLabel),
+				kubeClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil),
+				kubeClient.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Do(
+					func(_ interface{}, node *v1.Node, p client.Patch, _ ...client.GetOption) {
 						Expect(p.Type()).To(Equal(types.MergePatchType))
-						Expect(p.Data(n)).To(
-							Equal(
-								[]byte(`{"metadata":{"labels":{"some node label":""}}}`),
-							),
-						)
-					}),
+						data, err := p.Data(node)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(data).To(ContainSubstring("labels"))
+						Expect(data).To(ContainSubstring(nodeLabel))
+						Expect(data).To(ContainSubstring(deprecatedNodeLabel))
+					},
+				),
 			)
 
 			_, err := r.Reconcile(ctx, req)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should unlabel the node and remove the pod finalizer when the pod is being deleted", func() {
-			now := metav1.Now()
+		It("should remove the pod finalizer when the pod is being deleted", func() {
 
-			pod := v1.Pod{}
-			deletedPod := v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					DeletionTimestamp: &now,
-					Finalizers:        []string{constants.NodeLabelerFinalizer},
-					Labels:            map[string]string{constants.ModuleNameLabel: moduleName},
-				},
-				Spec: v1.PodSpec{NodeName: nodeName},
-			}
-			podWithoutFinalizer := v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					DeletionTimestamp: &now,
-					Finalizers:        make([]string, 0),
-					Labels:            map[string]string{constants.ModuleNameLabel: moduleName},
-				},
-				Spec: v1.PodSpec{NodeName: nodeName},
-			}
-
-			node := v1.Node{}
-			nodeWithEmptyLabels := v1.Node{
-				ObjectMeta: metav1.ObjectMeta{Labels: make(map[string]string)},
-			}
+			var (
+				now           = metav1.Now()
+				labelSelector = client.MatchingLabels{constants.ModuleNameLabel: moduleName}
+				fieldSelector = client.MatchingFields{"spec.nodeName": nodeName}
+			)
 
 			gomock.InOrder(
-				kubeClient.
-					EXPECT().
-					Get(ctx, nn, &pod).
-					Do(func(_ context.Context, _ types.NamespacedName, o client.Object, _ ...client.GetOption) {
-						o.SetLabels(map[string]string{constants.ModuleNameLabel: moduleName})
-						o.(*v1.Pod).Spec.NodeName = nodeName
-						o.SetDeletionTimestamp(&now)
-						o.SetFinalizers([]string{constants.NodeLabelerFinalizer})
-					}),
-				mockDC.EXPECT().GetNodeLabelFromPod(&deletedPod, moduleName).Return(nodeLabel),
-				kubeClient.
-					EXPECT().
-					Get(ctx, types.NamespacedName{Name: nodeName}, &node).
-					Do(func(_ context.Context, _ types.NamespacedName, o client.Object, _ ...client.GetOption) {
-						o.SetLabels(map[string]string{nodeLabel: ""})
-					}),
-				kubeClient.
-					EXPECT().
-					Patch(ctx, &nodeWithEmptyLabels, gomock.Any()).
-					Do(func(_ context.Context, n client.Object, p client.Patch, _ ...client.PatchOption) {
+				kubeClient.EXPECT().Get(ctx, req.NamespacedName, gomock.Any()).Do(
+					func(_ interface{}, _ interface{}, pod *v1.Pod, _ ...client.GetOption) {
+						pod.SetLabels(map[string]string{constants.ModuleNameLabel: moduleName})
+						pod.DeletionTimestamp = &now
+						pod.Finalizers = []string{constants.NodeLabelerFinalizer}
+						pod.Spec.NodeName = nodeName
+						pod.Name = podName
+					},
+				),
+				mockDC.EXPECT().GetNodeLabelFromPod(gomock.Any(), moduleName, false).Return(nodeLabel),
+				mockDC.EXPECT().GetNodeLabelFromPod(gomock.Any(), moduleName, true).Return(deprecatedNodeLabel),
+				kubeClient.EXPECT().List(ctx, gomock.Any(), labelSelector, fieldSelector).Return(nil),
+				kubeClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Do(
+					func(_ interface{}, _ interface{}, node *v1.Node, _ ...client.GetOption) {
+						node.SetLabels(map[string]string{nodeLabel: "", deprecatedNodeLabel: ""})
+					},
+				),
+				kubeClient.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(nil),
+				kubeClient.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Do(
+					func(_ interface{}, pod *v1.Pod, p client.Patch, _ ...client.GetOption) {
 						Expect(p.Type()).To(Equal(types.MergePatchType))
-						Expect(p.Data(n)).To(
-							Equal(
-								[]byte(`{"metadata":{"labels":null}}`),
-							),
-						)
-					}),
-				kubeClient.
-					EXPECT().
-					Patch(ctx, &podWithoutFinalizer, gomock.Any()).
-					Do(func(_ context.Context, po client.Object, p client.Patch, _ ...client.PatchOption) {
-						Expect(p.Type()).To(Equal(types.MergePatchType))
-						Expect(p.Data(po)).To(
-							Equal(
-								[]byte(`{"metadata":{"finalizers":null}}`),
-							),
-						)
-					}),
+						Expect(p.Data(pod)).To(Equal([]byte(`{"metadata":{"finalizers":null}}`)))
+					},
+				),
 			)
 
 			_, err := r.Reconcile(ctx, req)

--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -38,7 +38,7 @@ type DaemonSetCreator interface {
 	GetModuleDaemonSets(ctx context.Context, name, namespace string) ([]appsv1.DaemonSet, error)
 	SetDriverContainerAsDesired(ctx context.Context, ds *appsv1.DaemonSet, mld *api.ModuleLoaderData, useDefaultSA bool) error
 	SetDevicePluginAsDesired(ctx context.Context, ds *appsv1.DaemonSet, mod *kmmv1beta1.Module, useDefaultSA bool) error
-	GetNodeLabelFromPod(pod *v1.Pod, moduleName string) string
+	GetNodeLabelFromPod(pod *v1.Pod, moduleName string, useDeprecatedLabel bool) string
 }
 
 type daemonSetGenerator struct {
@@ -280,7 +280,7 @@ func (dc *daemonSetGenerator) SetDevicePluginAsDesired(
 				},
 				PriorityClassName:  "system-node-critical",
 				ImagePullSecrets:   GetPodPullSecrets(mod.Spec.ImageRepoSecret),
-				NodeSelector:       map[string]string{getDriverContainerNodeLabel(mod.Name): ""},
+				NodeSelector:       map[string]string{getDriverContainerNodeLabel(mod.Namespace, mod.Name, true): ""},
 				ServiceAccountName: serviceAccountName,
 				Volumes:            append([]v1.Volume{devicePluginVolume}, mod.Spec.DevicePlugin.Volumes...),
 			},
@@ -290,12 +290,12 @@ func (dc *daemonSetGenerator) SetDevicePluginAsDesired(
 	return controllerutil.SetControllerReference(mod, ds, dc.scheme)
 }
 
-func (dc *daemonSetGenerator) GetNodeLabelFromPod(pod *v1.Pod, moduleName string) string {
+func (dc *daemonSetGenerator) GetNodeLabelFromPod(pod *v1.Pod, moduleName string, useDeprecatedLabel bool) string {
 	podRole := pod.Labels[constants.DaemonSetRole]
 	if podRole == devicePluginRoleLabelValue {
-		return getDevicePluginNodeLabel(moduleName)
+		return getDevicePluginNodeLabel(pod.Namespace, moduleName, useDeprecatedLabel)
 	}
-	return getDriverContainerNodeLabel(moduleName)
+	return getDriverContainerNodeLabel(pod.Namespace, moduleName, useDeprecatedLabel)
 }
 
 func (dc *daemonSetGenerator) GetModuleDaemonSets(ctx context.Context, name, namespace string) ([]appsv1.DaemonSet, error) {
@@ -321,12 +321,20 @@ func CopyMapStringString(m map[string]string) map[string]string {
 	return n
 }
 
-func getDriverContainerNodeLabel(moduleName string) string {
-	return fmt.Sprintf("kmm.node.kubernetes.io/%s.ready", moduleName)
+func getDriverContainerNodeLabel(namespace, moduleName string, useDeprecatedLabel bool) string {
+	// TODO: "kmm.node.kubernetes.io/<module-name>.ready" is needed for backward compatibility. Remove for 2.0
+	if useDeprecatedLabel {
+		return fmt.Sprintf("kmm.node.kubernetes.io/%s.ready", moduleName)
+	}
+	return fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.ready", namespace, moduleName)
 }
 
-func getDevicePluginNodeLabel(moduleName string) string {
-	return fmt.Sprintf("kmm.node.kubernetes.io/%s.device-plugin-ready", moduleName)
+func getDevicePluginNodeLabel(namespace, moduleName string, useDeprecatedLabel bool) string {
+	// TODO: "kmm.node.kubernetes.io/<module-name>.device-plugin-ready" is needed for backward compatibility. Remove for 2.0
+	if useDeprecatedLabel {
+		return fmt.Sprintf("kmm.node.kubernetes.io/%s.device-plugin-ready", moduleName)
+	}
+	return fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.device-plugin-ready", namespace, moduleName)
 }
 
 func IsDevicePluginDS(ds *appsv1.DaemonSet) bool {

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -474,7 +474,7 @@ var _ = Describe("SetDevicePluginAsDesired", func() {
 						},
 						ImagePullSecrets: []v1.LocalObjectReference{repoSecret},
 						NodeSelector: map[string]string{
-							getDriverContainerNodeLabel(mod.Name): "",
+							getDriverContainerNodeLabel(mod.Namespace, mod.Name, true): "",
 						},
 						PriorityClassName:  "system-node-critical",
 						ServiceAccountName: serviceAccountName,
@@ -660,6 +660,8 @@ var _ = Describe("OverrideLabels", func() {
 })
 
 var _ = Describe("GetNodeLabelFromPod", func() {
+
+	const namespace = "some-namespace"
 	var dc DaemonSetCreator
 
 	BeforeEach(func() {
@@ -673,10 +675,13 @@ var _ = Describe("GetNodeLabelFromPod", func() {
 					constants.ModuleNameLabel: moduleName,
 					constants.DaemonSetRole:   "module-loader",
 				},
+				Namespace: namespace,
 			},
 		}
-		res := dc.GetNodeLabelFromPod(&pod, "module-name")
-		Expect(res).To(Equal(getDriverContainerNodeLabel("module-name")))
+		res := dc.GetNodeLabelFromPod(&pod, "module-name", false)
+		Expect(res).To(Equal(getDriverContainerNodeLabel(namespace, "module-name", false)))
+		res = dc.GetNodeLabelFromPod(&pod, "module-name", true)
+		Expect(res).To(Equal(getDriverContainerNodeLabel(namespace, "module-name", true)))
 	})
 
 	It("should return a device plugin label", func() {
@@ -686,10 +691,13 @@ var _ = Describe("GetNodeLabelFromPod", func() {
 					constants.ModuleNameLabel: moduleName,
 					constants.DaemonSetRole:   "device-plugin",
 				},
+				Namespace: namespace,
 			},
 		}
-		res := dc.GetNodeLabelFromPod(&pod, "module-name")
-		Expect(res).To(Equal(getDevicePluginNodeLabel("module-name")))
+		res := dc.GetNodeLabelFromPod(&pod, "module-name", false)
+		Expect(res).To(Equal(getDevicePluginNodeLabel(namespace, "module-name", false)))
+		res = dc.GetNodeLabelFromPod(&pod, "module-name", true)
+		Expect(res).To(Equal(getDevicePluginNodeLabel(namespace, "module-name", true)))
 	})
 })
 

--- a/internal/daemonset/mock_daemonset.go
+++ b/internal/daemonset/mock_daemonset.go
@@ -70,17 +70,17 @@ func (mr *MockDaemonSetCreatorMockRecorder) GetModuleDaemonSets(ctx, name, names
 }
 
 // GetNodeLabelFromPod mocks base method.
-func (m *MockDaemonSetCreator) GetNodeLabelFromPod(pod *v10.Pod, moduleName string) string {
+func (m *MockDaemonSetCreator) GetNodeLabelFromPod(pod *v10.Pod, moduleName string, useDeprecatedLabel bool) string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNodeLabelFromPod", pod, moduleName)
+	ret := m.ctrl.Call(m, "GetNodeLabelFromPod", pod, moduleName, useDeprecatedLabel)
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
 // GetNodeLabelFromPod indicates an expected call of GetNodeLabelFromPod.
-func (mr *MockDaemonSetCreatorMockRecorder) GetNodeLabelFromPod(pod, moduleName interface{}) *gomock.Call {
+func (mr *MockDaemonSetCreatorMockRecorder) GetNodeLabelFromPod(pod, moduleName, useDeprecatedLabel interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeLabelFromPod", reflect.TypeOf((*MockDaemonSetCreator)(nil).GetNodeLabelFromPod), pod, moduleName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeLabelFromPod", reflect.TypeOf((*MockDaemonSetCreator)(nil).GetNodeLabelFromPod), pod, moduleName, useDeprecatedLabel)
 }
 
 // SetDevicePluginAsDesired mocks base method.


### PR DESCRIPTION
This is handy when there are multiple modules on each node and make it easier to determine where is each module.

Also, solving a race condition in a new pod was created while the old pod of a `moduleLoader` is being terminated which resulted in the `<module>.ready` label to be deleted.

Fixes #519
/cc @ybettan @yevgeny-shnaidman