### PR TITLE
Adding sign jobs garbage collection to hub flow

### DIFF
--- a/controllers/hub/managedclustermodule_reconciler.go
+++ b/controllers/hub/managedclustermodule_reconciler.go
@@ -143,9 +143,9 @@ func (r *ManagedClusterModuleReconciler) Reconcile(ctx context.Context, req ctrl
 		return res, fmt.Errorf("failed to garbage collect ManifestWorks with no matching cluster selector: %v", err)
 	}
 
-	deleted, err := r.clusterAPI.GarbageCollectBuilds(ctx, *mcm)
+	deleted, err := r.clusterAPI.GarbageCollectBuildsAndSigns(ctx, *mcm)
 	if err != nil {
-		return res, fmt.Errorf("failed to garbage collect build objects: %v", err)
+		return res, fmt.Errorf("failed to garbage collect build and sign objects: %v", err)
 	}
 	if len(deleted) > 0 {
 		logger.Info("Garbage-collected Build objects", "names", deleted)

--- a/controllers/hub/managedclustermodule_reconciler_test.go
+++ b/controllers/hub/managedclustermodule_reconciler_test.go
@@ -161,7 +161,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 			mockClusterAPI.EXPECT().RequestedManagedClusterModule(ctx, req.NamespacedName).Return(mcm, nil),
 			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, gomock.Any()).Return(&clusterList, nil),
 			mockMW.EXPECT().GarbageCollect(ctx, clusterList, *mcm),
-			mockClusterAPI.EXPECT().GarbageCollectBuilds(ctx, *mcm),
+			mockClusterAPI.EXPECT().GarbageCollectBuildsAndSigns(ctx, *mcm),
 			mockMW.EXPECT().GetOwnedManifestWorks(ctx, *mcm).Return(&manifestWorkList, nil),
 			mockSU.EXPECT().ManagedClusterModuleUpdateStatus(ctx, mcm, manifestWorkList.Items).Return(nil),
 		)
@@ -230,7 +230,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 			mockClusterAPI.EXPECT().RequestedManagedClusterModule(ctx, req.NamespacedName).Return(mcm, nil),
 			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, gomock.Any()).Return(&clusterList, nil),
 			mockMW.EXPECT().GarbageCollect(ctx, clusterList, *mcm),
-			mockClusterAPI.EXPECT().GarbageCollectBuilds(ctx, *mcm).Return(nil, errors.New("test")),
+			mockClusterAPI.EXPECT().GarbageCollectBuildsAndSigns(ctx, *mcm).Return(nil, errors.New("test")),
 		)
 
 		mr := NewManagedClusterModuleReconciler(
@@ -264,7 +264,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 			mockClusterAPI.EXPECT().RequestedManagedClusterModule(ctx, req.NamespacedName).Return(mcm, nil),
 			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, gomock.Any()).Return(&clusterList, nil),
 			mockMW.EXPECT().GarbageCollect(ctx, clusterList, *mcm),
-			mockClusterAPI.EXPECT().GarbageCollectBuilds(ctx, *mcm),
+			mockClusterAPI.EXPECT().GarbageCollectBuildsAndSigns(ctx, *mcm),
 			mockMW.EXPECT().GetOwnedManifestWorks(ctx, *mcm).Return(nil, errors.New("generic-error")),
 		)
 
@@ -300,7 +300,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 			mockClusterAPI.EXPECT().RequestedManagedClusterModule(ctx, req.NamespacedName).Return(mcm, nil),
 			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, gomock.Any()).Return(&clusterList, nil),
 			mockMW.EXPECT().GarbageCollect(ctx, clusterList, *mcm),
-			mockClusterAPI.EXPECT().GarbageCollectBuilds(ctx, *mcm),
+			mockClusterAPI.EXPECT().GarbageCollectBuildsAndSigns(ctx, *mcm),
 			mockMW.EXPECT().GetOwnedManifestWorks(ctx, *mcm).Return(&manifestWorkList, nil),
 			mockSU.EXPECT().ManagedClusterModuleUpdateStatus(ctx, mcm, manifestWorkList.Items).Return(errors.New("generic-error")),
 		)
