### PR TITLE
Fixing worker pod failure in case no pullsecrets are defined (#545)

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -31,6 +31,6 @@ RUN ["microdnf", "-y", "install", "kmod"]
 WORKDIR /
 
 COPY --from=builder /opt/app-root/src/worker /usr/local/bin/worker
-RUN mkdir -p /mnt/img
+RUN ["mkdir", "-p", "/mnt/img", "/var/run/kmm/pull-secrets"]
 
 ENTRYPOINT ["/usr/local/bin/worker"]


### PR DESCRIPTION
On initiliazation, worker pod goes over /var/run/kmm/pull-secrets directory in roder to read all pull secret and create authentication keychain. Currently, in case no pullsecrets are define, this function fails, since the directory itself does not exists. This PR defines the directory in the Dockerfile, and during pod creation, pull secrets will be mapping via volumes