### PR TITLE
Fixing ModuleLoader recreation during Node reboot (#464) (#655)

### DIFF
--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -33,6 +33,26 @@ var skipDeletions predicate.Predicate = predicate.Funcs{
 	DeleteFunc: func(_ event.DeleteEvent) bool { return false },
 }
 
+var nodeBecomesReady predicate.Predicate = predicate.Funcs{
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		oldNode, ok := e.ObjectOld.(*v1.Node)
+		if !ok {
+			return false
+		}
+
+		newNode, ok := e.ObjectNew.(*v1.Node)
+		if !ok {
+			return false
+		}
+		newReadyStatus := getNodeReadyCondition(newNode)
+		oldReadyStatus := getNodeReadyCondition(oldNode)
+		if newReadyStatus != oldReadyStatus && newReadyStatus == v1.ConditionTrue {
+			return true
+		}
+		return false
+	},
+}
+
 var kmmClusterClaimChanged predicate.Predicate = predicate.Funcs{
 	UpdateFunc: func(e event.UpdateEvent) bool {
 		oldManagedCluster, ok := e.ObjectOld.(*clusterv1.ManagedCluster)
@@ -80,7 +100,7 @@ func (f *Filter) ModuleReconcilerNodePredicate(kernelLabel string) predicate.Pre
 	return predicate.And(
 		skipDeletions,
 		HasLabel(kernelLabel),
-		predicate.LabelChangedPredicate{},
+		predicate.Or(nodeBecomesReady, predicate.LabelChangedPredicate{}),
 	)
 }
 
@@ -334,4 +354,13 @@ func NodeLabelModuleVersionUpdatePredicate(logger logr.Logger) predicate.Predica
 			return !reflect.DeepEqual(oldNodeVersionLabels, newNodeVersionLabels)
 		},
 	}
+}
+
+func getNodeReadyCondition(node *v1.Node) v1.ConditionStatus {
+	for _, condition := range node.Status.Conditions {
+		if condition.Type == v1.NodeReady {
+			return condition.Status
+		}
+	}
+	return v1.ConditionUnknown
 }

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -804,3 +804,48 @@ var _ = Describe("ImageStreamReconcilerPredicate", func() {
 		)
 	})
 })
+
+var _ = Describe("nodeBecomesReady", func() {
+	var (
+		oldNode v1.Node
+		newNode *v1.Node
+	)
+
+	BeforeEach(func() {
+		oldNode = v1.Node{
+			Status: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					{
+						Type:   v1.NodeMemoryPressure,
+						Status: v1.ConditionFalse,
+					},
+				},
+			},
+		}
+		newNode = oldNode.DeepCopy()
+	})
+	nodeReadyTrue := v1.NodeCondition{
+		Type:   v1.NodeReady,
+		Status: v1.ConditionTrue,
+	}
+	nodeReadyUnknown := v1.NodeCondition{
+		Type:   v1.NodeReady,
+		Status: v1.ConditionUnknown,
+	}
+
+	DescribeTable("Should return the expected value", func(oldCond v1.NodeCondition, newCond v1.NodeCondition, expected bool) {
+		newNode.Status.Conditions = append(newNode.Status.Conditions, newCond)
+		oldNode.Status.Conditions = append(oldNode.Status.Conditions, oldCond)
+		res := nodeBecomesReady.Update(event.UpdateEvent{ObjectOld: &oldNode, ObjectNew: newNode})
+		if expected {
+			Expect(res).To(BeTrue())
+		} else {
+			Expect(res).To(BeFalse())
+		}
+	},
+		Entry("old True, new True", nodeReadyTrue, nodeReadyTrue, false),
+		Entry("old Unknown, new Unknown", nodeReadyUnknown, nodeReadyUnknown, false),
+		Entry("old True, new Unknown", nodeReadyTrue, nodeReadyUnknown, false),
+		Entry("old Unknown, new True", nodeReadyUnknown, nodeReadyTrue, true),
+	)
+})


### PR DESCRIPTION
Bug sequence as following:
1) Module deployed, with selector targeting only one node 2) ModuleLoader DS created and pod is running
3) Targeted Node rebooted
4) Once Node becomes NotReady, DS is destroyed
5) Node becomes Ready again, but no new ModuleLoader DS is created (bug)

The reason for bug is that once node is in the cluster, all the event for node are Update events. Since the labels do not change between the time that node was NotReady to NodeReady, the events are filtered our and the reconciliation loop is not started

Solution: add another predicate to the filtering of the node event for module reconciler. This predicate will return true in case the Node's condition for Ready type has chnaged and the new condition status is True