@@ -354,7 +354,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 			mockClusterAPI.EXPECT().SelectedManagedClusters(ctx, gomock.Any()).Return(&clusterList, nil),
 			mockClusterAPI.EXPECT().BuildAndSign(gomock.Any(), mcm, clusterList.Items[0]).Return(false, nil),
 			mockMW.EXPECT().GarbageCollect(ctx, clusterList, mcm),
-			mockClusterAPI.EXPECT().GarbageCollectBuilds(ctx, mcm),
+			mockClusterAPI.EXPECT().GarbageCollectBuildsAndSigns(ctx, mcm),
 			mockMW.EXPECT().GetOwnedManifestWorks(ctx, mcm).Return(&manifestWorkList, nil),
 			mockSU.EXPECT().ManagedClusterModuleUpdateStatus(ctx, &mcm, manifestWorkList.Items).Return(nil),
 		)
@@ -411,7 +411,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 			mockMW.EXPECT().SetManifestWorkAsDesired(context.Background(), &mw, gomock.AssignableToTypeOf(mcm)),
 			clnt.EXPECT().Create(gomock.Any(), gomock.Any()).Return(nil),
 			mockMW.EXPECT().GarbageCollect(ctx, clusterList, mcm),
-			mockClusterAPI.EXPECT().GarbageCollectBuilds(ctx, mcm),
+			mockClusterAPI.EXPECT().GarbageCollectBuildsAndSigns(ctx, mcm),
 			mockMW.EXPECT().GetOwnedManifestWorks(ctx, mcm).Return(&manifestWorkList, nil),
 			mockSU.EXPECT().ManagedClusterModuleUpdateStatus(ctx, &mcm, manifestWorkList.Items).Return(nil),
 		)
@@ -472,7 +472,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 				}),
 			clnt.EXPECT().Patch(gomock.Any(), gomock.Any(), gomock.Any()),
 			mockMW.EXPECT().GarbageCollect(ctx, clusterList, mcm),
-			mockClusterAPI.EXPECT().GarbageCollectBuilds(ctx, mcm),
+			mockClusterAPI.EXPECT().GarbageCollectBuildsAndSigns(ctx, mcm),
 			mockMW.EXPECT().GetOwnedManifestWorks(ctx, mcm).Return(&manifestWorkList, nil),
 			mockSU.EXPECT().ManagedClusterModuleUpdateStatus(ctx, &mcm, manifestWorkList.Items).Return(nil),
 		)

--- a/internal/cluster/cluster_test.go
+++ b/internal/cluster/cluster_test.go
@@ -16,382 +16,394 @@ import (
 	hubv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api-hub/v1beta1"
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/build"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/module"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/sign"
 )
 
