### PR TITLE
Upgrade support between v1.02 and v1.1 (#639)

### DIFF
--- a/controllers/mock_module_reconciler.go
+++ b/controllers/mock_module_reconciler.go
@@ -115,31 +115,31 @@ func (mr *MockmoduleReconcilerHelperAPIMockRecorder) handleBuild(ctx, mld interf
 }
 
 // handleDevicePlugin mocks base method.
-func (m *MockmoduleReconcilerHelperAPI) handleDevicePlugin(ctx context.Context, mod *v1beta1.Module) error {
+func (m *MockmoduleReconcilerHelperAPI) handleDevicePlugin(ctx context.Context, mod *v1beta1.Module, existingModuleDS []v1.DaemonSet) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "handleDevicePlugin", ctx, mod)
+	ret := m.ctrl.Call(m, "handleDevicePlugin", ctx, mod, existingModuleDS)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // handleDevicePlugin indicates an expected call of handleDevicePlugin.
-func (mr *MockmoduleReconcilerHelperAPIMockRecorder) handleDevicePlugin(ctx, mod interface{}) *gomock.Call {
+func (mr *MockmoduleReconcilerHelperAPIMockRecorder) handleDevicePlugin(ctx, mod, existingModuleDS interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleDevicePlugin", reflect.TypeOf((*MockmoduleReconcilerHelperAPI)(nil).handleDevicePlugin), ctx, mod)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleDevicePlugin", reflect.TypeOf((*MockmoduleReconcilerHelperAPI)(nil).handleDevicePlugin), ctx, mod, existingModuleDS)
 }
 
 // handleDriverContainer mocks base method.
-func (m *MockmoduleReconcilerHelperAPI) handleDriverContainer(ctx context.Context, mld *api.ModuleLoaderData) error {
+func (m *MockmoduleReconcilerHelperAPI) handleDriverContainer(ctx context.Context, mld *api.ModuleLoaderData, existingModuleDS []v1.DaemonSet) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "handleDriverContainer", ctx, mld)
+	ret := m.ctrl.Call(m, "handleDriverContainer", ctx, mld, existingModuleDS)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // handleDriverContainer indicates an expected call of handleDriverContainer.
-func (mr *MockmoduleReconcilerHelperAPIMockRecorder) handleDriverContainer(ctx, mld interface{}) *gomock.Call {
+func (mr *MockmoduleReconcilerHelperAPIMockRecorder) handleDriverContainer(ctx, mld, existingModuleDS interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleDriverContainer", reflect.TypeOf((*MockmoduleReconcilerHelperAPI)(nil).handleDriverContainer), ctx, mld)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleDriverContainer", reflect.TypeOf((*MockmoduleReconcilerHelperAPI)(nil).handleDriverContainer), ctx, mld, existingModuleDS)
 }
 
 // handleSigning mocks base method.

--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -21,8 +21,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/mitchellh/hashstructure/v2"
 	buildv1 "github.com/openshift/api/build/v1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	v1 "k8s.io/api/core/v1"
@@ -126,6 +126,11 @@ func (r *ModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return res, fmt.Errorf("could get kernel mappings and nodes for modules %s: %w", mod.Name, err)
 	}
 
+	existingModuleDS, err := r.daemonAPI.GetModuleDaemonSets(ctx, mod.Name, mod.Namespace)
+	if err != nil {
+		return res, fmt.Errorf("could not get DaemonSets for module %s, namespace %s: %v", mod.Name, mod.Namespace, err)
+	}
+
 	for kernelVersion, mld := range mldMappings {
 		completedSuccessfully, err := r.reconHelperAPI.handleBuild(ctx, mld)
 		if err != nil {
@@ -149,21 +154,16 @@ func (r *ModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			continue
 		}
 
-		err = r.reconHelperAPI.handleDriverContainer(ctx, mld)
+		err = r.reconHelperAPI.handleDriverContainer(ctx, mld, existingModuleDS)
 		if err != nil {
 			return res, fmt.Errorf("failed to handle driver container for kernel version %s: %v", kernelVersion, err)
 		}
 	}
 
 	logger.Info("Handle device plugin")
-	err = r.reconHelperAPI.handleDevicePlugin(ctx, mod)
+	err = r.reconHelperAPI.handleDevicePlugin(ctx, mod, existingModuleDS)
 	if err != nil {
 		return res, fmt.Errorf("could handle device plugin: %w", err)
-	}
-
-	existingModuleDS, err := r.daemonAPI.GetModuleDaemonSets(ctx, mod.Name, mod.Namespace)
-	if err != nil {
-		return res, fmt.Errorf("could get DaemonSets for module %s, namespace %s: %v", mod.Name, mod.Namespace, err)
 	}
 
 	logger.Info("Run garbage collection")
@@ -191,14 +191,9 @@ type moduleReconcilerHelperAPI interface {
 	getRelevantKernelMappingsAndNodes(ctx context.Context, mod *kmmv1beta1.Module, targetedNodes []v1.Node) (map[string]*api.ModuleLoaderData, []v1.Node, error)
 	handleBuild(ctx context.Context, mld *api.ModuleLoaderData) (bool, error)
 	handleSigning(ctx context.Context, mld *api.ModuleLoaderData) (bool, error)
-	handleDriverContainer(ctx context.Context, mld *api.ModuleLoaderData) error
-	handleDevicePlugin(ctx context.Context, mod *kmmv1beta1.Module) error
+	handleDriverContainer(ctx context.Context, mld *api.ModuleLoaderData, existingModuleDS []appsv1.DaemonSet) error
+	handleDevicePlugin(ctx context.Context, mod *kmmv1beta1.Module, existingModuleDS []appsv1.DaemonSet) error
 	garbageCollect(ctx context.Context, mod *kmmv1beta1.Module, mldMappings map[string]*api.ModuleLoaderData, existingDS []appsv1.DaemonSet) error
-}
-
-type hashData struct {
-	KernelVersion string
-	ModuleVersion string
 }
 
 type moduleReconcilerHelper struct {
@@ -355,22 +350,18 @@ func (mrh *moduleReconcilerHelper) handleSigning(ctx context.Context, mld *api.M
 }
 
 func (mrh *moduleReconcilerHelper) handleDriverContainer(ctx context.Context,
-	mld *api.ModuleLoaderData) error {
-
-	dsNameData := hashData{
-		KernelVersion: mld.KernelVersion,
-		ModuleVersion: mld.ModuleVersion,
-	}
-	hashValue, err := hashstructure.Hash(dsNameData, hashstructure.FormatV2, nil)
-	if err != nil {
-		return fmt.Errorf("failed to hash kernel and module versions (%s %s) and for module loader daemonset name: %v", mld.KernelVersion, mld.ModuleVersion, err)
-	}
-	name := fmt.Sprintf("%s-%x", mld.Name, hashValue)
-	ds := &appsv1.DaemonSet{
-		ObjectMeta: metav1.ObjectMeta{Namespace: mld.Namespace, Name: name},
-	}
+	mld *api.ModuleLoaderData,
+	existingModuleDS []appsv1.DaemonSet) error {
 
 	logger := log.FromContext(ctx)
+	ds := getExistingDS(existingModuleDS, mld.Namespace, mld.Name, mld.KernelVersion, mld.ModuleVersion, false)
+	if ds == nil {
+		logger.Info("creating new driver container DS", "kernel version", mld.KernelVersion, "image", mld.ContainerImage, "version", mld.ModuleVersion)
+		ds = &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Namespace: mld.Namespace, GenerateName: mld.Name + "-"},
+		}
+	}
+
 	opRes, err := controllerutil.CreateOrPatch(ctx, mrh.client, ds, func() error {
 		return mrh.daemonAPI.SetDriverContainerAsDesired(ctx, ds, mld, mld.Namespace == mrh.operatorNamespace)
 	})
@@ -382,21 +373,19 @@ func (mrh *moduleReconcilerHelper) handleDriverContainer(ctx context.Context,
 	return err
 }
 
-func (mrh *moduleReconcilerHelper) handleDevicePlugin(ctx context.Context, mod *kmmv1beta1.Module) error {
+func (mrh *moduleReconcilerHelper) handleDevicePlugin(ctx context.Context, mod *kmmv1beta1.Module, existingModuleDS []appsv1.DaemonSet) error {
 	if mod.Spec.DevicePlugin == nil {
 		return nil
 	}
 
 	logger := log.FromContext(ctx)
-	hashValue, err := hashstructure.Hash(hashData{ModuleVersion: mod.Spec.ModuleLoader.Container.Version}, hashstructure.FormatV2, nil)
-	if err != nil {
-		return fmt.Errorf("failed to hash module version %s for device-plugin daemonset name: %v", mod.Spec.ModuleLoader.Container.Version, err)
+	ds := getExistingDS(existingModuleDS, mod.Namespace, mod.Name, "", mod.Spec.ModuleLoader.Container.Version, true)
+	if ds == nil {
+		logger.Info("creating new device plugin DS", "version", mod.Spec.ModuleLoader.Container.Version)
+		ds = &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{Namespace: mod.Namespace, GenerateName: mod.Name + "-device-plugin-"},
+		}
 	}
-	name := fmt.Sprintf("%s-device-plugin-%x", mod.Name, hashValue)
-	ds := &appsv1.DaemonSet{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: mod.Namespace},
-	}
-
 	opRes, err := controllerutil.CreateOrPatch(ctx, mrh.client, ds, func() error {
 		return mrh.daemonAPI.SetDevicePluginAsDesired(ctx, ds, mod, mod.Namespace == mrh.operatorNamespace)
 	})
@@ -534,4 +523,26 @@ func isModuleBuildAndSignCapable(mod *kmmv1beta1.Module) (bool, bool) {
 		}
 	}
 	return buildCapable, signCapable
+}
+
+func getExistingDS(existingDS []appsv1.DaemonSet,
+	moduleNamespace string,
+	moduleName string,
+	kernelVersion string,
+	moduleVersion string,
+	isDevicePlugin bool) *appsv1.DaemonSet {
+
+	versionLabel := utils.GetModuleLoaderVersionLabelName(moduleNamespace, moduleName)
+	if isDevicePlugin {
+		versionLabel = utils.GetDevicePluginVersionLabelName(moduleNamespace, moduleName)
+	}
+	for _, ds := range existingDS {
+		dsLabels := ds.GetLabels()
+		dsKernelVersion := dsLabels[constants.KernelLabel]
+		dsModuleVersion := dsLabels[versionLabel]
+		if dsKernelVersion == kernelVersion && dsModuleVersion == moduleVersion {
+			return &ds
+		}
+	}
+	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.19
 require (
 	github.com/a8m/envsubst v1.4.2
 	github.com/go-logr/logr v1.2.4
-	github.com/go-openapi/swag v0.22.3
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-containerregistry v0.15.2
@@ -40,6 +39,7 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
+	github.com/go-openapi/swag v0.22.4 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,9 @@ github.com/go-openapi/jsonpointer v0.19.6 h1:eCs3fxoIi3Wh6vtgmLTOjdhSpiqphQ+DaPn
 github.com/go-openapi/jsonpointer v0.19.6/go.mod h1:osyAmYz/mB/C3I+WsTTSgw1ONzaLJoLCyoi6/zppojs=
 github.com/go-openapi/jsonreference v0.20.2 h1:3sVjiK66+uXK/6oQ8xgcRKcFgQ5KXa2KvnJRumpMGbE=
 github.com/go-openapi/jsonreference v0.20.2/go.mod h1:Bl1zwGIM8/wsvqjsOQLJ/SH+En5Ap4rVB5KVcIDZG2k=
-github.com/go-openapi/swag v0.22.3 h1:yMBqmnQ0gyZvEb/+KzuWZOXgllrXT4SADYbvDaXHv/g=
 github.com/go-openapi/swag v0.22.3/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
+github.com/go-openapi/swag v0.22.4 h1:QLMzNJnMGPRNDCbySlcj1x01tzU8/9LTTL9hZZZogBU=
+github.com/go-openapi/swag v0.22.4/go.mod h1:UzaqsxGiab7freDnrUUra0MwWfN/q7tE4j+VcZ0yl14=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 h1:tfuBGBXKqDEevZMzYi5KSi8KkcZtzBcTgAUUtapy0OI=
 github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572/go.mod h1:9Pwr4B2jHnOSGXyyzV8ROjYa2ojvAY6HCGYYfMoC3Ls=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=

--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/go-openapi/swag"
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
@@ -225,13 +224,12 @@ func (dc *daemonSetGenerator) SetDriverContainerAsDesired(
 				Annotations: modulesOrderAnnotations,
 			},
 			Spec: v1.PodSpec{
-				ShareProcessNamespace: swag.Bool(true),
-				Containers:            []v1.Container{container},
-				ImagePullSecrets:      GetPodPullSecrets(mld.ImageRepoSecret),
-				NodeSelector:          nodeSelector,
-				PriorityClassName:     "system-node-critical",
-				ServiceAccountName:    serviceAccountName,
-				Volumes:               volumes,
+				Containers:         []v1.Container{container},
+				ImagePullSecrets:   GetPodPullSecrets(mld.ImageRepoSecret),
+				NodeSelector:       nodeSelector,
+				PriorityClassName:  "system-node-critical",
+				ServiceAccountName: serviceAccountName,
+				Volumes:            volumes,
 			},
 		},
 		Selector: &metav1.LabelSelector{MatchLabels: standardLabels},

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-openapi/swag"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
 	. "github.com/onsi/ginkgo/v2"
@@ -317,7 +316,6 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 								},
 							},
 						},
