### PR TITLE
Adding OCP builds filtering by owner

### DIFF
--- a/internal/build/ocpbuild/manager.go
+++ b/internal/build/ocpbuild/manager.go
@@ -43,7 +43,7 @@ func NewManager(
 }
 
 func (m *manager) GarbageCollect(ctx context.Context, modName, namespace string, owner metav1.Object) ([]string, error) {
-	moduleBuilds, err := m.ocpBuildsHelper.GetModuleOCPBuilds(ctx, modName, namespace)
+	moduleBuilds, err := m.ocpBuildsHelper.GetModuleOCPBuilds(ctx, modName, namespace, owner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get OCP builds for module's builds %s: %v", modName, err)
 	}
@@ -100,7 +100,7 @@ func (m *manager) Sync(
 		return "", fmt.Errorf("could not make Build template: %v", err)
 	}
 
-	build, err := m.ocpBuildsHelper.GetModuleOCPBuildByKernel(ctx, mld)
+	build, err := m.ocpBuildsHelper.GetModuleOCPBuildByKernel(ctx, mld, owner)
 	if err != nil {
 		if !errors.Is(err, ocpbuildutils.ErrNoMatchingBuild) {
 			return "", fmt.Errorf("error getting the build: %v", err)

--- a/internal/build/ocpbuild/manager_test.go
+++ b/internal/build/ocpbuild/manager_test.go
@@ -184,7 +184,7 @@ var _ = Describe("Sync", func() {
 
 		gomock.InOrder(
 			mockMaker.EXPECT().MakeBuildTemplate(ctx, &mld, true, mld.Owner).Return(&b, nil),
-			mockOCPBuildsHelper.EXPECT().GetModuleOCPBuildByKernel(ctx, &mld).Return(nil, ocpbuild.ErrNoMatchingBuild),
+			mockOCPBuildsHelper.EXPECT().GetModuleOCPBuildByKernel(ctx, &mld, nil).Return(nil, ocpbuild.ErrNoMatchingBuild),
 			mockKubeClient.EXPECT().Create(ctx, &b),
 		)
 
@@ -226,7 +226,7 @@ var _ = Describe("Sync", func() {
 
 			gomock.InOrder(
 				mockMaker.EXPECT().MakeBuildTemplate(ctx, &mld, true, mld.Owner).Return(&build, nil),
-				mockOCPBuildsHelper.EXPECT().GetModuleOCPBuildByKernel(ctx, &mld).Return(&build, nil),
+				mockOCPBuildsHelper.EXPECT().GetModuleOCPBuildByKernel(ctx, &mld, mld.Owner).Return(&build, nil),
 			)
 
 			status, err := m.Sync(ctx, &mld, true, mld.Owner)
@@ -269,7 +269,7 @@ var _ = Describe("GarbageCollect", func() {
 	ctx := context.Background()
 
 	It("GetModuleBuilds failed", func() {
-		mockOCPBuildsHelper.EXPECT().GetModuleOCPBuilds(ctx, moduleName, namespace).Return(nil, fmt.Errorf("some error"))
+		mockOCPBuildsHelper.EXPECT().GetModuleOCPBuilds(ctx, moduleName, namespace, nil).Return(nil, fmt.Errorf("some error"))
 
 		deleted, err := m.GarbageCollect(ctx, moduleName, namespace, nil)
 
@@ -284,7 +284,7 @@ var _ = Describe("GarbageCollect", func() {
 			},
 		}
 		gomock.InOrder(
-			mockOCPBuildsHelper.EXPECT().GetModuleOCPBuilds(ctx, moduleName, namespace).Return([]buildv1.Build{ocpBuild}, nil),
+			mockOCPBuildsHelper.EXPECT().GetModuleOCPBuilds(ctx, moduleName, namespace, nil).Return([]buildv1.Build{ocpBuild}, nil),
 			mockOCPBuildsHelper.EXPECT().DeleteOCPBuild(ctx, &ocpBuild).Return(fmt.Errorf("some error")),
 		)
 		deleted, err := m.GarbageCollect(ctx, moduleName, namespace, nil)
@@ -305,7 +305,7 @@ var _ = Describe("GarbageCollect", func() {
 					Phase: buildPhase2,
 				},
 			}
-			mockOCPBuildsHelper.EXPECT().GetModuleOCPBuilds(ctx, moduleName, namespace).Return([]buildv1.Build{ocpBuild1, ocpBuild2}, nil)
+			mockOCPBuildsHelper.EXPECT().GetModuleOCPBuilds(ctx, moduleName, namespace, nil).Return([]buildv1.Build{ocpBuild1, ocpBuild2}, nil)
 			if buildPhase1 == buildv1.BuildPhaseComplete {
 				mockOCPBuildsHelper.EXPECT().DeleteOCPBuild(ctx, &ocpBuild1).Return(nil)
 			}

--- a/internal/sign/ocpbuild/manager.go
+++ b/internal/sign/ocpbuild/manager.go
@@ -43,7 +43,7 @@ func NewManager(
 }
 
 func (m *manager) GarbageCollect(ctx context.Context, modName, namespace string, owner metav1.Object) ([]string, error) {
-	moduleSigns, err := m.ocpBuildsHelper.GetModuleOCPBuilds(ctx, modName, namespace)
+	moduleSigns, err := m.ocpBuildsHelper.GetModuleOCPBuilds(ctx, modName, namespace, owner)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get OCP builds for module's signs %s: %v", modName, err)
 	}
@@ -90,7 +90,7 @@ func (m *manager) Sync(
 		return "", fmt.Errorf("could not make Build template: %v", err)
 	}
 
-	build, err := m.ocpBuildsHelper.GetModuleOCPBuildByKernel(ctx, mld)
+	build, err := m.ocpBuildsHelper.GetModuleOCPBuildByKernel(ctx, mld, owner)
 	if err != nil {
 		if !errors.Is(err, ocpbuildutils.ErrNoMatchingBuild) {
 			return "", fmt.Errorf("error getting the build: %v", err)

--- a/internal/sign/ocpbuild/manager_test.go
+++ b/internal/sign/ocpbuild/manager_test.go
@@ -174,7 +174,7 @@ var _ = Describe("Sync", func() {
 
 		gomock.InOrder(
 			mockMaker.EXPECT().MakeBuildTemplate(ctx, &mld, unsignedImage, true, mld.Owner).Return(&b, nil),
-			mockOCPBuildsHelper.EXPECT().GetModuleOCPBuildByKernel(ctx, &mld).Return(nil, ocpbuild.ErrNoMatchingBuild),
+			mockOCPBuildsHelper.EXPECT().GetModuleOCPBuildByKernel(ctx, &mld, mld.Owner).Return(nil, ocpbuild.ErrNoMatchingBuild),
 			mockKubeClient.EXPECT().Create(ctx, &b),
 		)
 
@@ -208,7 +208,7 @@ var _ = Describe("Sync", func() {
 
 			gomock.InOrder(
 				mockMaker.EXPECT().MakeBuildTemplate(ctx, &mld, unsignedImage, true, mld.Owner).Return(&build, nil),
-				mockOCPBuildsHelper.EXPECT().GetModuleOCPBuildByKernel(ctx, &mld).Return(&build, nil),
+				mockOCPBuildsHelper.EXPECT().GetModuleOCPBuildByKernel(ctx, &mld, mld.Owner).Return(&build, nil),
 			)
 
 			status, err := mgr.Sync(ctx, &mld, unsignedImage, true, mld.Owner)
@@ -251,7 +251,7 @@ var _ = Describe("GarbageCollect", func() {
 	ctx := context.Background()
 
 	It("GetModuleOCPBuilds failed", func() {
-		mockOCPBuildsHelper.EXPECT().GetModuleOCPBuilds(ctx, moduleName, namespace).Return(nil, fmt.Errorf("some error"))
+		mockOCPBuildsHelper.EXPECT().GetModuleOCPBuilds(ctx, moduleName, namespace, nil).Return(nil, fmt.Errorf("some error"))
 
 		deleted, err := m.GarbageCollect(ctx, moduleName, namespace, nil)
 
@@ -266,7 +266,7 @@ var _ = Describe("GarbageCollect", func() {
 			},
 		}
 		gomock.InOrder(
-			mockOCPBuildsHelper.EXPECT().GetModuleOCPBuilds(ctx, moduleName, namespace).Return([]buildv1.Build{ocpBuild}, nil),
+			mockOCPBuildsHelper.EXPECT().GetModuleOCPBuilds(ctx, moduleName, namespace, nil).Return([]buildv1.Build{ocpBuild}, nil),
 			mockOCPBuildsHelper.EXPECT().DeleteOCPBuild(ctx, &ocpBuild).Return(fmt.Errorf("some error")),
 		)
 		deleted, err := m.GarbageCollect(ctx, moduleName, namespace, nil)
@@ -287,7 +287,7 @@ var _ = Describe("GarbageCollect", func() {
 					Phase: buildPhase2,
 				},
 			}
-			mockOCPBuildsHelper.EXPECT().GetModuleOCPBuilds(ctx, moduleName, namespace).Return([]buildv1.Build{ocpBuild1, ocpBuild2}, nil)
+			mockOCPBuildsHelper.EXPECT().GetModuleOCPBuilds(ctx, moduleName, namespace, nil).Return([]buildv1.Build{ocpBuild1, ocpBuild2}, nil)
 			if buildPhase1 == buildv1.BuildPhaseComplete {
 				mockOCPBuildsHelper.EXPECT().DeleteOCPBuild(ctx, &ocpBuild1).Return(nil)
 			}

--- a/internal/utils/ocpbuild/helper_test.go
+++ b/internal/utils/ocpbuild/helper_test.go
@@ -8,26 +8,36 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	buildv1 "github.com/openshift/api/build/v1"
+	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-var _ = Describe("OCPBuildsHelper_GetBuild", func() {
+var _ = Describe("OCPBuildsHelper_GetModuleOCPBuildByKernel", func() {
 	const (
 		buildType    = "build-type"
 		targetKernel = "target-kernels"
 	)
 
-	var mockKubeClient *client.MockClient
-
-	ctx := context.Background()
+	var (
+		mockKubeClient *client.MockClient
+		osbh           OCPBuildsHelper
+	)
 
 	BeforeEach(func() {
 		ctrl := gomock.NewController(GinkgoT())
 		mockKubeClient = client.NewMockClient(ctrl)
+		osbh = NewOCPBuildsHelper(mockKubeClient, buildType)
+
 	})
+
+	ctx := context.Background()
+	mod := kmmv1beta1.Module{
+		ObjectMeta: metav1.ObjectMeta{Name: "moduleName", Namespace: "moduleNamespace"},
+	}
 
 	It("should return an error if an error occurred", func() {
 		mockKubeClient.
@@ -35,17 +45,28 @@ var _ = Describe("OCPBuildsHelper_GetBuild", func() {
 			List(ctx, &buildv1.BuildList{}, gomock.Any(), gomock.Any()).
 			Return(errors.New("random error"))
 
-		osbh := NewOCPBuildsHelper(mockKubeClient, buildType)
 		mld := api.ModuleLoaderData{
 			KernelVersion: targetKernel,
 		}
 
-		_, err := osbh.GetModuleOCPBuildByKernel(ctx, &mld)
+		_, err := osbh.GetModuleOCPBuildByKernel(ctx, &mld, &mod)
 
 		Expect(err).To(HaveOccurred())
 	})
 
-	It("should return an error if there are two Builids with the same labels", func() {
+	It("should return an error if there are two Builds with the same labels and owner", func() {
+		build1 := buildv1.Build{
+			ObjectMeta: metav1.ObjectMeta{Name: "buildName", Namespace: "moduleNamespace"},
+		}
+		build2 := buildv1.Build{
+			ObjectMeta: metav1.ObjectMeta{Name: "buildName", Namespace: "moduleNamespace"},
+		}
+
+		err := controllerutil.SetControllerReference(&mod, &build1, scheme)
+		Expect(err).NotTo(HaveOccurred())
+		err = controllerutil.SetControllerReference(&mod, &build2, scheme)
+		Expect(err).NotTo(HaveOccurred())
+
 		mockKubeClient.
 			EXPECT().
 			List(ctx, &buildv1.BuildList{}, gomock.Any(), gomock.Any()).
@@ -53,36 +74,155 @@ var _ = Describe("OCPBuildsHelper_GetBuild", func() {
 				bcs.Items = make([]buildv1.Build, 2)
 			})
 
-		osbh := NewOCPBuildsHelper(mockKubeClient, buildType)
 		mld := api.ModuleLoaderData{
 			KernelVersion: targetKernel,
 		}
 
-		_, err := osbh.GetModuleOCPBuildByKernel(ctx, &mld)
+		_, err = osbh.GetModuleOCPBuildByKernel(ctx, &mld, &mod)
 
 		Expect(err).To(HaveOccurred())
 	})
 
 	It("should work as expected", func() {
-		bc := &buildv1.Build{
-			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+		build := buildv1.Build{
+			ObjectMeta: metav1.ObjectMeta{Name: "buildName", Namespace: "moduleNamespace"},
 		}
+		err := controllerutil.SetControllerReference(&mod, &build, scheme)
+		Expect(err).NotTo(HaveOccurred())
 
 		mockKubeClient.
 			EXPECT().
 			List(ctx, &buildv1.BuildList{}, gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, bcs *buildv1.BuildList, _ ...ctrlclient.ListOption) {
-				bcs.Items = []buildv1.Build{*bc}
+				bcs.Items = []buildv1.Build{build}
 			})
 
-		osbh := NewOCPBuildsHelper(mockKubeClient, buildType)
 		mld := api.ModuleLoaderData{
 			KernelVersion: targetKernel,
 		}
 
-		res, err := osbh.GetModuleOCPBuildByKernel(ctx, &mld)
+		res, err := osbh.GetModuleOCPBuildByKernel(ctx, &mld, &mod)
 
 		Expect(err).NotTo(HaveOccurred())
-		Expect(res).To(Equal(bc))
+		Expect(res).To(Equal(&build))
+	})
+})
+
+var _ = Describe("OCPBuildsHelper_GetOCPBuilds", func() {
+	const (
+		buildType       = "build-type"
+		moduleName      = "moduleName"
+		moduleNamespace = "moduleNamespace"
+	)
+
+	var (
+		mockKubeClient *client.MockClient
+		osbh           OCPBuildsHelper
+	)
+
+	BeforeEach(func() {
+		ctrl := gomock.NewController(GinkgoT())
+		mockKubeClient = client.NewMockClient(ctrl)
+		osbh = NewOCPBuildsHelper(mockKubeClient, buildType)
+
+	})
+
+	ctx := context.Background()
+	mod := kmmv1beta1.Module{
+		ObjectMeta: metav1.ObjectMeta{Name: moduleName, Namespace: moduleNamespace},
+	}
+
+	It("should return an error if an error occurred", func() {
+		mockKubeClient.
+			EXPECT().
+			List(ctx, &buildv1.BuildList{}, gomock.Any(), gomock.Any()).
+			Return(errors.New("random error"))
+
+		_, err := osbh.GetModuleOCPBuilds(ctx, moduleName, moduleNamespace, &mod)
+
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should work as expected", func() {
+		build1 := buildv1.Build{
+			ObjectMeta: metav1.ObjectMeta{Name: "buildName1", Namespace: moduleNamespace},
+		}
+		build2 := buildv1.Build{
+			ObjectMeta: metav1.ObjectMeta{Name: "buildName2", Namespace: moduleNamespace},
+		}
+		err := controllerutil.SetControllerReference(&mod, &build1, scheme)
+		Expect(err).NotTo(HaveOccurred())
+		err = controllerutil.SetControllerReference(&mod, &build2, scheme)
+		Expect(err).NotTo(HaveOccurred())
+
+		mockKubeClient.
+			EXPECT().
+			List(ctx, &buildv1.BuildList{}, gomock.Any(), gomock.Any()).
+			Do(func(_ context.Context, bcs *buildv1.BuildList, _ ...ctrlclient.ListOption) {
+				bcs.Items = []buildv1.Build{build1, build2}
+			})
+
+		res, err := osbh.GetModuleOCPBuilds(ctx, moduleName, moduleNamespace, &mod)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res[0]).To(Equal(build1))
+		Expect(res[1]).To(Equal(build2))
+	})
+
+	It("zero builds found", func() {
+		mockKubeClient.
+			EXPECT().
+			List(ctx, &buildv1.BuildList{}, gomock.Any(), gomock.Any()).
+			Do(func(_ context.Context, bcs *buildv1.BuildList, _ ...ctrlclient.ListOption) {
+				bcs.Items = []buildv1.Build{}
+			})
+
+		res, err := osbh.GetModuleOCPBuilds(ctx, moduleName, moduleNamespace, &mod)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(res)).To(Equal(0))
+	})
+})
+
+var _ = Describe("OCPBuildsHelper_DeleteOCPBuild", func() {
+	const buildType = "build-type"
+
+	var (
+		ctrl           *gomock.Controller
+		mockKubeClient *client.MockClient
+		osbh           OCPBuildsHelper
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockKubeClient = client.NewMockClient(ctrl)
+		osbh = NewOCPBuildsHelper(mockKubeClient, buildType)
+	})
+
+	ctx := context.Background()
+
+	It("good flow", func() {
+		build := buildv1.Build{}
+		opts := []ctrlclient.DeleteOption{
+			ctrlclient.PropagationPolicy(metav1.DeletePropagationBackground),
+		}
+		mockKubeClient.EXPECT().Delete(ctx, &build, opts).Return(nil)
+
+		err := osbh.DeleteOCPBuild(ctx, &build)
+
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("error flow", func() {
+		build := buildv1.Build{}
+
+		opts := []ctrlclient.DeleteOption{
+			ctrlclient.PropagationPolicy(metav1.DeletePropagationBackground),
+		}
+		mockKubeClient.EXPECT().Delete(ctx, &build, opts).Return(errors.New("random error"))
+
+		err := osbh.DeleteOCPBuild(ctx, &build)
+
+		Expect(err).To(HaveOccurred())
 	})
 })

--- a/internal/utils/ocpbuild/mock_helper.go
+++ b/internal/utils/ocpbuild/mock_helper.go
@@ -11,6 +11,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1 "github.com/openshift/api/build/v1"
 	api "github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
+	v10 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // MockOCPBuildsHelper is a mock of OCPBuildsHelper interface.
@@ -51,31 +52,31 @@ func (mr *MockOCPBuildsHelperMockRecorder) DeleteOCPBuild(ctx, build interface{}
 }
 
 // GetModuleOCPBuildByKernel mocks base method.
-func (m *MockOCPBuildsHelper) GetModuleOCPBuildByKernel(ctx context.Context, mld *api.ModuleLoaderData) (*v1.Build, error) {
+func (m *MockOCPBuildsHelper) GetModuleOCPBuildByKernel(ctx context.Context, mld *api.ModuleLoaderData, owner v10.Object) (*v1.Build, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetModuleOCPBuildByKernel", ctx, mld)
+	ret := m.ctrl.Call(m, "GetModuleOCPBuildByKernel", ctx, mld, owner)
 	ret0, _ := ret[0].(*v1.Build)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetModuleOCPBuildByKernel indicates an expected call of GetModuleOCPBuildByKernel.
-func (mr *MockOCPBuildsHelperMockRecorder) GetModuleOCPBuildByKernel(ctx, mld interface{}) *gomock.Call {
+func (mr *MockOCPBuildsHelperMockRecorder) GetModuleOCPBuildByKernel(ctx, mld, owner interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleOCPBuildByKernel", reflect.TypeOf((*MockOCPBuildsHelper)(nil).GetModuleOCPBuildByKernel), ctx, mld)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleOCPBuildByKernel", reflect.TypeOf((*MockOCPBuildsHelper)(nil).GetModuleOCPBuildByKernel), ctx, mld, owner)
 }
 
 // GetModuleOCPBuilds mocks base method.
-func (m *MockOCPBuildsHelper) GetModuleOCPBuilds(ctx context.Context, moduleName, moduleNamespace string) ([]v1.Build, error) {
+func (m *MockOCPBuildsHelper) GetModuleOCPBuilds(ctx context.Context, moduleName, moduleNamespace string, owner v10.Object) ([]v1.Build, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetModuleOCPBuilds", ctx, moduleName, moduleNamespace)
+	ret := m.ctrl.Call(m, "GetModuleOCPBuilds", ctx, moduleName, moduleNamespace, owner)
 	ret0, _ := ret[0].([]v1.Build)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetModuleOCPBuilds indicates an expected call of GetModuleOCPBuilds.
-func (mr *MockOCPBuildsHelperMockRecorder) GetModuleOCPBuilds(ctx, moduleName, moduleNamespace interface{}) *gomock.Call {
+func (mr *MockOCPBuildsHelperMockRecorder) GetModuleOCPBuilds(ctx, moduleName, moduleNamespace, owner interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleOCPBuilds", reflect.TypeOf((*MockOCPBuildsHelper)(nil).GetModuleOCPBuilds), ctx, moduleName, moduleNamespace)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleOCPBuilds", reflect.TypeOf((*MockOCPBuildsHelper)(nil).GetModuleOCPBuilds), ctx, moduleName, moduleNamespace, owner)
 }

--- a/internal/utils/ocpbuild/suite_test.go
+++ b/internal/utils/ocpbuild/suite_test.go
@@ -21,9 +21,20 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/test"
+	"k8s.io/apimachinery/pkg/runtime"
 )
+
+var scheme *runtime.Scheme
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
+
+	var err error
+
+	scheme, err = test.TestScheme()
+	Expect(err).NotTo(HaveOccurred())
+
 	RunSpecs(t, "Build Suite")
 }


### PR DESCRIPTION
OCP builds are used during KMM sign and build flows. It can be created both by module reconcile flow and preflight flow. This PR adds additional filtering when looking for OCP builds based on module/kernel/type label to also filter by owner