### PR TITLE
Fixing termination timeout for module loader pods (#379)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/a8m/envsubst v1.4.2
 	github.com/go-logr/logr v1.2.4
+	github.com/go-openapi/swag v0.22.3
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-containerregistry v0.14.0
@@ -41,7 +42,6 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
-	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/gobuffalo/flect v0.3.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect

--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/go-openapi/swag"
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
@@ -203,12 +204,13 @@ func (dc *daemonSetGenerator) SetDriverContainerAsDesired(
 				Finalizers: []string{constants.NodeLabelerFinalizer},
 			},
 			Spec: v1.PodSpec{
-				Containers:         []v1.Container{container},
-				ImagePullSecrets:   GetPodPullSecrets(mld.ImageRepoSecret),
-				NodeSelector:       nodeSelector,
-				PriorityClassName:  "system-node-critical",
-				ServiceAccountName: serviceAccountName,
-				Volumes:            volumes,
+				ShareProcessNamespace: swag.Bool(true),
+				Containers:            []v1.Container{container},
+				ImagePullSecrets:      GetPodPullSecrets(mld.ImageRepoSecret),
+				NodeSelector:          nodeSelector,
+				PriorityClassName:     "system-node-critical",
+				ServiceAccountName:    serviceAccountName,
+				Volumes:               volumes,
 			},
 		},
 		Selector: &metav1.LabelSelector{MatchLabels: standardLabels},

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/go-openapi/swag"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo/v2"
@@ -271,6 +272,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 								},
 							},
 						},
+						ShareProcessNamespace: swag.Bool(true),
 						ImagePullSecrets: []v1.LocalObjectReference{
 							{Name: imageRepoSecretName},
 						},


### PR DESCRIPTION
Setting the SharedProcessNamespace to true, which will cause the PID 1 process of the pod container to be pause. Puase process is trapping (has signal handler for) SIGTERM, which will allow kubelet to destroy the container process immediately, without 30 seconds timeout

Fixes [543](https://github.com/rh-ecosystem-edge/kernel-module-management/issues/543)