### PR TITLE
Fixing the in-tree removal flow

### DIFF
--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -421,11 +421,7 @@ func makeLoadCommand(inTreeModuleToRemove string, spec kmmv1beta1.ModprobeSpec, 
 	var loadCommand strings.Builder
 
 	if inTreeModuleToRemove != "" {
-		loadCommand.WriteString("modprobe -r")
-		if spec.DirName != "" {
-			loadCommand.WriteString(" -d " + spec.DirName)
-		}
-		loadCommand.WriteString(" " + inTreeModuleToRemove + " && ")
+		fmt.Fprintf(&loadCommand, "modprobe -r %q && ", inTreeModuleToRemove)
 	}
 
 	if fw := spec.FirmwarePath; fw != "" {

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -922,7 +922,7 @@ var _ = Describe("makeLoadCommand", func() {
 			Equal([]string{
 				"/bin/sh",
 				"-c",
-				fmt.Sprintf("modprobe -r -d %s %s && modprobe -v -d %s %s %s %s", dir, "in-tree-module", dir, kernelModuleName, arg1, arg2),
+				fmt.Sprintf("modprobe -r %q && modprobe -v -d %s %s %s %s", "in-tree-module", dir, kernelModuleName, arg1, arg2),
 			}),
 		)
 	})


### PR DESCRIPTION
When removing in-tree module, the module file will be located at the default location on the host filesystem, and not on the ModuleLoader image. Removing the "-d" option from the modprobe command