### PR TITLE
Fixing panic in case worker pod has failed (#523)

### DIFF
--- a/controllers/nodemodulesconfig_reconciler.go
+++ b/controllers/nodemodulesconfig_reconciler.go
@@ -227,13 +227,17 @@ func (w *workerHelper) ProcessModuleSpec(
 
 	if status == nil {
 		logger.Info("Missing status; creating loader Pod")
-
 		return w.pm.CreateLoaderPod(ctx, nmc, spec)
 	}
 
 	if status.InProgress {
 		logger.Info("Worker pod is running; skipping")
 		return nil
+	}
+
+	if status.Config == nil {
+		logger.Info("Missing status config and pod is not running: previously failed pod, creating loader Pod")
+		return w.pm.CreateLoaderPod(ctx, nmc, spec)
 	}
 
 	if !reflect.DeepEqual(spec.Config, *status.Config) {

--- a/controllers/nodemodulesconfig_reconciler_test.go
+++ b/controllers/nodemodulesconfig_reconciler_test.go
@@ -193,6 +193,27 @@ var _ = Describe("workerHelper_ProcessModuleSpec", func() {
 		)
 	})
 
+	It("should create a loader Pod if inStatus is false, but the Config is not define (nil)", func() {
+		nmc := &kmmv1beta1.NodeModulesConfig{}
+		spec := &kmmv1beta1.NodeModuleSpec{
+			Name:      name,
+			Namespace: namespace,
+			Config:    kmmv1beta1.ModuleConfig{ContainerImage: "old-container-image"},
+		}
+
+		status := &kmmv1beta1.NodeModuleStatus{
+			Name:      name,
+			Namespace: namespace,
+		}
+		pm.EXPECT().CreateLoaderPod(ctx, nmc, spec)
+
+		Expect(
+			wh.ProcessModuleSpec(ctx, &kmmv1beta1.NodeModulesConfig{}, spec, status),
+		).NotTo(
+			HaveOccurred(),
+		)
+	})
+
 	It("should create an unloader Pod if the spec is different from the status", func() {
 		nmc := &kmmv1beta1.NodeModulesConfig{}
 


### PR DESCRIPTION
The status of the working pod that has completed with error does not contain the valid Config field ( it is set only on success). When processing NMC, the NMC controller tries to compare the Config of the status and spec, and in that case it fails, since status Config is nil.
Fix: in case status != nil, inProgress = false and Config is nil, just create a loader worker pod, without futher comparison to the spec