### PR TITLE
Fixing Unloading Kmod on a previously failed Load Pod (#530)

### DIFF
--- a/controllers/nodemodulesconfig_reconciler_test.go
+++ b/controllers/nodemodulesconfig_reconciler_test.go
@@ -352,6 +352,22 @@ var _ = Describe("workerHelper_ProcessOrphanModuleStatus", func() {
 		)
 	})
 
+	It("should remove status in case Config is nil", func() {
+		nmc := &kmmv1beta1.NodeModulesConfig{}
+		status := &kmmv1beta1.NodeModuleStatus{}
+
+		ctrl := gomock.NewController(GinkgoT())
+		client := testclient.NewMockClient(ctrl)
+		sw := testclient.NewMockStatusWriter(ctrl)
+		client.EXPECT().Status().Return(sw)
+		sw.EXPECT().Patch(ctx, nmc, gomock.Any())
+		Expect(
+			NewWorkerHelper(client, nil).ProcessOrphanModuleStatus(ctx, nmc, status),
+		).NotTo(
+			HaveOccurred(),
+		)
+	})
+
 	It("should create an unloader Pod", func() {
 		ctrl := gomock.NewController(GinkgoT())
 		client := testclient.NewMockClient(ctrl)
@@ -359,7 +375,9 @@ var _ = Describe("workerHelper_ProcessOrphanModuleStatus", func() {
 		wh := NewWorkerHelper(client, pm)
 
 		nmc := &kmmv1beta1.NodeModulesConfig{}
-		status := &kmmv1beta1.NodeModuleStatus{}
+		status := &kmmv1beta1.NodeModuleStatus{
+			Config: &kmmv1beta1.ModuleConfig{},
+		}
 
 		pm.EXPECT().CreateUnloaderPod(ctx, nmc, status)
 

--- a/internal/nmc/helper.go
+++ b/internal/nmc/helper.go
@@ -75,7 +75,7 @@ func (h *helper) GetModuleEntry(nmc *kmmv1beta1.NodeModulesConfig, modNamespace,
 	return nil, 0
 }
 
-func findModuleStatus(statuses []kmmv1beta1.NodeModuleStatus, moduleNamespace, moduleName string) *kmmv1beta1.NodeModuleStatus {
+func FindModuleStatus(statuses []kmmv1beta1.NodeModuleStatus, moduleNamespace, moduleName string) *kmmv1beta1.NodeModuleStatus {
 	for i := 0; i < len(statuses); i++ {
 		s := statuses[i]
 
@@ -108,7 +108,7 @@ func SetModuleStatus(statuses *[]kmmv1beta1.NodeModuleStatus, status kmmv1beta1.
 		return
 	}
 
-	s := findModuleStatus(*statuses, status.Namespace, status.Name)
+	s := FindModuleStatus(*statuses, status.Namespace, status.Name)
 
 	if s != nil {
 		*s = status


### PR DESCRIPTION
This PR fixes 2 issues:
1) In case Load Pod is failing, its Config in status is nil.
   if NMC is configured to un load the module, for whatever reason,
   the code must also check if the Config is nil, and then just to
   delete the status for module, in order to avoid panic
2) When unload Pod is failing, its status should be retained as is,
   otherwise the Config is lost, and the following unload pod won't be
   able to run