-var _ = Describe("ClusterAPI", func() {
-	var (
-		ctrl   *gomock.Controller
-		clnt   *client.MockClient
-		mockKM *module.MockKernelMapper
-		mockBM *build.MockManager
-		mockSM *sign.MockSignManager
-	)
+const (
+	mcmName = "test-module"
+
+	namespace = "namespace"
+)
+
+var _ = Describe("RequestedManagedClusterModule", func() {
+	var c ClusterAPI
 
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		clnt = client.NewMockClient(ctrl)
-		mockKM = module.NewMockKernelMapper(ctrl)
-		mockBM = build.NewMockManager(ctrl)
-		mockSM = sign.NewMockSignManager(ctrl)
+		c = NewClusterAPI(clnt, mockKM, nil, nil, "")
 	})
 
-	const (
-		mcmName = "test-module"
-
-		namespace = "namespace"
-	)
-
-	var _ = Describe("RequestedManagedClusterModule", func() {
-		It("should return the requested ManagedClusterModule", func() {
-			mcm := &hubv1beta1.ManagedClusterModule{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      mcmName,
-					Namespace: namespace,
-				},
-				Spec: hubv1beta1.ManagedClusterModuleSpec{
-					ModuleSpec: kmmv1beta1.ModuleSpec{},
-					Selector:   map[string]string{"key": "value"},
-				},
-			}
-
-			nsn := types.NamespacedName{
+	It("should return the requested ManagedClusterModule", func() {
+		mcm := &hubv1beta1.ManagedClusterModule{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      mcmName,
 				Namespace: namespace,
-			}
+			},
+			Spec: hubv1beta1.ManagedClusterModuleSpec{
+				ModuleSpec: kmmv1beta1.ModuleSpec{},
+				Selector:   map[string]string{"key": "value"},
+			},
+		}
 
-			ctx := context.Background()
+		nsn := types.NamespacedName{
+			Name:      mcmName,
+			Namespace: namespace,
+		}
 
-			gomock.InOrder(
-				clnt.EXPECT().Get(ctx, nsn, gomock.Any()).DoAndReturn(
-					func(_ interface{}, _ interface{}, m *hubv1beta1.ManagedClusterModule, _ ...ctrlclient.GetOption) error {
-						m.ObjectMeta = mcm.ObjectMeta
-						m.Spec = mcm.Spec
-						return nil
-					},
-				),
-			)
+		ctx := context.Background()
 
-			c := NewClusterAPI(clnt, mockKM, nil, nil, "")
-
-			res, err := c.RequestedManagedClusterModule(ctx, nsn)
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(res).To(Equal(mcm))
-		})
-
-		It("should return the respective error when the client Get request fails", func() {
-			nsn := types.NamespacedName{
-				Name:      mcmName,
-				Namespace: namespace,
-			}
-
-			ctx := context.Background()
-
-			gomock.InOrder(
-				clnt.EXPECT().Get(ctx, nsn, gomock.Any()).Return(errors.New("generic-error")),
-			)
-
-			c := NewClusterAPI(clnt, mockKM, nil, nil, "")
-
-			res, err := c.RequestedManagedClusterModule(ctx, nsn)
-
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("generic-error"))
-			Expect(res).To(BeNil())
-		})
-	})
-
-	var _ = Describe("SelectedManagedClusters", func() {
-		It("should return the ManagedClusters matching the ManagedClusterModule selector", func() {
-			mcm := &hubv1beta1.ManagedClusterModule{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      mcmName,
-					Namespace: namespace,
+		gomock.InOrder(
+			clnt.EXPECT().Get(ctx, nsn, gomock.Any()).DoAndReturn(
+				func(_ interface{}, _ interface{}, m *hubv1beta1.ManagedClusterModule, _ ...ctrlclient.GetOption) error {
+					m.ObjectMeta = mcm.ObjectMeta
+					m.Spec = mcm.Spec
+					return nil
 				},
-				Spec: hubv1beta1.ManagedClusterModuleSpec{
-					ModuleSpec: kmmv1beta1.ModuleSpec{},
-					Selector:   map[string]string{"key": "value"},
-				},
-			}
-
-			clusterList := clusterv1.ManagedClusterList{
-				Items: []clusterv1.ManagedCluster{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:   "default",
-							Labels: map[string]string{"key": "value"},
-						},
-					},
-				},
-			}
-
-			ctx := context.Background()
-
-			gomock.InOrder(
-				clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-					func(_ interface{}, list *clusterv1.ManagedClusterList, _ ...interface{}) error {
-						list.Items = clusterList.Items
-						return nil
-					},
-				),
-			)
-
-			c := NewClusterAPI(clnt, mockKM, nil, nil, "")
-
-			res, err := c.SelectedManagedClusters(ctx, mcm)
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(res).To(Equal(&clusterList))
-		})
-
-		It("should return the respective error when the client List request fails", func() {
-			ctx := context.Background()
-
-			gomock.InOrder(
-				clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(errors.New("generic-error")),
-			)
-
-			c := NewClusterAPI(clnt, mockKM, nil, nil, "")
-
-			res, err := c.SelectedManagedClusters(ctx, &hubv1beta1.ManagedClusterModule{})
-
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("generic-error"))
-			Expect(res.Items).To(BeEmpty())
-		})
-	})
-
-	var _ = Describe("BuildAndSign", func() {
-		const (
-			imageName = "test-image"
-
-			kernelVersion = "1.2.3"
+			),
 		)
 
-		var (
-			mld = api.ModuleLoaderData{
-				ContainerImage: imageName,
-				KernelVersion:  kernelVersion,
-			}
+		res, err := c.RequestedManagedClusterModule(ctx, nsn)
 
-			mcm = &hubv1beta1.ManagedClusterModule{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      mcmName,
-					Namespace: namespace,
-				},
-				Spec: hubv1beta1.ManagedClusterModuleSpec{
-					ModuleSpec: kmmv1beta1.ModuleSpec{},
-					Selector:   map[string]string{"key": "value"},
-				},
-			}
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(Equal(mcm))
+	})
 
