### PR TITLE
Upgrade to Go 1.19 and ubi9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi8/go-toolset:1.18 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.19 as builder
 
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -25,9 +25,10 @@ COPY .git .git
 ARG TARGET
 
 # Build
+RUN git config --global --add safe.directory ${PWD}
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 make ${TARGET}
 
-FROM registry.access.redhat.com/ubi8/ubi-micro:8.7
+FROM registry.access.redhat.com/ubi9/ubi-micro:9.2
 
 ARG TARGET
 

--- a/Dockerfile.kmm-operator-build
+++ b/Dockerfile.kmm-operator-build
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.18
+FROM registry.ci.openshift.org/openshift/release:golang-1.19
 
 ENV GO111MODULE=on
 ENV GOFLAGS=""
@@ -6,10 +6,9 @@ ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=amd64
 
-RUN yum install -y which
 RUN yum install -y podman docker
 RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2
-RUN curl -L --retry 5 "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.3.0/kustomize_v4.3.0_linux_amd64.tar.gz" | \
+RUN curl -L --retry 5 "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.0.1/kustomize_v5.0.1_linux_amd64.tar.gz" | \
     tar -zx -C /usr/bin
 RUN go install github.com/golang/mock/mockgen@v1.5.0
 RUN curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /tmp/kubectl

--- a/Dockerfile.must-gather
+++ b/Dockerfile.must-gather
@@ -1,6 +1,6 @@
 FROM quay.io/openshift/origin-cli:4.14 as builder
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
 
 RUN microdnf update -y \
     && microdnf install -y tar rsync findutils gzip iproute util-linux \

--- a/Dockerfile.signimage
+++ b/Dockerfile.signimage
@@ -1,9 +1,9 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7 as ksource
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2 as ksource
 
 # install the package that will contain the sign utilities
 RUN ["microdnf", "install", "kernel-devel"]
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.7
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.2
 
 COPY --from=ksource /usr/src/kernels/*/scripts/sign-file /usr/local/bin/
 USER 65534:65534

--- a/ci/kmm-kmod-dockerfile.yaml
+++ b/ci/kmm-kmod-dockerfile.yaml
@@ -21,7 +21,7 @@ data:
 
     RUN KERNEL_SRC_DIR=/lib/modules/${KERNEL_VERSION}/build make all
 
-    FROM registry.redhat.io/ubi8/ubi-minimal
+    FROM registry.redhat.io/ubi9/ubi-minimal
 
     ARG KERNEL_VERSION
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rh-ecosystem-edge/kernel-module-management
 
-go 1.18
+go 1.19
 
 require (
 	github.com/a8m/envsubst v1.4.2


### PR DESCRIPTION
Make Skipper install a more recent kustomize.

Requires https://github.com/openshift/release/pull/39411

/cc @mresvanis @yevgeny-shnaidman 