### PR TITLE
Fixing permission for images' pull directory on worker pod (#522)

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -31,6 +31,8 @@ RUN ["microdnf", "-y", "install", "kmod"]
 WORKDIR /
 
 COPY --from=builder /opt/app-root/src/worker /usr/local/bin/worker
+RUN mkdir -p /mnt/img
+RUN chown 65534:65534 /mnt/img
 USER 65534:65534
 
 ENTRYPOINT ["/usr/local/bin/worker"]

--- a/internal/controllers/nmc_reconciler_test.go
+++ b/internal/controllers/nmc_reconciler_test.go
@@ -868,10 +868,12 @@ modprobe:
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				{
-					Name:            "worker",
-					Image:           workerImage,
-					Args:            []string{"kmod", subcommand, "/etc/kmm-worker/config.yaml"},
-					SecurityContext: &v1.SecurityContext{Privileged: pointer.Bool(true)},
+					Name:  "worker",
+					Image: workerImage,
+					Args:  []string{"kmod", subcommand, "/etc/kmm-worker/config.yaml"},
+					SecurityContext: &v1.SecurityContext{
+						Privileged: pointer.Bool(true),
+					},
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:      volNameConfig,


### PR DESCRIPTION
Worker Pod container application tries to create directory for image pulling on /mnt/img, which fails due to the permission This PR add RunAsUser 0 to the security context