-			clusterList = clusterv1.ManagedClusterList{
-				Items: []clusterv1.ManagedCluster{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:   "default",
-							Labels: map[string]string{"key": "value"},
-						},
-						Status: clusterv1.ManagedClusterStatus{
-							ClusterClaims: []clusterv1.ManagedClusterClaim{
-								{
-									Name:  constants.KernelVersionsClusterClaimName,
-									Value: kernelVersion,
-								},
+	It("should return the respective error when the client Get request fails", func() {
+		nsn := types.NamespacedName{
+			Name:      mcmName,
+			Namespace: namespace,
+		}
+
+		ctx := context.Background()
+
+		gomock.InOrder(
+			clnt.EXPECT().Get(ctx, nsn, gomock.Any()).Return(errors.New("generic-error")),
+		)
+
+		res, err := c.RequestedManagedClusterModule(ctx, nsn)
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("generic-error"))
+		Expect(res).To(BeNil())
+	})
+})
+
+var _ = Describe("SelectedManagedClusters", func() {
+	var c ClusterAPI
+
+	BeforeEach(func() {
+		c = NewClusterAPI(clnt, mockKM, nil, nil, "")
+	})
+
+	It("should return the ManagedClusters matching the ManagedClusterModule selector", func() {
+		mcm := &hubv1beta1.ManagedClusterModule{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      mcmName,
+				Namespace: namespace,
+			},
+			Spec: hubv1beta1.ManagedClusterModuleSpec{
+				ModuleSpec: kmmv1beta1.ModuleSpec{},
+				Selector:   map[string]string{"key": "value"},
+			},
+		}
+
+		clusterList := clusterv1.ManagedClusterList{
+			Items: []clusterv1.ManagedCluster{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "default",
+						Labels: map[string]string{"key": "value"},
+					},
+				},
+			},
+		}
+
+		ctx := context.Background()
+
+		gomock.InOrder(
+			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ interface{}, list *clusterv1.ManagedClusterList, _ ...interface{}) error {
+					list.Items = clusterList.Items
+					return nil
+				},
+			),
+		)
+
+		res, err := c.SelectedManagedClusters(ctx, mcm)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(res).To(Equal(&clusterList))
+	})
+
+	It("should return the respective error when the client List request fails", func() {
+		ctx := context.Background()
+
+		gomock.InOrder(
+			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(errors.New("generic-error")),
+		)
+
+		res, err := c.SelectedManagedClusters(ctx, &hubv1beta1.ManagedClusterModule{})
+
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("generic-error"))
+		Expect(res.Items).To(BeEmpty())
+	})
+})
+
+var _ = Describe("BuildAndSign", func() {
+	const (
+		imageName = "test-image"
+
+		kernelVersion = "1.2.3"
+	)
+
+	var c ClusterAPI
+
+	BeforeEach(func() {
+		c = NewClusterAPI(clnt, mockKM, mockBM, mockSM, namespace)
+	})
+
+	var (
+		mld = api.ModuleLoaderData{
+			ContainerImage: imageName,
+			KernelVersion:  kernelVersion,
+		}
+
+		mcm = &hubv1beta1.ManagedClusterModule{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      mcmName,
+				Namespace: namespace,
+			},
+			Spec: hubv1beta1.ManagedClusterModuleSpec{
+				ModuleSpec: kmmv1beta1.ModuleSpec{},
+				Selector:   map[string]string{"key": "value"},
+			},
+		}
+
+		clusterList = clusterv1.ManagedClusterList{
+			Items: []clusterv1.ManagedCluster{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "default",
+						Labels: map[string]string{"key": "value"},
+					},
+					Status: clusterv1.ManagedClusterStatus{
+						ClusterClaims: []clusterv1.ManagedClusterClaim{
+							{
+								Name:  constants.KernelVersionsClusterClaimName,
+								Value: kernelVersion,
 							},
 						},
 					},
 				},
-			}
+			},
+		}
 
-			mod = kmmv1beta1.Module{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      mcm.Name,
-					Namespace: namespace,
-				},
-				Spec: mcm.Spec.ModuleSpec,
-			}
+		mod = kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      mcm.Name,
+				Namespace: namespace,
+			},
+			Spec: mcm.Spec.ModuleSpec,
+		}
 
