### PR TITLE
Define version and commit through ldflags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
 VERSION ?= 0.0.1
 
+GIT_COMMIT ?= $(shell git rev-parse --short HEAD)
+
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:
@@ -143,10 +145,10 @@ lint: golangci-lint ## Run golangci-lint against code.
 ##@ Build
 
 manager: $(shell find -name "*.go") go.mod go.sum  ## Build manager binary.
-	go build -o $@ ./cmd/manager
+	go build -ldflags="-X main.Version=$(VERSION) -X main.GitCommit=$(GIT_COMMIT)" -o $@ ./cmd/manager
 
 manager-hub: $(shell find -name "*.go") go.mod go.sum  ## Build manager-hub binary.
-	go build -o $@ ./cmd/manager-hub
+	go build -ldflags="-X main.Version=$(VERSION) -X main.GitCommit=$(GIT_COMMIT)" -o $@ ./cmd/manager-hub
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.

--- a/cmd/manager-hub/main.go
+++ b/cmd/manager-hub/main.go
@@ -63,7 +63,12 @@ import (
 	//+kubebuilder:scaffold:imports
 )
 
-var scheme = runtime.NewScheme()
+var (
+	GitCommit = "undefined"
+	Version   = "undefined"
+
+	scheme = runtime.NewScheme()
+)
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
@@ -90,13 +95,8 @@ func main() {
 
 	flag.Parse()
 
-	commit, err := cmd.GitCommit()
-	if err != nil {
-		setupLogger.Error(err, "Could not get the git commit; using <undefined>")
-		commit = "<undefined>"
-	}
-
-	setupLogger.Info("Creating manager", "git commit", commit)
+	setupLogger.Info("Creating manager", "version", Version, "git commit", GitCommit)
+	setupLogger.Info("Parsing configuration file", "path", configFile)
 
 	cfg, err := config.ParseFile(configFile)
 	if err != nil {

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -62,7 +62,12 @@ import (
 	//+kubebuilder:scaffold:imports
 )
 
-var scheme = runtime.NewScheme()
+var (
+	GitCommit = "undefined"
+	Version   = "undefined"
+
+	scheme = runtime.NewScheme()
+)
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
@@ -87,11 +92,7 @@ func main() {
 
 	flag.Parse()
 
-	commit, err := cmd.GitCommit()
-	if err != nil {
-		setupLogger.Error(err, "Could not get the git commit; using <undefined>")
-		commit = "<undefined>"
-	}
+	setupLogger.Info("Creating manager", "version", Version, "git commit", GitCommit)
 
 	operatorNamespace := cmd.GetEnvOrFatalError(constants.OperatorNamespaceEnvVar, setupLogger)
 
@@ -101,7 +102,7 @@ func main() {
 		managed = false
 	}
 
-	setupLogger.Info("Creating manager", "git commit", commit)
+	setupLogger.Info("Parsing configuration file", "path", configFile)
 
 	cfg, err := config.ParseFile(configFile)
 	if err != nil {

--- a/internal/cmd/cmdutils.go
+++ b/internal/cmd/cmdutils.go
@@ -2,9 +2,7 @@ package cmd
 
 import (
 	"errors"
-	"fmt"
 	"os"
-	"runtime/debug"
 
 	"github.com/go-logr/logr"
 )
@@ -21,21 +19,4 @@ func GetEnvOrFatalError(name string, logger logr.Logger) string {
 	}
 
 	return val
-}
-
-func GitCommit() (string, error) {
-	bi, ok := debug.ReadBuildInfo()
-	if !ok {
-		return "", errors.New("build info is not available")
-	}
-
-	const vcsRevisionKey = "vcs.revision"
-
-	for _, s := range bi.Settings {
-		if s.Key == vcsRevisionKey {
-			return s.Value, nil
-		}
-	}
-
-	return "", fmt.Errorf("%s not found in build info settings", vcsRevisionKey)
 }


### PR DESCRIPTION
Do not use Go's `runtime/debug` to embed VCS information. Instead, set those values from external sources via ldflags.
- when building with `go build ./cmd/manager{,-hub}`, the value will be `undefined`
- when building with `make manager{,-hub}`, the `Makefile` will populate the version and git commit
- in CI, we fallback to `make manager` which should set the values
- on CPaaS, [$MR](https://gitlab.cee.redhat.com/rh-ecosystem-edge/kmm/-/merge_requests/233) adds the ldflags and uses CPaaS values to set the upstream commit.