### PR TITLE
Stop using a deprecated constant

### DIFF
--- a/internal/registry/registry_helper_test.go
+++ b/internal/registry/registry_helper_test.go
@@ -41,7 +41,7 @@ func prepareLayer(fileName string, data []byte) (v1.Layer, error) {
 	if err := tw.WriteHeader(&tar.Header{
 		Name:     fileName,
 		Size:     int64(len(data)),
-		Typeflag: tar.TypeRegA,
+		Typeflag: tar.TypeReg,
 	}); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
[staticcheck](https://staticcheck.dev/) complains:
```
internal/registry/registry_helper_test.go:44:13: SA1019: tar.TypeRegA has been deprecated since Go 1.11 and an alternative has been available since Go 1.1: Use TypeReg instead. (staticcheck)
		Typeflag: tar.TypeRegA,
		          ^
```
https://staticcheck.dev/docs/checks/#SA1019

This PR unlocks https://github.com/openshift/release/pull/41900.

/cc @ybettan