### PR TITLE
[release-1.1] Add further checks on Module version

### DIFF
--- a/api/v1beta1/module_webhook.go
+++ b/api/v1beta1/module_webhook.go
@@ -54,8 +54,20 @@ func (m *Module) ValidateCreate() error {
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-func (m *Module) ValidateUpdate(_ runtime.Object) error {
+func (m *Module) ValidateUpdate(old runtime.Object) error {
 	modulelog.Info("Validating Module update", "name", m.Name, "namespace", m.Namespace)
+
+	if old != nil {
+		oldModule, ok := old.(*Module)
+		if !ok {
+			return fmt.Errorf("old object %v is not of the expected type *Module", old)
+		}
+
+		if (oldModule.Spec.ModuleLoader.Container.Version == "" && m.Spec.ModuleLoader.Container.Version != "") ||
+			(oldModule.Spec.ModuleLoader.Container.Version != "" && m.Spec.ModuleLoader.Container.Version == "") {
+			return errors.New("cannot update to or from an empty version; please delete the Module and create it again")
+		}
+	}
 
 	return m.validate()
 }

--- a/api/v1beta1/module_webhook_test.go
+++ b/api/v1beta1/module_webhook_test.go
@@ -516,6 +516,30 @@ var _ = Describe("ValidateUpdate", func() {
 		Expect(e).To(HaveOccurred())
 		Expect(e.Error()).To(ContainSubstring("failed to validate kernel mappings"))
 	})
+
+	DescribeTable(
+		"version updates",
+		func(oldVersion, newVersion string, errorExpected bool) {
+			old := validModule
+			old.Spec.ModuleLoader.Container.Version = oldVersion
+
+			new := validModule
+			new.Spec.ModuleLoader.Container.Version = newVersion
+
+			err := new.ValidateUpdate(&old)
+			exp := Expect(err)
+
+			if errorExpected {
+				exp.To(HaveOccurred())
+			} else {
+				exp.NotTo(HaveOccurred())
+			}
+		},
+		Entry(nil, "v1", "", true),
+		Entry(nil, "", "v2", true),
+		Entry(nil, "", "", false),
+		Entry(nil, "v1", "v2", false),
+	)
 })
 
 var _ = Describe("ValidateDelete", func() {


### PR DESCRIPTION
This is a cherry-pick of 5067a83.

/cc @yevgeny-shnaidman 

---

Prevent updating to or from an empty ModuleLoader version, as this requires recreating new DaemonSets because of labelSelector updates

Upstream-Commit: 4b3bc41f58135aa859050dbe4115a1c4974a6376