-			ctx = context.Background()
+		ctx = context.Background()
+	)
+
+	It("should do nothing when no kernel mappings are found", func() {
+		gomock.InOrder(
+			mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(nil, errors.New("generic-error")),
 		)
 
-		It("should do nothing when no kernel mappings are found", func() {
-			gomock.InOrder(
-				mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(nil, errors.New("generic-error")),
-			)
+		completed, err := c.BuildAndSign(ctx, *mcm, clusterList.Items[0])
 
-			c := NewClusterAPI(clnt, mockKM, mockBM, mockSM, namespace)
-
-			completed, err := c.BuildAndSign(ctx, *mcm, clusterList.Items[0])
-			Expect(err).ToNot(HaveOccurred())
-			Expect(completed).To(BeFalse())
-		})
-
-		It("should return an error when ClusterClaims are not found or empty", func() {
-			clusterList := clusterv1.ManagedClusterList{
-				Items: []clusterv1.ManagedCluster{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:   "default",
-							Labels: map[string]string{"key": "value"},
-						},
-					},
-				},
-			}
-
-			c := NewClusterAPI(clnt, mockKM, mockBM, mockSM, namespace)
-
-			completed, err := c.BuildAndSign(ctx, *mcm, clusterList.Items[0])
-			Expect(err).To(HaveOccurred())
-			Expect(completed).To(BeFalse())
-		})
-
-		It("should do nothing when Build and Sign are not needed", func() {
-			gomock.InOrder(
-				mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil),
-				mockBM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(false, nil),
-				mockSM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(false, nil),
-			)
-
-			c := NewClusterAPI(clnt, mockKM, mockBM, mockSM, namespace)
-
-			completed, err := c.BuildAndSign(ctx, *mcm, clusterList.Items[0])
-			Expect(err).ToNot(HaveOccurred())
-			Expect(completed).To(BeTrue())
-		})
-
-		It("should run build sync if needed", func() {
-			gomock.InOrder(
-				mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil),
-				mockBM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
-				mockBM.EXPECT().Sync(gomock.Any(), &mld, true, mcm).Return(buildutils.Status(buildutils.StatusCompleted), nil),
-				mockSM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(false, nil),
-			)
-
-			c := NewClusterAPI(clnt, mockKM, mockBM, mockSM, namespace)
-
-			completed, err := c.BuildAndSign(ctx, *mcm, clusterList.Items[0])
-			Expect(err).ToNot(HaveOccurred())
-			Expect(completed).To(BeTrue())
-		})
-
-		It("should return an error when build sync errors", func() {
-			gomock.InOrder(
-				mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil),
-				mockBM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
-				mockBM.EXPECT().Sync(gomock.Any(), &mld, true, mcm).Return(buildutils.Status(""), errors.New("test-error")),
-			)
-
-			c := NewClusterAPI(clnt, mockKM, mockBM, mockSM, namespace)
-
-			completed, err := c.BuildAndSign(ctx, *mcm, clusterList.Items[0])
-			Expect(err).To(HaveOccurred())
-			Expect(completed).To(BeFalse())
-		})
-
-		It("should run sign sync if needed", func() {
-			gomock.InOrder(
-				mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil),
-				mockBM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(false, nil),
-				mockSM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
-				mockSM.EXPECT().Sync(gomock.Any(), &mld, "", true, mcm).Return(buildutils.Status(buildutils.StatusInProgress), nil),
-			)
-
-			c := NewClusterAPI(clnt, mockKM, mockBM, mockSM, namespace)
-
-			completed, err := c.BuildAndSign(ctx, *mcm, clusterList.Items[0])
-			Expect(err).ToNot(HaveOccurred())
-			Expect(completed).To(BeFalse())
-		})
-
-		It("should return an error when sign sync errors", func() {
-			gomock.InOrder(
-				mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil),
-				mockBM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(false, nil),
-				mockSM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
-				mockSM.EXPECT().Sync(gomock.Any(), &mld, "", true, mcm).Return(buildutils.Status(""), errors.New("test-error")),
-			)
-
-			c := NewClusterAPI(clnt, mockKM, mockBM, mockSM, namespace)
-
-			completed, err := c.BuildAndSign(ctx, *mcm, clusterList.Items[0])
-			Expect(err).To(HaveOccurred())
-			Expect(completed).To(BeFalse())
-		})
-
-		It("should not run sign sync when build sync does not complete", func() {
-			gomock.InOrder(
-				mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil),
-				mockBM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
-				mockBM.EXPECT().Sync(gomock.Any(), &mld, true, mcm).Return(buildutils.Status(buildutils.StatusInProgress), nil),
-			)
-
-			c := NewClusterAPI(clnt, mockKM, mockBM, mockSM, namespace)
-
-			completed, err := c.BuildAndSign(ctx, *mcm, clusterList.Items[0])
-			Expect(err).ToNot(HaveOccurred())
-			Expect(completed).To(BeFalse())
-		})
-
-		It("should run both build sync and sign sync when build is completed", func() {
-			gomock.InOrder(
-				mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil),
-				mockBM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
-				mockBM.EXPECT().Sync(gomock.Any(), &mld, true, mcm).Return(buildutils.Status(buildutils.StatusCompleted), nil),
-				mockSM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
-				mockSM.EXPECT().Sync(gomock.Any(), &mld, "", true, mcm).Return(buildutils.Status(buildutils.StatusCompleted), nil),
-			)
-
-			c := NewClusterAPI(clnt, mockKM, mockBM, mockSM, namespace)
-
-			completed, err := c.BuildAndSign(ctx, *mcm, clusterList.Items[0])
-			Expect(err).ToNot(HaveOccurred())
-			Expect(completed).To(BeTrue())
-		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(completed).To(BeFalse())
 	})
 
