### PR TITLE
handling Version change in DevicPlugin and ModuleLoader DaemonSets (#…

### DIFF
--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -198,6 +198,7 @@ type moduleReconcilerHelperAPI interface {
 
 type hashData struct {
 	KernelVersion string
+	ModuleVersion string
 }
 
 type moduleReconcilerHelper struct {
@@ -356,9 +357,13 @@ func (mrh *moduleReconcilerHelper) handleSigning(ctx context.Context, mld *api.M
 func (mrh *moduleReconcilerHelper) handleDriverContainer(ctx context.Context,
 	mld *api.ModuleLoaderData) error {
 
-	hashValue, err := hashstructure.Hash(hashData{KernelVersion: mld.KernelVersion}, hashstructure.FormatV2, nil)
+	dsNameData := hashData{
+		KernelVersion: mld.KernelVersion,
+		ModuleVersion: mld.ModuleVersion,
+	}
+	hashValue, err := hashstructure.Hash(dsNameData, hashstructure.FormatV2, nil)
 	if err != nil {
-		return fmt.Errorf("failed to hash kernel version %s for module loader daemonset name: %v", mld.KernelVersion, err)
+		return fmt.Errorf("failed to hash kernel and module versions (%s %s) and for module loader daemonset name: %v", mld.KernelVersion, mld.ModuleVersion, err)
 	}
 	name := fmt.Sprintf("%s-%x", mld.Name, hashValue)
 	ds := &appsv1.DaemonSet{
@@ -383,8 +388,13 @@ func (mrh *moduleReconcilerHelper) handleDevicePlugin(ctx context.Context, mod *
 	}
 
 	logger := log.FromContext(ctx)
+	hashValue, err := hashstructure.Hash(hashData{ModuleVersion: mod.Spec.ModuleLoader.Container.Version}, hashstructure.FormatV2, nil)
+	if err != nil {
+		return fmt.Errorf("failed to hash module version %s for device-plugin daemonset name: %v", mod.Spec.ModuleLoader.Container.Version, err)
+	}
+	name := fmt.Sprintf("%s-device-plugin-%x", mod.Name, hashValue)
 	ds := &appsv1.DaemonSet{
-		ObjectMeta: metav1.ObjectMeta{Name: mod.Name + "-device-plugin", Namespace: mod.Namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: mod.Namespace},
 	}
 
 	opRes, err := controllerutil.CreateOrPatch(ctx, mrh.client, ds, func() error {
@@ -406,7 +416,7 @@ func (mrh *moduleReconcilerHelper) garbageCollect(ctx context.Context,
 	// Garbage collect old DaemonSets for which there are no nodes.
 	validKernels := sets.KeySet[string](mldMappings)
 
-	deleted, err := mrh.daemonAPI.GarbageCollect(ctx, existingDS, validKernels)
+	deleted, err := mrh.daemonAPI.GarbageCollect(ctx, mod, existingDS, validKernels)
 	if err != nil {
 		return fmt.Errorf("could not garbage collect DaemonSets: %v", err)
 	}

--- a/controllers/module_reconciler_test.go
+++ b/controllers/module_reconciler_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -556,8 +557,9 @@ var _ = Describe("ModuleReconciler_handleDriverContainer", func() {
 			Name:          "name",
 			Namespace:     "namespace",
 			KernelVersion: "kernelVersion1",
+			ModuleVersion: "v234.e",
 		}
-		hashValue, err := hashstructure.Hash(hashData{KernelVersion: mld.KernelVersion}, hashstructure.FormatV2, nil)
+		hashValue, err := hashstructure.Hash(hashData{KernelVersion: mld.KernelVersion, ModuleVersion: mld.ModuleVersion}, hashstructure.FormatV2, nil)
 		Expect(err).NotTo(HaveOccurred())
 		newDS := &appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{Namespace: mld.Namespace, Name: fmt.Sprintf("%s-%x", mld.Name, hashValue)},
@@ -580,13 +582,26 @@ var _ = Describe("ModuleReconciler_handleDriverContainer", func() {
 			Name:          "name",
 			Namespace:     "namespace",
 			KernelVersion: "kernelVersion1",
+			ModuleVersion: "wr4656",
+		}
+		hashValue, err := hashstructure.Hash(hashData{KernelVersion: mld.KernelVersion, ModuleVersion: mld.ModuleVersion}, hashstructure.FormatV2, nil)
+		Expect(err).NotTo(HaveOccurred())
+		name := fmt.Sprintf("%s-%x", mld.Name, hashValue)
+		existingDS := &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Namespace: mld.Namespace, Name: name},
 		}
 		gomock.InOrder(
-			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil),
-			mockDC.EXPECT().SetDriverContainerAsDesired(ctx, gomock.Any(), &mld, true).Return(nil),
+			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ interface{}, _ interface{}, ds *appsv1.DaemonSet, _ ...ctrlclient.GetOption) error {
+					ds.SetName(name)
+					ds.SetNamespace(mld.Namespace)
+					return nil
+				},
+			),
+			mockDC.EXPECT().SetDriverContainerAsDesired(ctx, existingDS, &mld, true).Return(nil),
 		)
 
-		err := mhr.handleDriverContainer(ctx, &mld)
+		err = mhr.handleDriverContainer(ctx, &mld)
 
 		Expect(err).NotTo(HaveOccurred())
 
@@ -653,8 +668,11 @@ var _ = Describe("ModuleReconciler_handleDevicePlugin", func() {
 			},
 		}
 
+		hashValue, err := hashstructure.Hash(hashData{ModuleVersion: ""}, hashstructure.FormatV2, nil)
+		Expect(err).NotTo(HaveOccurred())
+
 		newDS := &appsv1.DaemonSet{
-			ObjectMeta: metav1.ObjectMeta{Namespace: mod.Namespace, Name: mod.Name + "-device-plugin"},
+			ObjectMeta: metav1.ObjectMeta{Namespace: mod.Namespace, Name: fmt.Sprintf("%s-device-plugin-%x", mod.Name, hashValue)},
 		}
 		gomock.InOrder(
 			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),
@@ -662,7 +680,7 @@ var _ = Describe("ModuleReconciler_handleDevicePlugin", func() {
 			clnt.EXPECT().Create(ctx, gomock.Any()).Return(nil),
 		)
 
-		err := mhr.handleDevicePlugin(ctx, &mod)
+		err = mhr.handleDevicePlugin(ctx, &mod)
 
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -679,15 +697,24 @@ var _ = Describe("ModuleReconciler_handleDevicePlugin", func() {
 			},
 		}
 
+		hashValue, err := hashstructure.Hash(hashData{ModuleVersion: ""}, hashstructure.FormatV2, nil)
+		Expect(err).NotTo(HaveOccurred())
+		name := fmt.Sprintf("%s-device-plugin-%x", mod.Name, hashValue)
 		existingDS := &appsv1.DaemonSet{
-			ObjectMeta: metav1.ObjectMeta{Namespace: mod.Namespace, Name: mod.Name + "-device-plugin"},
+			ObjectMeta: metav1.ObjectMeta{Namespace: mod.Namespace, Name: name},
 		}
 		gomock.InOrder(
-			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil),
+			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ interface{}, _ interface{}, ds *appsv1.DaemonSet, _ ...ctrlclient.GetOption) error {
+					ds.SetName(name)
+					ds.SetNamespace(mod.Namespace)
+					return nil
+				},
+			),
 			mockDC.EXPECT().SetDevicePluginAsDesired(ctx, existingDS, &mod, true).Return(nil),
 		)
 
-		err := mhr.handleDevicePlugin(ctx, &mod)
+		err = mhr.handleDevicePlugin(ctx, &mod)
 
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -724,7 +751,7 @@ var _ = Describe("ModuleReconciler_garbageCollect", func() {
 		existingDS := []appsv1.DaemonSet{appsv1.DaemonSet{}, appsv1.DaemonSet{}}
 		kernelSet := sets.New("kernelVersion1", "kernelVersion2")
 		gomock.InOrder(
-			mockDC.EXPECT().GarbageCollect(context.Background(), existingDS, kernelSet).Return(nil, nil),
+			mockDC.EXPECT().GarbageCollect(context.Background(), mod, existingDS, kernelSet).Return(nil, nil),
 			mockBM.EXPECT().GarbageCollect(context.Background(), mod.Name, mod.Namespace, mod).Return(nil, nil),
 			mockSM.EXPECT().GarbageCollect(context.Background(), mod.Name, mod.Namespace, mod).Return(nil, nil),
 		)
@@ -742,10 +769,10 @@ var _ = Describe("ModuleReconciler_garbageCollect", func() {
 		existingDS := []appsv1.DaemonSet{appsv1.DaemonSet{}, appsv1.DaemonSet{}}
 		kernelSet := sets.New("kernelVersion1", "kernelVersion2")
 		if dcError {
-			mockDC.EXPECT().GarbageCollect(context.Background(), existingDS, kernelSet).Return(nil, returnedError)
+			mockDC.EXPECT().GarbageCollect(context.Background(), mod, existingDS, kernelSet).Return(nil, returnedError)
 			goto executeTestFunction
 		}
-		mockDC.EXPECT().GarbageCollect(context.Background(), existingDS, kernelSet).Return(nil, nil)
+		mockDC.EXPECT().GarbageCollect(context.Background(), mod, existingDS, kernelSet).Return(nil, nil)
 		if buildError {
 			mockBM.EXPECT().GarbageCollect(context.Background(), mod.Name, mod.Namespace, mod).Return(nil, returnedError)
 			goto executeTestFunction

--- a/internal/api/moduleloaderdata.go
+++ b/internal/api/moduleloaderdata.go
@@ -36,6 +36,9 @@ type ModuleLoaderData struct {
 	// Sign provides default kmod signing settings
 	Sign *kmmv1beta1.Sign
 
+	// Module version
+	ModuleVersion string
+
 	// ContainerImage is a top-level field
 	ContainerImage string
 

--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -34,7 +34,7 @@ const (
 //go:generate mockgen -source=daemonset.go -package=daemonset -destination=mock_daemonset.go
 
 type DaemonSetCreator interface {
-	GarbageCollect(ctx context.Context, existingDS []appsv1.DaemonSet, validKernels sets.Set[string]) ([]string, error)
+	GarbageCollect(ctx context.Context, mod *kmmv1beta1.Module, existingDS []appsv1.DaemonSet, validKernels sets.Set[string]) ([]string, error)
 	GetModuleDaemonSets(ctx context.Context, name, namespace string) ([]appsv1.DaemonSet, error)
 	SetDriverContainerAsDesired(ctx context.Context, ds *appsv1.DaemonSet, mld *api.ModuleLoaderData, useDefaultSA bool) error
 	SetDevicePluginAsDesired(ctx context.Context, ds *appsv1.DaemonSet, mod *kmmv1beta1.Module, useDefaultSA bool) error
@@ -55,11 +55,19 @@ func NewCreator(client client.Client, kernelLabel string, scheme *runtime.Scheme
 	}
 }
 
-func (dc *daemonSetGenerator) GarbageCollect(ctx context.Context, existingDS []appsv1.DaemonSet, validKernels sets.Set[string]) ([]string, error) {
+func (dc *daemonSetGenerator) GarbageCollect(ctx context.Context, mod *kmmv1beta1.Module, existingDS []appsv1.DaemonSet, validKernels sets.Set[string]) ([]string, error) {
 	deleted := make([]string, 0)
 
+	versionLabel := utils.GetModuleVersionLabelName(mod.Namespace, mod.Name)
 	for _, ds := range existingDS {
-		if !IsDevicePluginDS(&ds) && !validKernels.Has(ds.Labels[dc.kernelLabel]) {
+		if isOlderVersionUnusedDaemonset(&ds, versionLabel, mod.Spec.ModuleLoader.Container.Version) {
+			if err := dc.client.Delete(ctx, &ds); err != nil {
+				return nil, fmt.Errorf("could not delete DaemonSet %s: %v", ds.Name, err)
+			}
+			deleted = append(deleted, ds.Name)
+			continue
+		}
+		if isModuleLoaderDaemonsetWithInvalidKernel(&ds, dc.kernelLabel, validKernels) {
 			if err := dc.client.Delete(ctx, &ds); err != nil {
 				return nil, fmt.Errorf("could not delete DaemonSet %s: %v", ds.Name, err)
 			}
@@ -94,6 +102,10 @@ func (dc *daemonSetGenerator) SetDriverContainerAsDesired(
 		constants.ModuleNameLabel: mld.Name,
 		dc.kernelLabel:            kernelVersion,
 		constants.DaemonSetRole:   moduleLoaderRoleLabelValue,
+	}
+	if mld.ModuleVersion != "" {
+		versionLabel := utils.GetModuleVersionLabelName(mld.Namespace, mld.Name)
+		standardLabels[versionLabel] = mld.ModuleVersion
 	}
 
 	ds.SetLabels(
@@ -243,6 +255,10 @@ func (dc *daemonSetGenerator) SetDevicePluginAsDesired(
 		constants.ModuleNameLabel: mod.Name,
 		constants.DaemonSetRole:   devicePluginRoleLabelValue,
 	}
+	if mod.Spec.ModuleLoader.Container.Version != "" {
+		versionLabel := utils.GetModuleVersionLabelName(mod.Namespace, mod.Name)
+		standardLabels[versionLabel] = mod.Spec.ModuleLoader.Container.Version
+	}
 
 	ds.SetLabels(
 		OverrideLabels(ds.GetLabels(), standardLabels),
@@ -335,6 +351,14 @@ func getDevicePluginNodeLabel(namespace, moduleName string, useDeprecatedLabel b
 		return fmt.Sprintf("kmm.node.kubernetes.io/%s.device-plugin-ready", moduleName)
 	}
 	return fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.device-plugin-ready", namespace, moduleName)
+}
+
+func isOlderVersionUnusedDaemonset(ds *appsv1.DaemonSet, moduleVersionLabel, moduleVersion string) bool {
+	return ds.Labels[moduleVersionLabel] != moduleVersion && ds.Status.DesiredNumberScheduled == 0
+}
+
+func isModuleLoaderDaemonsetWithInvalidKernel(ds *appsv1.DaemonSet, kernelLabel string, validKernels sets.Set[string]) bool {
+	return !IsDevicePluginDS(ds) && !validKernels.Has(ds.Labels[kernelLabel])
 }
 
 func IsDevicePluginDS(ds *appsv1.DaemonSet) bool {

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -2,7 +2,6 @@ package daemonset
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/golang/mock/gomock"
@@ -13,6 +12,7 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -32,10 +32,14 @@ const (
 var (
 	ctrl *gomock.Controller
 	clnt *client.MockClient
+	dc   DaemonSetCreator
 )
 
 var _ = Describe("SetDriverContainerAsDesired", func() {
-	dg := NewCreator(nil, kernelLabel, scheme)
+
+	BeforeEach(func() {
+		dc = NewCreator(nil, kernelLabel, scheme)
+	})
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
@@ -44,7 +48,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 	It("should return an error if the DaemonSet is nil", func() {
 		Expect(
-			dg.SetDriverContainerAsDesired(context.Background(), nil, &api.ModuleLoaderData{}, false),
+			dc.SetDriverContainerAsDesired(context.Background(), nil, &api.ModuleLoaderData{}, false),
 		).To(
 			HaveOccurred(),
 		)
@@ -52,7 +56,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 	It("should return an error if the image is empty", func() {
 		Expect(
-			dg.SetDriverContainerAsDesired(context.Background(), &appsv1.DaemonSet{}, &api.ModuleLoaderData{}, false),
+			dc.SetDriverContainerAsDesired(context.Background(), &appsv1.DaemonSet{}, &api.ModuleLoaderData{}, false),
 		).To(
 			HaveOccurred(),
 		)
@@ -60,7 +64,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 	It("should return an error if the kernel version is empty", func() {
 		Expect(
-			dg.SetDriverContainerAsDesired(context.Background(), &appsv1.DaemonSet{}, &api.ModuleLoaderData{}, false),
+			dc.SetDriverContainerAsDesired(context.Background(), &appsv1.DaemonSet{}, &api.ModuleLoaderData{}, false),
 		).To(
 			HaveOccurred(),
 		)
@@ -76,7 +80,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 		ds := appsv1.DaemonSet{}
 
-		err := dg.SetDriverContainerAsDesired(context.Background(), &ds, &mld, false)
+		err := dc.SetDriverContainerAsDesired(context.Background(), &ds, &mld, false)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ds.Spec.Template.Spec.Containers).To(HaveLen(1))
 		Expect(ds.Spec.Template.Spec.Volumes).To(HaveLen(1))
@@ -111,7 +115,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 		ds := appsv1.DaemonSet{}
 
-		err := dg.SetDriverContainerAsDesired(context.Background(), &ds, &mld, false)
+		err := dc.SetDriverContainerAsDesired(context.Background(), &ds, &mld, false)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ds.Spec.Template.Spec.Volumes).To(HaveLen(2))
 		Expect(ds.Spec.Template.Spec.Volumes[1]).To(Equal(vol))
@@ -121,11 +125,6 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 	DescribeTable("should add the default ServiceAccount to the module loader",
 		func(useDefaultSA bool, expectedSA string) {
-			/*
-				mod := kmmv1beta1.Module{
-					Spec: kmmv1beta1.ModuleSpec{},
-				}
-			*/
 			mld := api.ModuleLoaderData{
 				Owner:          &kmmv1beta1.Module{},
 				ContainerImage: "test-image",
@@ -134,13 +133,34 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 			ds := appsv1.DaemonSet{}
 
-			err := dg.SetDriverContainerAsDesired(context.Background(), &ds, &mld, useDefaultSA)
+			err := dc.SetDriverContainerAsDesired(context.Background(), &ds, &mld, useDefaultSA)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ds.Spec.Template.Spec.ServiceAccountName).To(Equal(expectedSA))
 		},
 		Entry(nil, false, ""),
 		Entry(nil, true, "kmm-operator-module-loader"),
 	)
+
+	It("should add module version in case it is defined for the module", func() {
+		mld := api.ModuleLoaderData{
+			Name:      moduleName,
+			Namespace: namespace,
+			Modprobe: kmmv1beta1.ModprobeSpec{
+				FirmwarePath: "/opt/lib/firmware/example",
+			},
+			Owner:          &kmmv1beta1.Module{},
+			ContainerImage: "some image",
+			KernelVersion:  kernelVersion,
+			ModuleVersion:  "some version",
+		}
+		ds := appsv1.DaemonSet{}
+
+		err := dc.SetDriverContainerAsDesired(context.Background(), &ds, &mld, false)
+
+		versionLabel := utils.GetModuleVersionLabelName(mld.Namespace, mld.Name)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ds.GetLabels()).Should(HaveKeyWithValue(versionLabel, "some version"))
+	})
 
 	It("should work as expected", func() {
 		const (
@@ -179,7 +199,8 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 			},
 		}
 
-		err := dg.SetDriverContainerAsDesired(context.Background(), &ds, &mld, false)
+		err := dc.SetDriverContainerAsDesired(context.Background(), &ds, &mld, false)
+
 		Expect(err).NotTo(HaveOccurred())
 
 		podLabels := map[string]string{
@@ -284,11 +305,14 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 })
 
 var _ = Describe("SetDevicePluginAsDesired", func() {
-	dg := NewCreator(nil, kernelLabel, scheme)
+
+	BeforeEach(func() {
+		dc = NewCreator(nil, kernelLabel, scheme)
+	})
 
 	It("should return an error if the DaemonSet is nil", func() {
 		Expect(
-			dg.SetDevicePluginAsDesired(context.Background(), nil, &kmmv1beta1.Module{}, false),
+			dc.SetDevicePluginAsDesired(context.Background(), nil, &kmmv1beta1.Module{}, false),
 		).To(
 			HaveOccurred(),
 		)
@@ -297,7 +321,7 @@ var _ = Describe("SetDevicePluginAsDesired", func() {
 	It("should return an error if DevicePlugin not set in the Spec", func() {
 		ds := appsv1.DaemonSet{}
 		Expect(
-			dg.SetDevicePluginAsDesired(context.Background(), &ds, &kmmv1beta1.Module{}, false),
+			dc.SetDevicePluginAsDesired(context.Background(), &ds, &kmmv1beta1.Module{}, false),
 		).To(
 			HaveOccurred(),
 		)
@@ -317,7 +341,8 @@ var _ = Describe("SetDevicePluginAsDesired", func() {
 
 		ds := appsv1.DaemonSet{}
 
-		err := dg.SetDevicePluginAsDesired(context.Background(), &ds, &mod, false)
+		err := dc.SetDevicePluginAsDesired(context.Background(), &ds, &mod, false)
+
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ds.Spec.Template.Spec.Volumes).To(HaveLen(2))
 		Expect(ds.Spec.Template.Spec.Volumes[1]).To(Equal(vol))
@@ -333,13 +358,48 @@ var _ = Describe("SetDevicePluginAsDesired", func() {
 
 			ds := appsv1.DaemonSet{}
 
-			err := dg.SetDevicePluginAsDesired(context.Background(), &ds, &mod, useDefaultSA)
+			err := dc.SetDevicePluginAsDesired(context.Background(), &ds, &mod, useDefaultSA)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ds.Spec.Template.Spec.ServiceAccountName).To(Equal(expectedSA))
 		},
 		Entry(nil, false, ""),
 		Entry(nil, true, "kmm-operator-device-plugin"),
 	)
+
+	It("should add module version if it was defined in the Module", func() {
+		vol := v1.Volume{Name: "test-volume"}
+
+		mod := kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      moduleName,
+				Namespace: namespace,
+			},
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					Container: kmmv1beta1.ModuleLoaderContainerSpec{
+						Version: "some version",
+					},
+				},
+				DevicePlugin: &kmmv1beta1.DevicePluginSpec{
+					Container: kmmv1beta1.DevicePluginContainerSpec{Image: devicePluginImage},
+					Volumes:   []v1.Volume{vol},
+				},
+			},
+		}
+
+		ds := appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      moduleName,
+				Namespace: namespace,
+			},
+		}
+
+		err := dc.SetDevicePluginAsDesired(context.Background(), &ds, &mod, false)
+
+		versionLabel := utils.GetModuleVersionLabelName(namespace, moduleName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(ds.GetLabels()).Should(HaveKeyWithValue(versionLabel, "some version"))
+	})
 
 	It("should work as expected", func() {
 		const (
@@ -417,7 +477,8 @@ var _ = Describe("SetDevicePluginAsDesired", func() {
 			},
 		}
 
-		err := dg.SetDevicePluginAsDesired(context.Background(), &ds, &mod, false)
+		err := dc.SetDevicePluginAsDesired(context.Background(), &ds, &mod, false)
+
 		Expect(err).NotTo(HaveOccurred())
 
 		podLabels := map[string]string{
@@ -504,54 +565,122 @@ var _ = Describe("SetDevicePluginAsDesired", func() {
 })
 
 var _ = Describe("GarbageCollect", func() {
+	const (
+		legitKernelVersion    = "legit-kernel-version"
+		notLegitKernelVersion = "not-legit-kernel-version"
+		currentModuleVersion  = "current label"
+	)
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
+		dc = NewCreator(clnt, kernelLabel, scheme)
 	})
 
-	It("should only delete one of the two DaemonSets if only one is not used", func() {
-		const (
-			legitKernelVersion    = "legit-kernel-version"
-			legitName             = "legit"
-			notLegitKernelVersion = "not-legit-kernel-version"
-			notLegitName          = "not-legit"
-		)
+	mod := &kmmv1beta1.Module{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "moduleName",
+			Namespace: "namespace",
+		},
+		Spec: kmmv1beta1.ModuleSpec{
+			ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+				Container: kmmv1beta1.ModuleLoaderContainerSpec{
+					Version: currentModuleVersion,
+				},
+			},
+		},
+	}
+	versionLabel := utils.GetModuleVersionLabelName(mod.Namespace, mod.Name)
 
-		dsLegit := appsv1.DaemonSet{
-			ObjectMeta: metav1.ObjectMeta{Name: legitName, Namespace: namespace, Labels: map[string]string{kernelLabel: legitKernelVersion}},
+	DescribeTable("device-plugin and modue-loader GC", func(devicePluginFormerLabel, moduleLoaderFormerLabel, moduleLoaderInvalidKernel bool,
+		devicePluginFormerDesired, moduleLoaderFormerDesired int) {
+		moduleLoaderDS := appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "moduleLoader",
+				Namespace: "namespace",
+				Labels:    map[string]string{kernelLabel: legitKernelVersion, constants.DaemonSetRole: moduleLoaderRoleLabelValue, versionLabel: currentModuleVersion},
+			},
+		}
+		devicePluginDS := appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "devicePlugin",
+				Namespace: "namespace",
+				Labels:    map[string]string{constants.DaemonSetRole: devicePluginRoleLabelValue, versionLabel: currentModuleVersion},
+			},
+		}
+		devicePluginFormerVersionDS := &appsv1.DaemonSet{}
+		moduleLoaderFormerVersionDS := &appsv1.DaemonSet{}
+		moduleLoaderIllegalKernelVersionDS := &appsv1.DaemonSet{}
+
+		existingDS := []appsv1.DaemonSet{moduleLoaderDS, devicePluginDS}
+		expectedDeleteNames := []string{}
+		if devicePluginFormerLabel {
+			devicePluginFormerVersionDS = devicePluginDS.DeepCopy()
+			devicePluginFormerVersionDS.SetName("devicePluginFormer")
+			devicePluginFormerVersionDS.Labels[versionLabel] = "former label"
+			devicePluginFormerVersionDS.Status.DesiredNumberScheduled = int32(devicePluginFormerDesired)
+			existingDS = append(existingDS, *devicePluginFormerVersionDS)
+		}
+		if moduleLoaderFormerLabel {
+			moduleLoaderFormerVersionDS = moduleLoaderDS.DeepCopy()
+			moduleLoaderFormerVersionDS.SetName("moduleLoaderFormer")
+			moduleLoaderFormerVersionDS.Labels[versionLabel] = "former label"
+			moduleLoaderFormerVersionDS.Status.DesiredNumberScheduled = int32(moduleLoaderFormerDesired)
+			existingDS = append(existingDS, *moduleLoaderFormerVersionDS)
+		}
+		if moduleLoaderInvalidKernel {
+			moduleLoaderIllegalKernelVersionDS = moduleLoaderDS.DeepCopy()
+			moduleLoaderIllegalKernelVersionDS.SetName("moduleLoaderInvalidKernel")
+			moduleLoaderIllegalKernelVersionDS.Labels[kernelLabel] = notLegitKernelVersion
+			existingDS = append(existingDS, *moduleLoaderIllegalKernelVersionDS)
 		}
 
-		dsNotLegit := appsv1.DaemonSet{
-			ObjectMeta: metav1.ObjectMeta{Name: notLegitName, Namespace: namespace, Labels: map[string]string{kernelLabel: notLegitKernelVersion}},
+		if devicePluginFormerLabel && devicePluginFormerDesired == 0 {
+			expectedDeleteNames = append(expectedDeleteNames, "devicePluginFormer")
+			clnt.EXPECT().Delete(context.Background(), devicePluginFormerVersionDS).Return(nil)
+		}
+		if moduleLoaderFormerLabel && moduleLoaderFormerDesired == 0 {
+			expectedDeleteNames = append(expectedDeleteNames, "moduleLoaderFormer")
+			clnt.EXPECT().Delete(context.Background(), moduleLoaderFormerVersionDS).Return(nil)
+		}
+		if moduleLoaderInvalidKernel {
+			expectedDeleteNames = append(expectedDeleteNames, "moduleLoaderInvalidKernel")
+			clnt.EXPECT().Delete(context.Background(), moduleLoaderIllegalKernelVersionDS).Return(nil)
 		}
 
-		clnt.EXPECT().Delete(context.Background(), &dsNotLegit).AnyTimes()
+		res, err := dc.GarbageCollect(context.Background(), mod, existingDS, sets.New[string](legitKernelVersion))
 
-		dc := NewCreator(clnt, kernelLabel, scheme)
-
-		existingDS := []appsv1.DaemonSet{dsLegit, dsNotLegit}
-
-		validKernels := sets.New(legitKernelVersion)
-
-		res, err := dc.GarbageCollect(context.Background(), existingDS, validKernels)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(res).To(Equal([]string{notLegitName}))
-	})
+		Expect(res).To(Equal(expectedDeleteNames))
+	},
+		Entry("no deletes", false, false, false, 0, 0),
+		Entry("former device plugin", true, false, false, 0, 0),
+		Entry("former device plugin has desired", true, false, false, 1, 0),
+		Entry("former module loader", false, true, false, 0, 0),
+		Entry("former module loader has desired", false, true, false, 0, 1),
+		Entry("illegal kernel version", false, false, true, 0, 0),
+		Entry("former device plugin, former module loader, illegal kernel version", true, true, true, 0, 0),
+	)
 
 	It("should return an error if a deletion failed", func() {
-		clnt.EXPECT().Delete(context.Background(), gomock.Any()).Return(
-			errors.New("client returns some error"),
-		)
-
-		dc := NewCreator(clnt, kernelLabel, scheme)
-
-		dsNotLegit := appsv1.DaemonSet{
-			ObjectMeta: metav1.ObjectMeta{Name: "name", Namespace: "namespace", Labels: map[string]string{kernelLabel: "kernel version"}},
+		deleteDS := appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "moduleLoader",
+				Namespace: "namespace",
+				Labels:    map[string]string{kernelLabel: notLegitKernelVersion, constants.DaemonSetRole: moduleLoaderRoleLabelValue, versionLabel: currentModuleVersion},
+			},
 		}
+		clnt.EXPECT().Delete(context.Background(), &deleteDS).Return(fmt.Errorf("some error"))
 
-		existingDS := []appsv1.DaemonSet{dsNotLegit}
+		existingDS := []appsv1.DaemonSet{deleteDS}
 
-		_, err := dc.GarbageCollect(context.Background(), existingDS, sets.New[string]())
+		_, err := dc.GarbageCollect(context.Background(), mod, existingDS, sets.New[string](legitKernelVersion))
+		Expect(err).To(HaveOccurred())
+
+		deleteDS.Labels[versionLabel] = "former label"
+		clnt.EXPECT().Delete(context.Background(), &deleteDS).Return(fmt.Errorf("some error"))
+
+		existingDS = []appsv1.DaemonSet{deleteDS}
+		_, err = dc.GarbageCollect(context.Background(), mod, existingDS, sets.New[string](legitKernelVersion))
 		Expect(err).To(HaveOccurred())
 	})
 })

--- a/internal/daemonset/mock_daemonset.go
+++ b/internal/daemonset/mock_daemonset.go
@@ -40,18 +40,18 @@ func (m *MockDaemonSetCreator) EXPECT() *MockDaemonSetCreatorMockRecorder {
 }
 
 // GarbageCollect mocks base method.
-func (m *MockDaemonSetCreator) GarbageCollect(ctx context.Context, existingDS []v1.DaemonSet, validKernels sets.Set[string]) ([]string, error) {
+func (m *MockDaemonSetCreator) GarbageCollect(ctx context.Context, mod *v1beta1.Module, existingDS []v1.DaemonSet, validKernels sets.Set[string]) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GarbageCollect", ctx, existingDS, validKernels)
+	ret := m.ctrl.Call(m, "GarbageCollect", ctx, mod, existingDS, validKernels)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GarbageCollect indicates an expected call of GarbageCollect.
-func (mr *MockDaemonSetCreatorMockRecorder) GarbageCollect(ctx, existingDS, validKernels interface{}) *gomock.Call {
+func (mr *MockDaemonSetCreatorMockRecorder) GarbageCollect(ctx, mod, existingDS, validKernels interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockDaemonSetCreator)(nil).GarbageCollect), ctx, existingDS, validKernels)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockDaemonSetCreator)(nil).GarbageCollect), ctx, mod, existingDS, validKernels)
 }
 
 // GetModuleDaemonSets mocks base method.

--- a/internal/module/kernelmapper.go
+++ b/internal/module/kernelmapper.go
@@ -120,6 +120,7 @@ func (kh *kernelMapperHelper) prepareModuleLoaderData(mapping *kmmv1beta1.Kernel
 	mld.Selector = mod.Spec.Selector
 	mld.ServiceAccountName = mod.Spec.ModuleLoader.ServiceAccountName
 	mld.Modprobe = mod.Spec.ModuleLoader.Container.Modprobe
+	mld.ModuleVersion = mod.Spec.ModuleLoader.Container.Version
 	mld.Owner = mod
 
 	return mld, nil


### PR DESCRIPTION
…334)

This PR add handing of the Version of the module in the creation of DevicePlugin and ModuleLoader DaemonSets. The following was added: 1) setting the Module's Version in the ModuleLoaderData 2) adding Version the hash of DevicePlugin/ModuleLoader daemonset's name 3) adding module version label to the labels of DevicePlugin/ModuleLoader daemonsets 4) changing DS garbage collection to remove DS that does not contain the current
   version label, and has no more available pods

Fixes [522](https://github.com/rh-ecosystem-edge/kernel-module-management/issues/522)