### PR TITLE
Update skipper configuration (#422)

### DIFF
--- a/Dockerfile.kmm-operator-build
+++ b/Dockerfile.kmm-operator-build
@@ -7,14 +7,7 @@ ENV GOOS=linux
 ENV GOARCH=amd64
 
 RUN yum install -y podman docker
-RUN go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.9.2
-RUN curl -L --retry 5 "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.0.1/kustomize_v5.0.1_linux_amd64.tar.gz" | \
-    tar -zx -C /usr/bin
-RUN go install github.com/golang/mock/mockgen@v1.5.0
+RUN go install github.com/golang/mock/mockgen@v1.7.0-rc.1
 RUN curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /tmp/kubectl
 RUN install -o root -g root -m 0755 /tmp/kubectl /usr/local/bin/kubectl
-RUN export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.21.0 \
-    && curl --retry 5 -LO ${OPERATOR_SDK_DL_URL}/operator-sdk_linux_amd64 \
-    && chmod +x operator-sdk_linux_amd64 \
-    && install operator-sdk_linux_amd64 /usr/local/bin/operator-sdk
 COPY --from=quay.io/openshift/origin-cli:latest /usr/bin/oc /usr/bin


### PR DESCRIPTION
1) removing operator-sdk, kustomize and mockgen, since makefile is
   using the once installed under the repo/bin directory
2) update the mockgen version