-	var _ = Describe("GarbageCollectBuilds", func() {
-		It("should return the deleted build names when garbage collection succeeds", func() {
-			mcm := hubv1beta1.ManagedClusterModule{
-				ObjectMeta: metav1.ObjectMeta{Name: mcmName},
-			}
+	It("should return an error when ClusterClaims are not found or empty", func() {
+		clusterList := clusterv1.ManagedClusterList{
+			Items: []clusterv1.ManagedCluster{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "default",
+						Labels: map[string]string{"key": "value"},
+					},
+				},
+			},
+		}
 
-			collectedBuilds := []string{"test-build"}
+		completed, err := c.BuildAndSign(ctx, *mcm, clusterList.Items[0])
 
-			ctx := context.Background()
+		Expect(err).To(HaveOccurred())
+		Expect(completed).To(BeFalse())
+	})
 
-			gomock.InOrder(
-				mockBM.EXPECT().GarbageCollect(ctx, mcm.Name, namespace, &mcm).Return(collectedBuilds, nil),
-			)
+	It("should do nothing when Build and Sign are not needed", func() {
+		gomock.InOrder(
+			mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil),
+			mockBM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(false, nil),
+			mockSM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(false, nil),
+		)
 
-			c := NewClusterAPI(clnt, nil, mockBM, nil, namespace)
+		completed, err := c.BuildAndSign(ctx, *mcm, clusterList.Items[0])
 
-			collected, err := c.GarbageCollectBuilds(ctx, mcm)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(completed).To(BeTrue())
+	})
 
-			Expect(err).ToNot(HaveOccurred())
-			Expect(collected).To(Equal(collectedBuilds))
-		})
+	It("should run build sync if needed", func() {
+		gomock.InOrder(
+			mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil),
+			mockBM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
+			mockBM.EXPECT().Sync(gomock.Any(), &mld, true, mcm).Return(buildutils.Status(buildutils.StatusCompleted), nil),
+			mockSM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(false, nil),
+		)
 
-		It("should return an error when garbage collection fails", func() {
-			mcm := hubv1beta1.ManagedClusterModule{
-				ObjectMeta: metav1.ObjectMeta{Name: mcmName},
-			}
-			ctx := context.Background()
+		completed, err := c.BuildAndSign(ctx, *mcm, clusterList.Items[0])
 
-			gomock.InOrder(
-				mockBM.EXPECT().GarbageCollect(ctx, mcm.Name, namespace, &mcm).Return(nil, errors.New("test")),
-			)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(completed).To(BeTrue())
+	})
 
-			c := NewClusterAPI(clnt, nil, mockBM, nil, namespace)
+	It("should return an error when build sync errors", func() {
+		gomock.InOrder(
+			mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil),
+			mockBM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
+			mockBM.EXPECT().Sync(gomock.Any(), &mld, true, mcm).Return(buildutils.Status(""), errors.New("test-error")),
+		)
 
-			_, err := c.GarbageCollectBuilds(ctx, mcm)
+		completed, err := c.BuildAndSign(ctx, *mcm, clusterList.Items[0])
 
-			Expect(err).To(HaveOccurred())
-		})
+		Expect(err).To(HaveOccurred())
+		Expect(completed).To(BeFalse())
+	})
+
+	It("should run sign sync if needed", func() {
+		gomock.InOrder(
+			mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil),
+			mockBM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(false, nil),
+			mockSM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
+			mockSM.EXPECT().Sync(gomock.Any(), &mld, "", true, mcm).Return(buildutils.Status(buildutils.StatusInProgress), nil),
+		)
+
+		completed, err := c.BuildAndSign(ctx, *mcm, clusterList.Items[0])
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(completed).To(BeFalse())
+	})
+
+	It("should return an error when sign sync errors", func() {
+		gomock.InOrder(
+			mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil),
+			mockBM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(false, nil),
+			mockSM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
+			mockSM.EXPECT().Sync(gomock.Any(), &mld, "", true, mcm).Return(buildutils.Status(""), errors.New("test-error")),
+		)
+
+		completed, err := c.BuildAndSign(ctx, *mcm, clusterList.Items[0])
+
+		Expect(err).To(HaveOccurred())
+		Expect(completed).To(BeFalse())
+	})
+
+	It("should not run sign sync when build sync does not complete", func() {
+		gomock.InOrder(
+			mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil),
+			mockBM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
+			mockBM.EXPECT().Sync(gomock.Any(), &mld, true, mcm).Return(buildutils.Status(buildutils.StatusInProgress), nil),
+		)
+
+		completed, err := c.BuildAndSign(ctx, *mcm, clusterList.Items[0])
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(completed).To(BeFalse())
+	})
+
+	It("should run both build sync and sign sync when build is completed", func() {
+		gomock.InOrder(
+			mockKM.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil),
+			mockBM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
+			mockBM.EXPECT().Sync(gomock.Any(), &mld, true, mcm).Return(buildutils.Status(buildutils.StatusCompleted), nil),
+			mockSM.EXPECT().ShouldSync(gomock.Any(), &mld).Return(true, nil),
+			mockSM.EXPECT().Sync(gomock.Any(), &mld, "", true, mcm).Return(buildutils.Status(buildutils.StatusCompleted), nil),
+		)
+
+		completed, err := c.BuildAndSign(ctx, *mcm, clusterList.Items[0])
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(completed).To(BeTrue())
+	})
+})
+
+var _ = Describe("GarbageCollectBuildsAndSigns", func() {
+	var c ClusterAPI
+
+	BeforeEach(func() {
+		c = NewClusterAPI(clnt, nil, mockBM, mockSM, namespace)
+	})
+
+	DescribeTable("return deleted builds and signs if no failure", func(buildsToDeleteFound, signsToDeleteFound bool) {
+		deletedBuilds := []string{}
+		deletedSigns := []string{}
+		if buildsToDeleteFound {
+			deletedBuilds = append(deletedBuilds, "test-build")
+		}
+		if signsToDeleteFound {
+			deletedSigns = append(deletedSigns, "test-sign")
+		}
+		expectedCollected := append(deletedBuilds, deletedSigns...)
+		mcm := hubv1beta1.ManagedClusterModule{
+			ObjectMeta: metav1.ObjectMeta{Name: mcmName},
+		}
+		ctx := context.Background()
+
+		gomock.InOrder(
+			mockBM.EXPECT().GarbageCollect(ctx, mcm.Name, namespace, &mcm).Return(deletedBuilds, nil),
+			mockSM.EXPECT().GarbageCollect(ctx, mcm.Name, namespace, &mcm).Return(deletedSigns, nil),
+		)
+
+		collected, err := c.GarbageCollectBuildsAndSigns(ctx, mcm)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(collected).To(Equal(expectedCollected))
+	},
+		Entry("builds to delete found, signs to delete not found", true, false),
+		Entry("builds to delete not found, signs to delete found", false, true),
+		Entry("builds to delete found, signs to delete found", true, true),
+		Entry("builds to delete not found, signs to delete not found", true, true),
+	)
+
+	It("should return an error when builds garbage collection fails", func() {
+		mcm := hubv1beta1.ManagedClusterModule{
+			ObjectMeta: metav1.ObjectMeta{Name: mcmName},
+		}
+		ctx := context.Background()
+		collectedBuilds := []string{"test-build"}
+
+		gomock.InOrder(
+			mockBM.EXPECT().GarbageCollect(ctx, mcm.Name, namespace, &mcm).Return(collectedBuilds, nil),
+			mockSM.EXPECT().GarbageCollect(ctx, mcm.Name, namespace, &mcm).Return(nil, errors.New("test")),
+		)
+
+		collected, err := c.GarbageCollectBuildsAndSigns(ctx, mcm)
+
+		Expect(err).To(HaveOccurred())
+		Expect(collected).To(BeNil())
+	})
+
+	It("should return an error when signs garbage collection fails", func() {
+		mcm := hubv1beta1.ManagedClusterModule{
+			ObjectMeta: metav1.ObjectMeta{Name: mcmName},
+		}
+		ctx := context.Background()
+
+		gomock.InOrder(
+			mockBM.EXPECT().GarbageCollect(ctx, mcm.Name, namespace, &mcm).Return(nil, errors.New("test")),
+		)
+
+		collected, err := c.GarbageCollectBuildsAndSigns(ctx, mcm)
+
+		Expect(err).To(HaveOccurred())
+		Expect(collected).To(BeNil())
 	})
 })

