### PR TITLE
Use the default ServiceAccount when creating NMC

### DIFF
--- a/bundle/manifests/kmm-operator-manager-config_v1_configmap.yaml
+++ b/bundle/manifests/kmm-operator-manager-config_v1_configmap.yaml
@@ -8,6 +8,7 @@ data:
       enabled: true
       resourceID: kmm.sigs.x-k8s.io
     worker:
+      runAsUser: 0
       seLinuxType: spc_t
 kind: ConfigMap
 metadata:

--- a/ci/install-ci-spoke/kustomization.yaml
+++ b/ci/install-ci-spoke/kustomization.yaml
@@ -19,4 +19,5 @@ patchesStrategicMerge:
               env:
                 - name: KMM_MANAGED
                   value: "1"
-
+                - name: RELATED_IMAGES_WORKER
+                  value: kernel-module-management-worker

--- a/ci/prow/e2e-incluster-build
+++ b/ci/prow/e2e-incluster-build
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-readonly SKIP_MAKE_DEPLOY="${SKIP_MAKE_DEPLOY:-false}"
 POD_NAME=''
 
 wait_for_pod_and_print_logs () {
@@ -19,13 +18,6 @@ export KVER=$(oc debug node/${NODE} -- uname -r)
 
 echo "Label a node to match selector in Module afterwards..."
 oc label node ${NODE} task=kmm-ci
-
-if [ "$SKIP_MAKE_DEPLOY" == true ]; then
-  echo "Skipping deployment"
-else
-  echo "Deploy KMMO..."
-  make deploy
-fi
 
 echo "Check that the kmm_ci_a module is not loaded on the node..."
 if oc debug node/${NODE} -- chroot host/ lsmod | grep kmm_ci_a; then

--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -5,4 +5,5 @@ leaderElection:
   enabled: true
   resourceID: kmm.sigs.x-k8s.io
 worker:
+  runAsUser: 0
   seLinuxType: spc_t

--- a/internal/controllers/nmc_reconciler.go
+++ b/internal/controllers/nmc_reconciler.go
@@ -56,6 +56,7 @@ const (
 //+kubebuilder:rbac:groups="core",resources=pods,verbs=create;delete;get;list;watch
 //+kubebuilder:rbac:groups="core",resources=nodes,verbs=get;list;watch
 //+kubebuilder:rbac:groups="core",resources=secrets,verbs=get;list;watch
+//+kubebuilder:rbac:groups="core",resources=serviceaccounts,verbs=get;list;watch
 
 type NMCReconciler struct {
 	client client.Client
@@ -431,13 +432,13 @@ func (h *nmcReconcilerHelperImpl) SyncStatus(ctx context.Context, nmcObj *kmmv1b
 		if status == nil {
 			status = &kmmv1beta1.NodeModuleStatus{
 				ModuleItem: kmmv1beta1.ModuleItem{
-					ImageRepoSecret:    nil,
-					Name:               modName,
-					Namespace:          modNamespace,
-					ServiceAccountName: "",
+					Name:      modName,
+					Namespace: modNamespace,
 				},
 			}
 		}
+
+		status.ServiceAccountName = p.Spec.ServiceAccountName
 
 		deletePod := false
 		updateModuleStatus := false

--- a/internal/nmc/helper.go
+++ b/internal/nmc/helper.go
@@ -51,10 +51,8 @@ func (h *helper) SetModuleConfig(
 	if foundEntry == nil {
 		nms := kmmv1beta1.NodeModuleSpec{
 			ModuleItem: kmmv1beta1.ModuleItem{
-				ImageRepoSecret:    mld.ImageRepoSecret,
-				Name:               mld.Name,
-				Namespace:          mld.Namespace,
-				ServiceAccountName: mld.ServiceAccountName,
+				Name:      mld.Name,
+				Namespace: mld.Namespace,
 			},
 		}
 
@@ -62,7 +60,14 @@ func (h *helper) SetModuleConfig(
 		foundEntry = &nmc.Spec.Modules[len(nmc.Spec.Modules)-1]
 	}
 
+	saName := mld.ServiceAccountName
+	if saName == "" {
+		saName = "default"
+	}
+
 	foundEntry.Config = *moduleConfig
+	foundEntry.ImageRepoSecret = mld.ImageRepoSecret
+	foundEntry.ServiceAccountName = saName
 
 	return nil
 }

--- a/internal/nmc/helper_test.go
+++ b/internal/nmc/helper_test.go
@@ -76,8 +76,10 @@ var _ = Describe("SetModuleConfig", func() {
 		nmcHelper = NewHelper(nil)
 	})
 
-	namespace := "test_namespace"
-	name := "test_name"
+	const (
+		namespace = "test_namespace"
+		name      = "test_name"
+	)
 
 	nmc := kmmv1beta1.NodeModulesConfig{}
 
@@ -98,9 +100,12 @@ var _ = Describe("SetModuleConfig", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(nmc.Spec.Modules)).To(Equal(3))
 		Expect(nmc.Spec.Modules[2].Config.InTreeModuleToRemove).To(Equal("in-tree-module"))
+		Expect(nmc.Spec.Modules[2].ServiceAccountName).To(Equal("default"))
 	})
 
 	It("changing existing module config", func() {
+		const saName = "test-sa"
+
 		nmc.Spec.Modules = []kmmv1beta1.NodeModuleSpec{
 			{
 				ModuleItem: kmmv1beta1.ModuleItem{
@@ -118,12 +123,18 @@ var _ = Describe("SetModuleConfig", func() {
 		}
 
 		moduleConfig := kmmv1beta1.ModuleConfig{InTreeModuleToRemove: "in-tree-module"}
+		mld := api.ModuleLoaderData{
+			Name:               name,
+			Namespace:          namespace,
+			ServiceAccountName: saName,
+		}
 
-		err := nmcHelper.SetModuleConfig(&nmc, &api.ModuleLoaderData{Name: name, Namespace: namespace}, &moduleConfig)
+		err := nmcHelper.SetModuleConfig(&nmc, &mld, &moduleConfig)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(nmc.Spec.Modules)).To(Equal(2))
 		Expect(nmc.Spec.Modules[1].Config.InTreeModuleToRemove).To(Equal("in-tree-module"))
+		Expect(nmc.Spec.Modules[1].ServiceAccountName).To(Equal(saName))
 	})
 })
 


### PR DESCRIPTION
Using default instead of an empty string allows us to attach all pull secrets configured for that account when setting up the mounts for the worker Pod.