### PR TITLE
Fixing DevicePlugin generation for ordered upgrade

### DIFF
--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -383,7 +383,7 @@ func (mrh *moduleReconcilerHelper) handleDevicePlugin(ctx context.Context, mod *
 	if ds == nil {
 		logger.Info("creating new device plugin DS", "version", mod.Spec.ModuleLoader.Container.Version)
 		ds = &appsv1.DaemonSet{
-			ObjectMeta: metav1.ObjectMeta{Namespace: mod.Namespace, Name: mod.Name + "-device-plugin"},
+			ObjectMeta: metav1.ObjectMeta{Namespace: mod.Namespace, GenerateName: mod.Name + "-device-plugin-"},
 		}
 	}
 	opRes, err := controllerutil.CreateOrPatch(ctx, mrh.client, ds, func() error {

--- a/controllers/module_reconciler_test.go
+++ b/controllers/module_reconciler_test.go
@@ -670,7 +670,7 @@ var _ = Describe("ModuleReconciler_handleDevicePlugin", func() {
 		}
 
 		newDS := &appsv1.DaemonSet{
-			ObjectMeta: metav1.ObjectMeta{Namespace: mod.Namespace, Name: mod.Name + "-device-plugin"},
+			ObjectMeta: metav1.ObjectMeta{Namespace: mod.Namespace, GenerateName: mod.Name + "-device-plugin-"},
 		}
 		gomock.InOrder(
 			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(schema.GroupResource{}, "whatever")),


### PR DESCRIPTION
In case of ordered upgrade, we need to create a second DevicePlugin daemonset, since it will be managed by a different set of labels