### PR TITLE
Fix race condition for Node reboot issue

### DIFF
--- a/controllers/module_reconciler.go
+++ b/controllers/module_reconciler.go
@@ -276,7 +276,7 @@ func (mrh *moduleReconcilerHelper) getNodesListBySelector(ctx context.Context, m
 	nodes := make([]v1.Node, 0, len(selectedNodes.Items))
 
 	for _, node := range selectedNodes.Items {
-		if isNodeSchedulable(&node) {
+		if utils.IsNodeSchedulable(&node) {
 			nodes = append(nodes, node)
 		}
 	}
@@ -496,15 +496,6 @@ func (r *ModuleReconciler) SetupWithManager(mgr ctrl.Manager, kernelLabel string
 		).
 		Named(ModuleReconcilerName).
 		Complete(r)
-}
-
-func isNodeSchedulable(node *v1.Node) bool {
-	for _, taint := range node.Spec.Taints {
-		if taint.Effect == v1.TaintEffectNoSchedule {
-			return false
-		}
-	}
-	return true
 }
 
 func isModuleBuildAndSignCapable(mod *kmmv1beta1.Module) (bool, bool) {

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -34,7 +34,7 @@ var skipDeletions predicate.Predicate = predicate.Funcs{
 	DeleteFunc: func(_ event.DeleteEvent) bool { return false },
 }
 
-var nodeBecomesReady predicate.Predicate = predicate.Funcs{
+var nodeBecomesSchedulable predicate.Predicate = predicate.Funcs{
 	UpdateFunc: func(e event.UpdateEvent) bool {
 		oldNode, ok := e.ObjectOld.(*v1.Node)
 		if !ok {
@@ -45,11 +45,13 @@ var nodeBecomesReady predicate.Predicate = predicate.Funcs{
 		if !ok {
 			return false
 		}
-		newReadyStatus := getNodeReadyCondition(newNode)
-		oldReadyStatus := getNodeReadyCondition(oldNode)
-		if newReadyStatus != oldReadyStatus && newReadyStatus == v1.ConditionTrue {
+
+		isOldSchedulable := utils.IsNodeSchedulable(oldNode)
+		isNewSchedulable := utils.IsNodeSchedulable(newNode)
+		if isOldSchedulable != isNewSchedulable && isNewSchedulable {
 			return true
 		}
+
 		return false
 	},
 }
@@ -97,7 +99,7 @@ func (f *Filter) ModuleReconcilerNodePredicate(kernelLabel string) predicate.Pre
 	return predicate.And(
 		skipDeletions,
 		HasLabel(kernelLabel),
-		predicate.Or(nodeBecomesReady, predicate.LabelChangedPredicate{}),
+		predicate.Or(nodeBecomesSchedulable, predicate.LabelChangedPredicate{}),
 	)
 }
 
@@ -351,13 +353,4 @@ func NodeLabelModuleVersionUpdatePredicate(logger logr.Logger) predicate.Predica
 			return !reflect.DeepEqual(oldNodeVersionLabels, newNodeVersionLabels)
 		},
 	}
-}
-
-func getNodeReadyCondition(node *v1.Node) v1.ConditionStatus {
-	for _, condition := range node.Status.Conditions {
-		if condition.Type == v1.NodeReady {
-			return condition.Status
-		}
-	}
-	return v1.ConditionUnknown
 }

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -811,7 +811,7 @@ var _ = Describe("ImageStreamReconcilerPredicate", func() {
 	})
 })
 
-var _ = Describe("nodeBecomesReady", func() {
+var _ = Describe("nodeBecomesSchedulable", func() {
 	var (
 		oldNode v1.Node
 		newNode *v1.Node
@@ -830,28 +830,29 @@ var _ = Describe("nodeBecomesReady", func() {
 		}
 		newNode = oldNode.DeepCopy()
 	})
-	nodeReadyTrue := v1.NodeCondition{
-		Type:   v1.NodeReady,
-		Status: v1.ConditionTrue,
-	}
-	nodeReadyUnknown := v1.NodeCondition{
-		Type:   v1.NodeReady,
-		Status: v1.ConditionUnknown,
+
+	nonSchedulableTaint := v1.Taint{
+		Effect: v1.TaintEffectNoSchedule,
 	}
 
-	DescribeTable("Should return the expected value", func(oldCond v1.NodeCondition, newCond v1.NodeCondition, expected bool) {
-		newNode.Status.Conditions = append(newNode.Status.Conditions, newCond)
-		oldNode.Status.Conditions = append(oldNode.Status.Conditions, oldCond)
-		res := nodeBecomesReady.Update(event.UpdateEvent{ObjectOld: &oldNode, ObjectNew: newNode})
+	DescribeTable("Should return the expected value", func(oldTaint *v1.Taint, newTaint *v1.Taint, expected bool) {
+		if newTaint != nil {
+			newNode.Spec.Taints = append(newNode.Spec.Taints, *newTaint)
+		}
+		if oldTaint != nil {
+			oldNode.Spec.Taints = append(oldNode.Spec.Taints, *oldTaint)
+		}
+
+		res := nodeBecomesSchedulable.Update(event.UpdateEvent{ObjectOld: &oldNode, ObjectNew: newNode})
 		if expected {
 			Expect(res).To(BeTrue())
 		} else {
 			Expect(res).To(BeFalse())
 		}
 	},
-		Entry("old True, new True", nodeReadyTrue, nodeReadyTrue, false),
-		Entry("old Unknown, new Unknown", nodeReadyUnknown, nodeReadyUnknown, false),
-		Entry("old True, new Unknown", nodeReadyTrue, nodeReadyUnknown, false),
-		Entry("old Unknown, new True", nodeReadyUnknown, nodeReadyTrue, true),
+		Entry("old Schedulable, new Schedulable", nil, nil, false),
+		Entry("old NonSchedulable, new NonSchedulable", &nonSchedulableTaint, &nonSchedulableTaint, false),
+		Entry("old Schedulable, new NonSchedulable", nil, &nonSchedulableTaint, false),
+		Entry("old NonSchedulable, new Schedulable", &nonSchedulableTaint, nil, true),
 	)
 })

--- a/internal/utils/nodeutils.go
+++ b/internal/utils/nodeutils.go
@@ -1,0 +1,14 @@
+package utils
+
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
+func IsNodeSchedulable(node *v1.Node) bool {
+	for _, taint := range node.Spec.Taints {
+		if taint.Effect == v1.TaintEffectNoSchedule {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Module controller needs to be scheduled in case node has been rebooted and becomes ready. Module controller get the target nodes for the modules based on the selector and the NonSchedulable taint of the node. Sometimes node's Ready condition is set while the taint is not being removed, which causes the reconcilation loop to skip DS generation, and we have not addition event  scheduled. This PR changes the condition for reconciliation kick-off: now we are waiting for node to become scheduled, instead of just ready

/cc @yevgeny-shnaidman @bthurber 