### PR TITLE
Add common labels to the default overlays

### DIFF
--- a/bundle-hub/manifests/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
+++ b/bundle-hub/manifests/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
@@ -5,6 +5,10 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.12.0
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kmm-hub
+    app.kubernetes.io/name: kmm-hub
+    app.kubernetes.io/part-of: kmm
   name: managedclustermodules.hub.kmm.sigs.x-k8s.io
 spec:
   group: hub.kmm.sigs.x-k8s.io

--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -171,12 +171,18 @@ spec:
         serviceAccountName: kmm-operator-hub-controller-manager
       deployments:
       - label:
+          app.kubernetes.io/component: kmm-hub
+          app.kubernetes.io/name: kmm-hub
+          app.kubernetes.io/part-of: kmm
           control-plane: controller-manager
         name: kmm-operator-hub-controller-manager
         spec:
           replicas: 1
           selector:
             matchLabels:
+              app.kubernetes.io/component: kmm-hub
+              app.kubernetes.io/name: kmm-hub
+              app.kubernetes.io/part-of: kmm
               control-plane: controller-manager
           strategy: {}
           template:
@@ -184,6 +190,9 @@ spec:
               annotations:
                 kubectl.kubernetes.io/default-container: manager
               labels:
+                app.kubernetes.io/component: kmm-hub
+                app.kubernetes.io/name: kmm-hub
+                app.kubernetes.io/part-of: kmm
                 control-plane: controller-manager
             spec:
               containers:

--- a/bundle-hub/manifests/kmm-operator-hub-cluster-ca_v1_configmap.yaml
+++ b/bundle-hub/manifests/kmm-operator-hub-cluster-ca_v1_configmap.yaml
@@ -3,5 +3,8 @@ data: {}
 kind: ConfigMap
 metadata:
   labels:
+    app.kubernetes.io/component: kmm-hub
+    app.kubernetes.io/name: kmm-hub
+    app.kubernetes.io/part-of: kmm
     config.openshift.io/inject-trusted-cabundle: "true"
   name: kmm-operator-hub-cluster-ca

--- a/bundle-hub/manifests/kmm-operator-hub-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle-hub/manifests/kmm-operator-hub-controller-manager-metrics-service_v1_service.yaml
@@ -3,6 +3,9 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
+    app.kubernetes.io/component: kmm-hub
+    app.kubernetes.io/name: kmm-hub
+    app.kubernetes.io/part-of: kmm
     control-plane: controller-manager
   name: kmm-operator-hub-controller-manager-metrics-service
 spec:
@@ -12,6 +15,9 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
+    app.kubernetes.io/component: kmm-hub
+    app.kubernetes.io/name: kmm-hub
+    app.kubernetes.io/part-of: kmm
     control-plane: controller-manager
 status:
   loadBalancer: {}

--- a/bundle-hub/manifests/kmm-operator-hub-manager-config_v1_configmap.yaml
+++ b/bundle-hub/manifests/kmm-operator-hub-manager-config_v1_configmap.yaml
@@ -9,4 +9,8 @@ data:
       resourceID: kmm-hub.sigs.x-k8s.io
 kind: ConfigMap
 metadata:
+  labels:
+    app.kubernetes.io/component: kmm-hub
+    app.kubernetes.io/name: kmm-hub
+    app.kubernetes.io/part-of: kmm
   name: kmm-operator-hub-manager-config

--- a/bundle-hub/manifests/kmm-operator-hub-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle-hub/manifests/kmm-operator-hub-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -2,6 +2,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kmm-hub
+    app.kubernetes.io/name: kmm-hub
+    app.kubernetes.io/part-of: kmm
   name: kmm-operator-hub-metrics-reader
 rules:
 - nonResourceURLs:

--- a/bundle-hub/manifests/kmm-operator-hub-service-ca_v1_configmap.yaml
+++ b/bundle-hub/manifests/kmm-operator-hub-service-ca_v1_configmap.yaml
@@ -4,4 +4,8 @@ kind: ConfigMap
 metadata:
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"
+  labels:
+    app.kubernetes.io/component: kmm-hub
+    app.kubernetes.io/name: kmm-hub
+    app.kubernetes.io/part-of: kmm
   name: kmm-operator-hub-service-ca

--- a/bundle-hub/manifests/kmm-operator-hub-webhook-service_v1_service.yaml
+++ b/bundle-hub/manifests/kmm-operator-hub-webhook-service_v1_service.yaml
@@ -5,12 +5,12 @@ metadata:
     service.beta.openshift.io/serving-cert-secret-name: kmm-operator-hub-webhook-server-cert
   creationTimestamp: null
   labels:
-    app.kubernetes.io/component: webhook
+    app.kubernetes.io/component: kmm-hub
     app.kubernetes.io/created-by: kernel-module-management
     app.kubernetes.io/instance: webhook-service
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: service
-    app.kubernetes.io/part-of: kernel-module-management
+    app.kubernetes.io/name: kmm-hub
+    app.kubernetes.io/part-of: kmm
   name: kmm-operator-hub-webhook-service
 spec:
   ports:
@@ -18,6 +18,9 @@ spec:
     protocol: TCP
     targetPort: 9443
   selector:
+    app.kubernetes.io/component: kmm-hub
+    app.kubernetes.io/name: kmm-hub
+    app.kubernetes.io/part-of: kmm
     control-plane: controller-manager
 status:
   loadBalancer: {}

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -278,12 +278,18 @@ spec:
         serviceAccountName: kmm-operator-controller-manager
       deployments:
       - label:
+          app.kubernetes.io/component: kmm
+          app.kubernetes.io/name: kmm
+          app.kubernetes.io/part-of: kmm
           control-plane: controller-manager
         name: kmm-operator-controller-manager
         spec:
           replicas: 1
           selector:
             matchLabels:
+              app.kubernetes.io/component: kmm
+              app.kubernetes.io/name: kmm
+              app.kubernetes.io/part-of: kmm
               control-plane: controller-manager
           strategy: {}
           template:
@@ -291,6 +297,9 @@ spec:
               annotations:
                 kubectl.kubernetes.io/default-container: manager
               labels:
+                app.kubernetes.io/component: kmm
+                app.kubernetes.io/name: kmm
+                app.kubernetes.io/part-of: kmm
                 control-plane: controller-manager
             spec:
               containers:

--- a/bundle/manifests/kmm-operator-cluster-ca_v1_configmap.yaml
+++ b/bundle/manifests/kmm-operator-cluster-ca_v1_configmap.yaml
@@ -3,5 +3,8 @@ data: {}
 kind: ConfigMap
 metadata:
   labels:
+    app.kubernetes.io/component: kmm
+    app.kubernetes.io/name: kmm
+    app.kubernetes.io/part-of: kmm
     config.openshift.io/inject-trusted-cabundle: "true"
   name: kmm-operator-cluster-ca

--- a/bundle/manifests/kmm-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/kmm-operator-controller-manager-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -2,6 +2,9 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
+    app.kubernetes.io/component: kmm
+    app.kubernetes.io/name: kmm
+    app.kubernetes.io/part-of: kmm
     control-plane: controller-manager
   name: kmm-operator-controller-manager-metrics-monitor
 spec:

--- a/bundle/manifests/kmm-operator-controller-manager-metrics-service_v1_service.yaml
+++ b/bundle/manifests/kmm-operator-controller-manager-metrics-service_v1_service.yaml
@@ -3,6 +3,9 @@ kind: Service
 metadata:
   creationTimestamp: null
   labels:
+    app.kubernetes.io/component: kmm
+    app.kubernetes.io/name: kmm
+    app.kubernetes.io/part-of: kmm
     control-plane: controller-manager
   name: kmm-operator-controller-manager-metrics-service
 spec:
@@ -12,6 +15,9 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
+    app.kubernetes.io/component: kmm
+    app.kubernetes.io/name: kmm
+    app.kubernetes.io/part-of: kmm
     control-plane: controller-manager
 status:
   loadBalancer: {}

--- a/bundle/manifests/kmm-operator-manager-config_v1_configmap.yaml
+++ b/bundle/manifests/kmm-operator-manager-config_v1_configmap.yaml
@@ -9,4 +9,8 @@ data:
       resourceID: kmm.sigs.x-k8s.io
 kind: ConfigMap
 metadata:
+  labels:
+    app.kubernetes.io/component: kmm
+    app.kubernetes.io/name: kmm
+    app.kubernetes.io/part-of: kmm
   name: kmm-operator-manager-config

--- a/bundle/manifests/kmm-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/kmm-operator-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -2,6 +2,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kmm
+    app.kubernetes.io/name: kmm
+    app.kubernetes.io/part-of: kmm
   name: kmm-operator-metrics-reader
 rules:
 - nonResourceURLs:

--- a/bundle/manifests/kmm-operator-prometheus-k8s_rbac.authorization.k8s.io_v1_role.yaml
+++ b/bundle/manifests/kmm-operator-prometheus-k8s_rbac.authorization.k8s.io_v1_role.yaml
@@ -2,6 +2,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kmm
+    app.kubernetes.io/name: kmm
+    app.kubernetes.io/part-of: kmm
   name: kmm-operator-prometheus-k8s
 rules:
 - apiGroups:

--- a/bundle/manifests/kmm-operator-prometheus-k8s_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/kmm-operator-prometheus-k8s_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -2,6 +2,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kmm
+    app.kubernetes.io/name: kmm
+    app.kubernetes.io/part-of: kmm
   name: kmm-operator-prometheus-k8s
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/bundle/manifests/kmm-operator-service-ca_v1_configmap.yaml
+++ b/bundle/manifests/kmm-operator-service-ca_v1_configmap.yaml
@@ -4,4 +4,8 @@ kind: ConfigMap
 metadata:
   annotations:
     service.beta.openshift.io/inject-cabundle: "true"
+  labels:
+    app.kubernetes.io/component: kmm
+    app.kubernetes.io/name: kmm
+    app.kubernetes.io/part-of: kmm
   name: kmm-operator-service-ca

--- a/bundle/manifests/kmm-operator-webhook-service_v1_service.yaml
+++ b/bundle/manifests/kmm-operator-webhook-service_v1_service.yaml
@@ -5,12 +5,12 @@ metadata:
     service.beta.openshift.io/serving-cert-secret-name: kmm-operator-webhook-server-cert
   creationTimestamp: null
   labels:
-    app.kubernetes.io/component: webhook
+    app.kubernetes.io/component: kmm
     app.kubernetes.io/created-by: kernel-module-management
     app.kubernetes.io/instance: webhook-service
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/name: service
-    app.kubernetes.io/part-of: kernel-module-management
+    app.kubernetes.io/name: kmm
+    app.kubernetes.io/part-of: kmm
   name: kmm-operator-webhook-service
 spec:
   ports:
@@ -18,6 +18,9 @@ spec:
     protocol: TCP
     targetPort: 9443
   selector:
+    app.kubernetes.io/component: kmm
+    app.kubernetes.io/name: kmm
+    app.kubernetes.io/part-of: kmm
     control-plane: controller-manager
 status:
   loadBalancer: {}

--- a/bundle/manifests/kmm.sigs.x-k8s.io_modules.yaml
+++ b/bundle/manifests/kmm.sigs.x-k8s.io_modules.yaml
@@ -5,6 +5,10 @@ metadata:
     controller-gen.kubebuilder.io/version: v0.12.0
     service.beta.openshift.io/inject-cabundle: "true"
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kmm
+    app.kubernetes.io/name: kmm
+    app.kubernetes.io/part-of: kmm
   name: modules.kmm.sigs.x-k8s.io
 spec:
   group: kmm.sigs.x-k8s.io

--- a/bundle/manifests/kmm.sigs.x-k8s.io_preflightvalidations.yaml
+++ b/bundle/manifests/kmm.sigs.x-k8s.io_preflightvalidations.yaml
@@ -4,6 +4,10 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kmm
+    app.kubernetes.io/name: kmm
+    app.kubernetes.io/part-of: kmm
   name: preflightvalidations.kmm.sigs.x-k8s.io
 spec:
   group: kmm.sigs.x-k8s.io

--- a/bundle/manifests/kmm.sigs.x-k8s.io_preflightvalidationsocp.yaml
+++ b/bundle/manifests/kmm.sigs.x-k8s.io_preflightvalidationsocp.yaml
@@ -4,6 +4,10 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.12.0
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kmm
+    app.kubernetes.io/name: kmm
+    app.kubernetes.io/part-of: kmm
   name: preflightvalidationsocp.kmm.sigs.x-k8s.io
 spec:
   group: kmm.sigs.x-k8s.io

--- a/config/default-hub/kustomization.yaml
+++ b/config/default-hub/kustomization.yaml
@@ -12,8 +12,10 @@ namespace: openshift-kmm-hub
 namePrefix: kmm-operator-hub-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+commonLabels:
+  app.kubernetes.io/name: kmm-hub
+  app.kubernetes.io/component: kmm-hub
+  app.kubernetes.io/part-of: kmm
 
 resources:
 - ../crd-hub
@@ -30,5 +32,3 @@ patches:
 
 configurations:
   - kustomizeconfig.yaml
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -12,8 +12,10 @@ namespace: openshift-kmm
 namePrefix: kmm-operator-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+commonLabels:
+  app.kubernetes.io/name: kmm
+  app.kubernetes.io/component: kmm
+  app.kubernetes.io/part-of: kmm
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in crd/kustomization.yaml
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.


### PR DESCRIPTION
Label KMM and KMM-Hub resources with different values to avoid selectors from one edition include resources from the other when deployed in the same namespace.
This change was part of https://github.com/kubernetes-sigs/kernel-module-management/commit/6fdc011e2bf230c32a625dfbb742dcca73b0f42f upstream which was unfortunately not backported.

/cc @mresvanis 