-						ShareProcessNamespace: swag.Bool(true),
 						ImagePullSecrets: []v1.LocalObjectReference{
 							{Name: imageRepoSecretName},
 						},

--- a/vendor/github.com/go-openapi/swag/util.go
+++ b/vendor/github.com/go-openapi/swag/util.go
@@ -341,12 +341,21 @@ type zeroable interface {
 // IsZero returns true when the value passed into the function is a zero value.
 // This allows for safer checking of interface values.
 func IsZero(data interface{}) bool {
+	v := reflect.ValueOf(data)
+	// check for nil data
+	switch v.Kind() {
+	case reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+		if v.IsNil() {
+			return true
+		}
+	}
+
 	// check for things that have an IsZero method instead
 	if vv, ok := data.(zeroable); ok {
 		return vv.IsZero()
 	}
+
 	// continue with slightly more complex reflection
-	v := reflect.ValueOf(data)
 	switch v.Kind() {
 	case reflect.String:
 		return v.Len() == 0
@@ -358,14 +367,13 @@ func IsZero(data interface{}) bool {
 		return v.Uint() == 0
 	case reflect.Float32, reflect.Float64:
 		return v.Float() == 0
-	case reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
-		return v.IsNil()
 	case reflect.Struct, reflect.Array:
 		return reflect.DeepEqual(data, reflect.Zero(v.Type()).Interface())
 	case reflect.Invalid:
 		return true
+	default:
+		return false
 	}
-	return false
 }
 
 // AddInitialisms add additional initialisms

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -54,7 +54,7 @@ github.com/go-openapi/jsonpointer
 ## explicit; go 1.13
 github.com/go-openapi/jsonreference
 github.com/go-openapi/jsonreference/internal
-# github.com/go-openapi/swag v0.22.3
+# github.com/go-openapi/swag v0.22.4
 ## explicit; go 1.18
 github.com/go-openapi/swag
 # github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572


### PR DESCRIPTION
This is a chery-pick of 37a04a0.

---

Currently in v1.1 the naming scheme for ModuleLoader and DevicePlugin daemonsets is different the what we had in v1.0.2. We are using hashings and the names are deterministic. This causes issues during upgrade, since the upgraded controller will try to create new daemonsets (new names). The old daemonsets can not be deleted, since it will cause the unloading of kernel modules. Since there is no way to change/delete lifecycle hooks of the running pod, we need to support the naming scheme of v1.0.2
The changes in PR:
1. get the runnings Daemonsets of the module in the earlier stage of the reconciliation loop
2. during ModuleLoader or DevicePlugin handling, check if the appropriate daemonset already exists based on the kernel-version and version label of daemonset
3. if now daemnonset is found, then create a new one using GenerateName option
4. removing the fix for pods being stuck in Terminating state for ~30 seconds, since it changes the Container spec of the Daemonset, which means that during upgrade the DaemonSet will delete the pod and then restart it, which may cause unloading of kernel module
5. unit test fixes

Upstream-Commit: a0d6cb90271543682c8d556b3e02df721efe20bf