### PR TITLE
Revert modprobe quotes and DaemonSet role labels

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -146,7 +146,7 @@ func main() {
 		registryAPI,
 	)
 
-	daemonAPI := daemonset.NewCreator(client, constants.KernelLabel, scheme)
+	daemonAPI := daemonset.NewCreator(client, scheme)
 	kernelAPI := module.NewKernelMapper(buildHelperAPI, sign.NewSignerHelper())
 
 	mc := controllers.NewModuleReconciler(

--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -383,7 +383,7 @@ func (mrh *moduleReconcilerHelper) handleDevicePlugin(ctx context.Context, mod *
 	if ds == nil {
 		logger.Info("creating new device plugin DS", "version", mod.Spec.ModuleLoader.Container.Version)
 		ds = &appsv1.DaemonSet{
-			ObjectMeta: metav1.ObjectMeta{Namespace: mod.Namespace, GenerateName: mod.Name + "-device-plugin-"},
+			ObjectMeta: metav1.ObjectMeta{Namespace: mod.Namespace, Name: mod.Name + "-device-plugin"},
 		}
 	}
 	opRes, err := controllerutil.CreateOrPatch(ctx, mrh.client, ds, func() error {

--- a/controllers/module_reconciler_test.go
+++ b/controllers/module_reconciler_test.go
@@ -670,7 +670,7 @@ var _ = Describe("ModuleReconciler_handleDevicePlugin", func() {
 		}
 
 		newDS := &appsv1.DaemonSet{
-			ObjectMeta: metav1.ObjectMeta{Namespace: mod.Namespace, GenerateName: mod.Name + "-device-plugin-"},
+			ObjectMeta: metav1.ObjectMeta{Namespace: mod.Namespace, Name: mod.Name + "-device-plugin"},
 		}
 		gomock.InOrder(
 			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),

--- a/controllers/node_label_module_version_reconciler_test.go
+++ b/controllers/node_label_module_version_reconciler_test.go
@@ -168,7 +168,7 @@ var _ = Describe("getModuleLoaderAndDevicePluginPods", func() {
 
 	It("good flow", func() {
 		fieldSelector := client.MatchingFields{"spec.nodeName": nodeName}
-		labelSelector := client.HasLabels{constants.DaemonSetRole}
+		labelSelector := client.HasLabels{constants.ModuleNameLabel}
 		kubeClient.EXPECT().List(ctx, gomock.Any(), labelSelector, fieldSelector)
 
 		_, err := helper.getModuleLoaderAndDevicePluginPods(ctx, nodeName)
@@ -177,7 +177,7 @@ var _ = Describe("getModuleLoaderAndDevicePluginPods", func() {
 
 	It("error flow", func() {
 		fieldSelector := client.MatchingFields{"spec.nodeName": nodeName}
-		labelSelector := client.HasLabels{constants.DaemonSetRole}
+		labelSelector := client.HasLabels{constants.ModuleNameLabel}
 		kubeClient.EXPECT().List(ctx, gomock.Any(), labelSelector, fieldSelector).Return(fmt.Errorf("some error"))
 
 		res, err := helper.getModuleLoaderAndDevicePluginPods(ctx, nodeName)
@@ -256,7 +256,7 @@ var _ = Describe("reconcileLabels", func() {
 			moduleLoaderVersionLabel: "1",
 			devicePluginVersionLabel: "1",
 		}
-		pod.SetLabels(map[string]string{constants.ModuleNameLabel: "moduleName", constants.DaemonSetRole: constants.DevicePluginRoleLabelValue})
+		pod.SetLabels(map[string]string{constants.ModuleNameLabel: "moduleName"})
 
 		res := helper.reconcileLabels(map[string]*modulesVersionLabels{"key": moduleLabels}, []v1.Pod{pod})
 
@@ -289,7 +289,7 @@ var _ = Describe("reconcileLabels", func() {
 			moduleLoaderVersionLabel: "",
 			devicePluginVersionLabel: "",
 		}
-		pod.SetLabels(map[string]string{constants.ModuleNameLabel: "moduleName", constants.DaemonSetRole: constants.ModuleLoaderRoleLabelValue})
+		pod.SetLabels(map[string]string{constants.ModuleNameLabel: "moduleName", constants.KernelLabel: "kernel-version"})
 
 		res := helper.reconcileLabels(map[string]*modulesVersionLabels{"key": moduleLabels}, []v1.Pod{pod})
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -6,7 +6,6 @@ const (
 	ModuleNameLabel              = "kmm.node.kubernetes.io/module.name"
 	NodeLabelerFinalizer         = "kmm.node.kubernetes.io/node-labeler"
 	TargetKernelTarget           = "kmm.node.kubernetes.io/target-kernel"
-	DaemonSetRole                = "kmm.node.kubernetes.io/role"
 	KernelLabel                  = "kmm.node.kubernetes.io/kernel-version.full"
 	BuildTypeLabel               = "kmm.openshift.io/build.type"
 

--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -421,39 +421,46 @@ func makeLoadCommand(inTreeModuleToRemove string, spec kmmv1beta1.ModprobeSpec, 
 	var loadCommand strings.Builder
 
 	if inTreeModuleToRemove != "" {
-		fmt.Fprintf(&loadCommand, "modprobe -r %q && ", inTreeModuleToRemove)
+		loadCommand.WriteString("modprobe -r")
+		if spec.DirName != "" {
+			loadCommand.WriteString(" -d " + spec.DirName)
+		}
+		loadCommand.WriteString(" " + inTreeModuleToRemove + " && ")
 	}
 
 	if fw := spec.FirmwarePath; fw != "" {
-		fmt.Fprintf(&loadCommand, `cp -r "%s/*" %s && `, fw, nodeVarLibFirmwarePath)
+		fmt.Fprintf(&loadCommand, "cp -r %s/* %s && ", fw, nodeVarLibFirmwarePath)
 	}
 
 	loadCommand.WriteString("modprobe")
 
 	if rawArgs := spec.RawArgs; rawArgs != nil && len(rawArgs.Load) > 0 {
 		for _, arg := range rawArgs.Load {
-			fmt.Fprintf(&loadCommand, " %q", arg)
+			loadCommand.WriteRune(' ')
+			loadCommand.WriteString(arg)
 		}
 		return append(loadCommandShell, loadCommand.String())
 	}
 
 	if args := spec.Args; args != nil && len(args.Load) > 0 {
 		for _, arg := range args.Load {
-			fmt.Fprintf(&loadCommand, " %q", arg)
+			loadCommand.WriteRune(' ')
+			loadCommand.WriteString(arg)
 		}
 	} else {
 		loadCommand.WriteString(" -v")
 	}
 
 	if spec.DirName != "" {
-		fmt.Fprintf(&loadCommand, " -d %q", spec.DirName)
+		loadCommand.WriteString(" -d " + spec.DirName)
 	}
 
-	fmt.Fprintf(&loadCommand, " %q", spec.ModuleName)
+	loadCommand.WriteString(" " + spec.ModuleName)
 
 	if params := spec.Parameters; len(params) > 0 {
 		for _, param := range params {
-			fmt.Fprintf(&loadCommand, " %q", param)
+			loadCommand.WriteRune(' ')
+			loadCommand.WriteString(param)
 		}
 	}
 
@@ -471,32 +478,33 @@ func makeUnloadCommand(spec kmmv1beta1.ModprobeSpec, modName string) []string {
 
 	fwUnloadCommand := ""
 	if fw := spec.FirmwarePath; fw != "" {
-		fwUnloadCommand = fmt.Sprintf(` && cd %q && find |sort -r |xargs -I{} rm -d "%s/{}"`, fw, nodeVarLibFirmwarePath)
+		fwUnloadCommand = fmt.Sprintf(" && cd %s && find |sort -r |xargs -I{} rm -d %s/{}", fw, nodeVarLibFirmwarePath)
 	}
 
 	if rawArgs := spec.RawArgs; rawArgs != nil && len(rawArgs.Unload) > 0 {
 		for _, arg := range rawArgs.Unload {
-			fmt.Fprintf(&unloadCommand, " %q", arg)
+			unloadCommand.WriteRune(' ')
+			unloadCommand.WriteString(arg)
+			unloadCommand.WriteString(fwUnloadCommand)
 		}
-
-		unloadCommand.WriteString(fwUnloadCommand)
 
 		return append(unloadCommandShell, unloadCommand.String())
 	}
 
 	if args := spec.Args; args != nil && len(args.Unload) > 0 {
 		for _, arg := range args.Unload {
-			fmt.Fprintf(&unloadCommand, " %q", arg)
+			unloadCommand.WriteRune(' ')
+			unloadCommand.WriteString(arg)
 		}
 	} else {
 		unloadCommand.WriteString(" -rv")
 	}
 
 	if dirName := spec.DirName; dirName != "" {
-		fmt.Fprintf(&unloadCommand, " -d %q", dirName)
+		unloadCommand.WriteString(" -d " + dirName)
 	}
 
-	fmt.Fprintf(&unloadCommand, " %q", spec.ModuleName)
+	unloadCommand.WriteString(" " + spec.ModuleName)
 	unloadCommand.WriteString(fwUnloadCommand)
 
 	return append(unloadCommandShell, unloadCommand.String())

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -898,7 +898,7 @@ var _ = Describe("makeLoadCommand", func() {
 			Equal([]string{
 				"/bin/sh",
 				"-c",
-				`modprobe "load" "arguments"`,
+				"modprobe load arguments",
 			}),
 		)
 	})
@@ -922,7 +922,7 @@ var _ = Describe("makeLoadCommand", func() {
 			Equal([]string{
 				"/bin/sh",
 				"-c",
-				fmt.Sprintf(`modprobe -r %q && modprobe -v -d %q %q %q %q`, "in-tree-module", dir, kernelModuleName, arg1, arg2),
+				fmt.Sprintf("modprobe -r -d %s %s && modprobe -v -d %s %s %s %s", dir, "in-tree-module", dir, kernelModuleName, arg1, arg2),
 			}),
 		)
 	})
@@ -941,7 +941,7 @@ var _ = Describe("makeLoadCommand", func() {
 			Equal([]string{
 				"/bin/sh",
 				"-c",
-				fmt.Sprintf(`modprobe "-z" "-k" %q`, kernelModuleName),
+				fmt.Sprintf("modprobe -z -k %s", kernelModuleName),
 			}),
 		)
 	})
@@ -958,7 +958,7 @@ var _ = Describe("makeLoadCommand", func() {
 			Equal([]string{
 				"/bin/sh",
 				"-c",
-				fmt.Sprintf(`cp -r "/kmm/firmware/mymodule/*" /var/lib/firmware && modprobe -v %q`, kernelModuleName),
+				fmt.Sprintf("cp -r /kmm/firmware/mymodule/* /var/lib/firmware && modprobe -v %s", kernelModuleName),
 			}),
 		)
 	})
@@ -984,7 +984,7 @@ var _ = Describe("makeUnloadCommand", func() {
 			Equal([]string{
 				"/bin/sh",
 				"-c",
-				`modprobe "unload" "arguments"`,
+				"modprobe unload arguments",
 			}),
 		)
 	})
@@ -1003,7 +1003,7 @@ var _ = Describe("makeUnloadCommand", func() {
 			Equal([]string{
 				"/bin/sh",
 				"-c",
-				fmt.Sprintf(`modprobe -rv -d %q %q`, dir, kernelModuleName),
+				fmt.Sprintf("modprobe -rv -d %s %s", dir, kernelModuleName),
 			}),
 		)
 	})
@@ -1022,7 +1022,7 @@ var _ = Describe("makeUnloadCommand", func() {
 			Equal([]string{
 				"/bin/sh",
 				"-c",
-				fmt.Sprintf(`modprobe "-z" "-k" %q`, kernelModuleName),
+				fmt.Sprintf("modprobe -z -k %s", kernelModuleName),
 			}),
 		)
 	})
@@ -1039,7 +1039,7 @@ var _ = Describe("makeUnloadCommand", func() {
 			Equal([]string{
 				"/bin/sh",
 				"-c",
-				fmt.Sprintf(`modprobe -rv %q && cd "/kmm/firmware/mymodule" && find |sort -r |xargs -I{} rm -d "/var/lib/firmware/{}"`, kernelModuleName),
+				fmt.Sprintf("modprobe -rv %s && cd /kmm/firmware/mymodule && find |sort -r |xargs -I{} rm -d /var/lib/firmware/{}", kernelModuleName),
 			}),
 		)
 	})

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -25,7 +25,6 @@ const (
 	kernelVersion     = "1.2.3"
 	moduleName        = "module-name"
 	namespace         = "namespace"
-	kernelLabel       = "kernel-label"
 	devicePluginImage = "device-plugin-image"
 )
 
@@ -38,7 +37,7 @@ var (
 var _ = Describe("SetDriverContainerAsDesired", func() {
 
 	BeforeEach(func() {
-		dc = NewCreator(nil, kernelLabel, scheme)
+		dc = NewCreator(nil, scheme)
 	})
 
 	BeforeEach(func() {
@@ -250,8 +249,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 
 		podLabels := map[string]string{
 			constants.ModuleNameLabel: moduleName,
-			kernelLabel:               kernelVersion,
-			constants.DaemonSetRole:   "module-loader",
+			constants.KernelLabel:     kernelVersion,
 		}
 
 		directory := v1.HostPathDirectory
@@ -277,7 +275,10 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 				Template: v1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Finalizers: []string{constants.NodeLabelerFinalizer},
-						Labels:     podLabels,
+						Labels: map[string]string{
+							constants.ModuleNameLabel: moduleName,
+							constants.KernelLabel:     kernelVersion,
+						},
 					},
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{
@@ -320,8 +321,8 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 							{Name: imageRepoSecretName},
 						},
 						NodeSelector: map[string]string{
-							"has-feature-x": "true",
-							kernelLabel:     kernelVersion,
+							"has-feature-x":       "true",
+							constants.KernelLabel: kernelVersion,
 						},
 						PriorityClassName:  "system-node-critical",
 						ServiceAccountName: serviceAccountName,
@@ -352,7 +353,7 @@ var _ = Describe("SetDriverContainerAsDesired", func() {
 var _ = Describe("SetDevicePluginAsDesired", func() {
 
 	BeforeEach(func() {
-		dc = NewCreator(nil, kernelLabel, scheme)
+		dc = NewCreator(nil, scheme)
 	})
 
 	It("should return an error if the DaemonSet is nil", func() {
@@ -526,10 +527,7 @@ var _ = Describe("SetDevicePluginAsDesired", func() {
 
 		Expect(err).NotTo(HaveOccurred())
 
-		podLabels := map[string]string{
-			constants.ModuleNameLabel: moduleName,
-			constants.DaemonSetRole:   "device-plugin",
-		}
+		podLabels := map[string]string{constants.ModuleNameLabel: moduleName}
 
 		directory := v1.HostPathDirectory
 
@@ -618,7 +616,7 @@ var _ = Describe("GarbageCollect", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
-		dc = NewCreator(clnt, kernelLabel, scheme)
+		dc = NewCreator(clnt, scheme)
 	})
 
 	mod := &kmmv1beta1.Module{
@@ -644,8 +642,7 @@ var _ = Describe("GarbageCollect", func() {
 				Name:      "moduleLoader",
 				Namespace: "namespace",
 				Labels: map[string]string{
-					kernelLabel:               legitKernelVersion,
-					constants.DaemonSetRole:   constants.ModuleLoaderRoleLabelValue,
+					constants.KernelLabel:     legitKernelVersion,
 					moduleLoaderVersionLabel:  currentModuleVersion,
 					constants.ModuleNameLabel: mod.Name,
 				},
@@ -656,7 +653,6 @@ var _ = Describe("GarbageCollect", func() {
 				Name:      "devicePlugin",
 				Namespace: "namespace",
 				Labels: map[string]string{
-					constants.DaemonSetRole:   constants.DevicePluginRoleLabelValue,
 					devicePluginVersionLabel:  currentModuleVersion,
 					constants.ModuleNameLabel: mod.Name,
 				},
@@ -685,7 +681,7 @@ var _ = Describe("GarbageCollect", func() {
 		if moduleLoaderInvalidKernel {
 			moduleLoaderIllegalKernelVersionDS = moduleLoaderDS.DeepCopy()
 			moduleLoaderIllegalKernelVersionDS.SetName("moduleLoaderInvalidKernel")
-			moduleLoaderIllegalKernelVersionDS.Labels[kernelLabel] = notLegitKernelVersion
+			moduleLoaderIllegalKernelVersionDS.Labels[constants.KernelLabel] = notLegitKernelVersion
 			existingDS = append(existingDS, *moduleLoaderIllegalKernelVersionDS)
 		}
 
@@ -721,7 +717,7 @@ var _ = Describe("GarbageCollect", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "moduleLoader",
 				Namespace: "namespace",
-				Labels:    map[string]string{kernelLabel: notLegitKernelVersion, constants.DaemonSetRole: constants.ModuleLoaderRoleLabelValue, moduleLoaderVersionLabel: currentModuleVersion},
+				Labels:    map[string]string{constants.KernelLabel: notLegitKernelVersion, moduleLoaderVersionLabel: currentModuleVersion},
 			},
 		}
 		clnt.EXPECT().Delete(context.Background(), &deleteDS).Return(fmt.Errorf("some error"))
@@ -749,7 +745,7 @@ var _ = Describe("GetModuleDaemonSets", func() {
 	It("should return an empty map if no DaemonSets are present", func() {
 		clnt.EXPECT().List(context.Background(), gomock.Any(), gomock.Any())
 
-		dc := NewCreator(clnt, kernelLabel, scheme)
+		dc := NewCreator(clnt, scheme)
 
 		s, err := dc.GetModuleDaemonSets(context.Background(), moduleName, namespace)
 		Expect(err).NotTo(HaveOccurred())
@@ -765,7 +761,7 @@ var _ = Describe("GetModuleDaemonSets", func() {
 				Namespace: namespace,
 				Labels: map[string]string{
 					"kmm.node.kubernetes.io/module.name": moduleName,
-					kernelLabel:                          kernelVersion,
+					constants.KernelLabel:                kernelVersion,
 				},
 			},
 		}
@@ -776,7 +772,7 @@ var _ = Describe("GetModuleDaemonSets", func() {
 				Namespace: namespace,
 				Labels: map[string]string{
 					"kmm.node.kubernetes.io/module.name": moduleName,
-					kernelLabel:                          otherKernelVersion,
+					constants.KernelLabel:                otherKernelVersion,
 				},
 			},
 		}
@@ -790,7 +786,7 @@ var _ = Describe("GetModuleDaemonSets", func() {
 		)
 		expectSlice := []appsv1.DaemonSet{ds1, ds2}
 
-		dc := NewCreator(clnt, kernelLabel, scheme)
+		dc := NewCreator(clnt, scheme)
 
 		s, err := dc.GetModuleDaemonSets(context.Background(), moduleName, namespace)
 		Expect(err).NotTo(HaveOccurred())
@@ -849,7 +845,7 @@ var _ = Describe("GetNodeLabelFromPod", func() {
 	var dc DaemonSetCreator
 
 	BeforeEach(func() {
-		dc = NewCreator(clnt, kernelLabel, scheme)
+		dc = NewCreator(clnt, scheme)
 	})
 
 	It("should return a driver container label", func() {
@@ -857,7 +853,7 @@ var _ = Describe("GetNodeLabelFromPod", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					constants.ModuleNameLabel: moduleName,
-					constants.DaemonSetRole:   "module-loader",
+					constants.KernelLabel:     "some-kernel-version",
 				},
 				Namespace: namespace,
 			},
@@ -871,10 +867,7 @@ var _ = Describe("GetNodeLabelFromPod", func() {
 	It("should return a device plugin label", func() {
 		pod := v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					constants.ModuleNameLabel: moduleName,
-					constants.DaemonSetRole:   "device-plugin",
-				},
+				Labels:    map[string]string{constants.ModuleNameLabel: moduleName},
 				Namespace: namespace,
 			},
 		}

--- a/internal/statusupdater/statusupdater_test.go
+++ b/internal/statusupdater/statusupdater_test.go
@@ -255,9 +255,9 @@ var _ = Describe("preflight status updates", func() {
 })
 
 func getDaemonSet(dsConfig daemonSetConfig) appsv1.DaemonSet {
-	roleLabel := map[string]string{constants.DaemonSetRole: "module-loader"}
-	if dsConfig.isDevicePlugin {
-		roleLabel[constants.DaemonSetRole] = "device-plugin"
+	labels := make(map[string]string)
+	if !dsConfig.isDevicePlugin {
+		labels[constants.KernelLabel] = "some value"
 	}
 	ds := appsv1.DaemonSet{
 		Status: appsv1.DaemonSetStatus{
@@ -265,7 +265,7 @@ func getDaemonSet(dsConfig daemonSetConfig) appsv1.DaemonSet {
 			DesiredNumberScheduled: int32(dsConfig.numberAvailable),
 		},
 	}
-	ds.SetLabels(roleLabel)
+	ds.SetLabels(labels)
 	return ds
 }
 


### PR DESCRIPTION
Remove label and spec changes since 1.0 that prevented the DaemonSets from being reconciled.

/cc @yevgeny-shnaidman