--- a/internal/cluster/mock_cluster.go
+++ b/internal/cluster/mock_cluster.go
@@ -52,19 +52,19 @@ func (mr *MockClusterAPIMockRecorder) BuildAndSign(ctx, mcm, cluster interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildAndSign", reflect.TypeOf((*MockClusterAPI)(nil).BuildAndSign), ctx, mcm, cluster)
 }
 
-// GarbageCollectBuilds mocks base method.
-func (m *MockClusterAPI) GarbageCollectBuilds(ctx context.Context, mcm v1beta1.ManagedClusterModule) ([]string, error) {
+// GarbageCollectBuildsAndSigns mocks base method.
+func (m *MockClusterAPI) GarbageCollectBuildsAndSigns(ctx context.Context, mcm v1beta1.ManagedClusterModule) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GarbageCollectBuilds", ctx, mcm)
+	ret := m.ctrl.Call(m, "GarbageCollectBuildsAndSigns", ctx, mcm)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GarbageCollectBuilds indicates an expected call of GarbageCollectBuilds.
-func (mr *MockClusterAPIMockRecorder) GarbageCollectBuilds(ctx, mcm interface{}) *gomock.Call {
+// GarbageCollectBuildsAndSigns indicates an expected call of GarbageCollectBuildsAndSigns.
+func (mr *MockClusterAPIMockRecorder) GarbageCollectBuildsAndSigns(ctx, mcm interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollectBuilds", reflect.TypeOf((*MockClusterAPI)(nil).GarbageCollectBuilds), ctx, mcm)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollectBuildsAndSigns", reflect.TypeOf((*MockClusterAPI)(nil).GarbageCollectBuildsAndSigns), ctx, mcm)
 }
 
 // RequestedManagedClusterModule mocks base method.

--- a/internal/cluster/suite_test.go
+++ b/internal/cluster/suite_test.go
@@ -19,22 +19,41 @@ package cluster
 import (
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/test"
 	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/build"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/module"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/sign"
 	//+kubebuilder:scaffold:imports
 )
 
-var scheme *runtime.Scheme
+var (
+	scheme *runtime.Scheme
+	ctrl   *gomock.Controller
+	clnt   *client.MockClient
+	mockKM *module.MockKernelMapper
+	mockBM *build.MockManager
+	mockSM *sign.MockSignManager
+)
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	var err error
-
-	scheme, err = test.TestScheme()
-	Expect(err).NotTo(HaveOccurred())
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		mockKM = module.NewMockKernelMapper(ctrl)
+		mockBM = build.NewMockManager(ctrl)
+		mockSM = sign.NewMockSignManager(ctrl)
+		var err error
+		scheme, err = test.TestScheme()
+		Expect(err).NotTo(HaveOccurred())
+	})
 
 	RunSpecs(t, "Cluster Suite")
 }


### PR DESCRIPTION
Currently only build jobs are garbage collected during hub flow. This PR also adds sign jobs garbage collection, at the same time as build jobs

Fixes [551](https://github.com/rh-ecosystem-edge/kernel-module-management/issues/551)