### PR TITLE
Finalize Module resources

### DIFF
--- a/ci/prow/e2e-incluster-build
+++ b/ci/prow/e2e-incluster-build
@@ -65,7 +65,10 @@ echo "Check that the module gets loaded on the node..."
 timeout 10m bash -c 'until oc debug node/${NODE} -- chroot host/ lsmod | grep kmm_ci_a; do sleep 3; done'
 
 echo "Remove the Module..."
-oc delete -f ci/module-kmm-ci-build-sign.yaml
+oc delete -f ci/module-kmm-ci-build-sign.yaml --wait=false
 
 echo "Check that the module gets unloaded from the node..."
 timeout 1m bash -c 'until ! oc debug node/${NODE} -- chroot host/ lsmod | grep kmm_ci_a; do sleep 3; done'
+
+echo "Wait for the Module to be deleted..."
+oc wait --for delete modules.kmm.sigs.x-k8s.io/kmm-ci

--- a/internal/controllers/mock_nmc_reconciler.go
+++ b/internal/controllers/mock_nmc_reconciler.go
@@ -14,31 +14,45 @@ import (
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// MockworkerHelper is a mock of workerHelper interface.
-type MockworkerHelper struct {
+// MocknmcReconcilerHelper is a mock of nmcReconcilerHelper interface.
+type MocknmcReconcilerHelper struct {
 	ctrl     *gomock.Controller
-	recorder *MockworkerHelperMockRecorder
+	recorder *MocknmcReconcilerHelperMockRecorder
 }
 
-// MockworkerHelperMockRecorder is the mock recorder for MockworkerHelper.
-type MockworkerHelperMockRecorder struct {
-	mock *MockworkerHelper
+// MocknmcReconcilerHelperMockRecorder is the mock recorder for MocknmcReconcilerHelper.
+type MocknmcReconcilerHelperMockRecorder struct {
+	mock *MocknmcReconcilerHelper
 }
 
-// NewMockworkerHelper creates a new mock instance.
-func NewMockworkerHelper(ctrl *gomock.Controller) *MockworkerHelper {
-	mock := &MockworkerHelper{ctrl: ctrl}
-	mock.recorder = &MockworkerHelperMockRecorder{mock}
+// NewMocknmcReconcilerHelper creates a new mock instance.
+func NewMocknmcReconcilerHelper(ctrl *gomock.Controller) *MocknmcReconcilerHelper {
+	mock := &MocknmcReconcilerHelper{ctrl: ctrl}
+	mock.recorder = &MocknmcReconcilerHelperMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockworkerHelper) EXPECT() *MockworkerHelperMockRecorder {
+func (m *MocknmcReconcilerHelper) EXPECT() *MocknmcReconcilerHelperMockRecorder {
 	return m.recorder
 }
 
+// GarbageCollectInUseLabels mocks base method.
+func (m *MocknmcReconcilerHelper) GarbageCollectInUseLabels(ctx context.Context, nmc *v1beta1.NodeModulesConfig) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GarbageCollectInUseLabels", ctx, nmc)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GarbageCollectInUseLabels indicates an expected call of GarbageCollectInUseLabels.
+func (mr *MocknmcReconcilerHelperMockRecorder) GarbageCollectInUseLabels(ctx, nmc interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollectInUseLabels", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).GarbageCollectInUseLabels), ctx, nmc)
+}
+
 // ProcessModuleSpec mocks base method.
-func (m *MockworkerHelper) ProcessModuleSpec(ctx context.Context, nmc *v1beta1.NodeModulesConfig, spec *v1beta1.NodeModuleSpec, status *v1beta1.NodeModuleStatus) error {
+func (m *MocknmcReconcilerHelper) ProcessModuleSpec(ctx context.Context, nmc *v1beta1.NodeModulesConfig, spec *v1beta1.NodeModuleSpec, status *v1beta1.NodeModuleStatus) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ProcessModuleSpec", ctx, nmc, spec, status)
 	ret0, _ := ret[0].(error)
@@ -46,27 +60,27 @@ func (m *MockworkerHelper) ProcessModuleSpec(ctx context.Context, nmc *v1beta1.N
 }
 
 // ProcessModuleSpec indicates an expected call of ProcessModuleSpec.
-func (mr *MockworkerHelperMockRecorder) ProcessModuleSpec(ctx, nmc, spec, status interface{}) *gomock.Call {
+func (mr *MocknmcReconcilerHelperMockRecorder) ProcessModuleSpec(ctx, nmc, spec, status interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessModuleSpec", reflect.TypeOf((*MockworkerHelper)(nil).ProcessModuleSpec), ctx, nmc, spec, status)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessModuleSpec", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).ProcessModuleSpec), ctx, nmc, spec, status)
 }
 
-// ProcessOrphanModuleStatus mocks base method.
-func (m *MockworkerHelper) ProcessOrphanModuleStatus(ctx context.Context, nmc *v1beta1.NodeModulesConfig, status *v1beta1.NodeModuleStatus) error {
+// ProcessUnconfiguredModuleStatus mocks base method.
+func (m *MocknmcReconcilerHelper) ProcessUnconfiguredModuleStatus(ctx context.Context, nmc *v1beta1.NodeModulesConfig, status *v1beta1.NodeModuleStatus) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ProcessOrphanModuleStatus", ctx, nmc, status)
+	ret := m.ctrl.Call(m, "ProcessUnconfiguredModuleStatus", ctx, nmc, status)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// ProcessOrphanModuleStatus indicates an expected call of ProcessOrphanModuleStatus.
-func (mr *MockworkerHelperMockRecorder) ProcessOrphanModuleStatus(ctx, nmc, status interface{}) *gomock.Call {
+// ProcessUnconfiguredModuleStatus indicates an expected call of ProcessUnconfiguredModuleStatus.
+func (mr *MocknmcReconcilerHelperMockRecorder) ProcessUnconfiguredModuleStatus(ctx, nmc, status interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessOrphanModuleStatus", reflect.TypeOf((*MockworkerHelper)(nil).ProcessOrphanModuleStatus), ctx, nmc, status)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ProcessUnconfiguredModuleStatus", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).ProcessUnconfiguredModuleStatus), ctx, nmc, status)
 }
 
 // RemoveOrphanFinalizers mocks base method.
-func (m *MockworkerHelper) RemoveOrphanFinalizers(ctx context.Context, nodeName string) error {
+func (m *MocknmcReconcilerHelper) RemoveOrphanFinalizers(ctx context.Context, nodeName string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveOrphanFinalizers", ctx, nodeName)
 	ret0, _ := ret[0].(error)
@@ -74,13 +88,13 @@ func (m *MockworkerHelper) RemoveOrphanFinalizers(ctx context.Context, nodeName 
 }
 
 // RemoveOrphanFinalizers indicates an expected call of RemoveOrphanFinalizers.
-func (mr *MockworkerHelperMockRecorder) RemoveOrphanFinalizers(ctx, nodeName interface{}) *gomock.Call {
+func (mr *MocknmcReconcilerHelperMockRecorder) RemoveOrphanFinalizers(ctx, nodeName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveOrphanFinalizers", reflect.TypeOf((*MockworkerHelper)(nil).RemoveOrphanFinalizers), ctx, nodeName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveOrphanFinalizers", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).RemoveOrphanFinalizers), ctx, nodeName)
 }
 
 // SyncStatus mocks base method.
-func (m *MockworkerHelper) SyncStatus(ctx context.Context, nmc *v1beta1.NodeModulesConfig) error {
+func (m *MocknmcReconcilerHelper) SyncStatus(ctx context.Context, nmc *v1beta1.NodeModulesConfig) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SyncStatus", ctx, nmc)
 	ret0, _ := ret[0].(error)
@@ -88,9 +102,9 @@ func (m *MockworkerHelper) SyncStatus(ctx context.Context, nmc *v1beta1.NodeModu
 }
 
 // SyncStatus indicates an expected call of SyncStatus.
-func (mr *MockworkerHelperMockRecorder) SyncStatus(ctx, nmc interface{}) *gomock.Call {
+func (mr *MocknmcReconcilerHelperMockRecorder) SyncStatus(ctx, nmc interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncStatus", reflect.TypeOf((*MockworkerHelper)(nil).SyncStatus), ctx, nmc)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncStatus", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).SyncStatus), ctx, nmc)
 }
 
 // MockpodManager is a mock of podManager interface.

--- a/internal/controllers/module_nmc_reconciler.go
+++ b/internal/controllers/module_nmc_reconciler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/auth"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/filter"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/labels"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/module"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/nmc"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/registry"
@@ -116,9 +117,29 @@ func (mnr *ModuleNMCReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	err = sumErr.ErrorOrNil()
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to reconcile module %s/%s with nodes: %v", mod.Namespace, mod.Name, err)
+		return ctrl.Result{}, fmt.Errorf("failed to reconcile module %s/%s config: %v", mod.Namespace, mod.Name, err)
 	}
 	return ctrl.Result{}, nil
+}
+
+func (mnr *ModuleNMCReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.
+		NewControllerManagedBy(mgr).
+		For(&kmmv1beta1.Module{}).
+		Owns(&buildv1.Build{}, builder.WithPredicates(filter.ModuleNMCReconcileBuildPredicate())).
+		Watches(
+			&v1.Node{},
+			handler.EnqueueRequestsFromMapFunc(mnr.filter.FindModulesForNMCNodeChange),
+			builder.WithPredicates(
+				filter.ModuleNMCReconcilerNodePredicate(),
+			),
+		).
+		Watches(
+			&kmmv1beta1.NodeModulesConfig{},
+			handler.EnqueueRequestsFromMapFunc(filter.ListModulesForNMC),
+		).
+		Named(ModuleNMCReconcilerName).
+		Complete(mnr)
 }
 
 //go:generate mockgen -source=module_nmc_reconciler.go -package=controllers -destination=mock_module_nmc_reconciler.go moduleNMCReconcilerHelperAPI
@@ -183,23 +204,45 @@ func (mnrh *moduleNMCReconcilerHelper) getRequestedModule(ctx context.Context, n
 
 func (mnrh *moduleNMCReconcilerHelper) finalizeModule(ctx context.Context, mod *kmmv1beta1.Module) error {
 	nmcList := kmmv1beta1.NodeModulesConfigList{}
-	err := mnrh.client.List(ctx, &nmcList)
-	if err != nil {
-		return fmt.Errorf("failed to list NMCs in the cluster: %v", err)
+
+	modNSN := types.NamespacedName{Namespace: mod.Namespace, Name: mod.Name}
+
+	matchesConfigured := client.MatchingLabels{
+		nmc.ModuleConfiguredLabel(mod.Namespace, mod.Name): "",
+	}
+
+	if err := mnrh.client.List(ctx, &nmcList, matchesConfigured); err != nil {
+		return fmt.Errorf("failed to list NMCs with %s configured in the cluster: %v", modNSN, err)
 	}
 
 	var sumErr *multierror.Error
 	// errs := make([]error, 0, len(nmcList.Items))
 	for _, nmc := range nmcList.Items {
-		err = mnrh.removeModuleFromNMC(ctx, &nmc, mod.Namespace, mod.Name)
+		err := mnrh.removeModuleFromNMC(ctx, &nmc, mod.Namespace, mod.Name)
 		sumErr = multierror.Append(sumErr, err)
 		//errs = append(errs, err)
 	}
 
 	//err = errors.Join(errs...)
-	err = sumErr.ErrorOrNil()
+	err := sumErr.ErrorOrNil()
 	if err != nil {
-		return fmt.Errorf("failed to remove %s/%s module from some of NMCs: %v", mod.Namespace, mod.Name, err)
+		return fmt.Errorf("failed to remove %s module from some of NMCs: %v", modNSN, err)
+	}
+
+	// Now, list all NMCs that still have the Module loaded
+	nmcList = kmmv1beta1.NodeModulesConfigList{}
+
+	matchesInUse := client.MatchingLabels{
+		nmc.ModuleInUseLabel(mod.Namespace, mod.Name): "",
+	}
+
+	if err := mnrh.client.List(ctx, &nmcList, matchesInUse); err != nil {
+		return fmt.Errorf("failed to list NMCs with %s loaded in the cluster: %v", modNSN, err)
+	}
+
+	if l := len(nmcList.Items); l > 0 {
+		ctrl.LoggerFrom(ctx).Info("Some NMCs still list the Module as in-use; not removing the finalizer", "count", l)
+		return nil
 	}
 
 	// remove finalizer
@@ -239,7 +282,7 @@ func (mnrh *moduleNMCReconcilerHelper) getNMCsByModuleSet(ctx context.Context, m
 
 func (mnrh *moduleNMCReconcilerHelper) getNMCsNamesForModule(ctx context.Context, mod *kmmv1beta1.Module) ([]string, error) {
 	logger := log.FromContext(ctx)
-	moduleNMCLabel := utils.GetModuleNMCLabel(mod.Namespace, mod.Name)
+	moduleNMCLabel := nmc.ModuleConfiguredLabel(mod.Namespace, mod.Name)
 	logger.V(1).Info("Listing nmcs", "selector", moduleNMCLabel)
 	selectedNMCs := kmmv1beta1.NodeModulesConfigList{}
 	opt := client.MatchingLabels(map[string]string{moduleNMCLabel: ""})
@@ -305,16 +348,20 @@ func (mnrh *moduleNMCReconcilerHelper) enableModuleOnNode(ctx context.Context, m
 		moduleConfig.InsecurePull = tls.Insecure || tls.InsecureSkipTLSVerify
 	}
 
-	nmc := &kmmv1beta1.NodeModulesConfig{
+	nmcObj := &kmmv1beta1.NodeModulesConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: node.Name},
 	}
 
-	opRes, err := controllerutil.CreateOrPatch(ctx, mnrh.client, nmc, func() error {
-		err = mnrh.nmcHelper.SetModuleConfig(nmc, mld, &moduleConfig)
+	opRes, err := controllerutil.CreateOrPatch(ctx, mnrh.client, nmcObj, func() error {
+		err = mnrh.nmcHelper.SetModuleConfig(nmcObj, mld, &moduleConfig)
 		if err != nil {
 			return err
 		}
-		return controllerutil.SetOwnerReference(node, nmc, mnrh.scheme)
+
+		labels.SetLabel(nmcObj, nmc.ModuleConfiguredLabel(mld.Namespace, mld.Name), "")
+		labels.SetLabel(nmcObj, nmc.ModuleInUseLabel(mld.Namespace, mld.Name), "")
+
+		return controllerutil.SetOwnerReference(node, nmcObj, mnrh.scheme)
 	})
 
 	if err != nil {
@@ -332,33 +379,22 @@ func (mnrh *moduleNMCReconcilerHelper) disableModuleOnNode(ctx context.Context, 
 	return mnrh.removeModuleFromNMC(ctx, nmc, modNamespace, modName)
 }
 
-func (mnrh *moduleNMCReconcilerHelper) removeModuleFromNMC(ctx context.Context, nmc *kmmv1beta1.NodeModulesConfig, modNamespace, modName string) error {
+func (mnrh *moduleNMCReconcilerHelper) removeModuleFromNMC(ctx context.Context, nmcObj *kmmv1beta1.NodeModulesConfig, modNamespace, modName string) error {
 	logger := log.FromContext(ctx)
-	opRes, err := controllerutil.CreateOrPatch(ctx, mnrh.client, nmc, func() error {
-		return mnrh.nmcHelper.RemoveModuleConfig(nmc, modNamespace, modName)
+	opRes, err := controllerutil.CreateOrPatch(ctx, mnrh.client, nmcObj, func() error {
+		if err := mnrh.nmcHelper.RemoveModuleConfig(nmcObj, modNamespace, modName); err != nil {
+			return err
+		}
+
+		labels.RemoveLabel(nmcObj, nmc.ModuleConfiguredLabel(modNamespace, modName))
+
+		return nil
 	})
 
 	if err != nil {
-		return fmt.Errorf("failed to disable module %s/%s in NMC %s: %v", modNamespace, modName, nmc.Name, err)
+		return fmt.Errorf("failed to disable module %s/%s in NMC %s: %v", modNamespace, modName, nmcObj.Name, err)
 	}
 
-	logger.Info("Disabled module in NMC", "name", modName, "namespace", modNamespace, "NMC", nmc.Name, "result", opRes)
+	logger.Info("Disabled module in NMC", "name", modName, "namespace", modNamespace, "NMC", nmcObj.Name, "result", opRes)
 	return nil
-}
-
-func (mnr *ModuleNMCReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.
-		NewControllerManagedBy(mgr).
-		For(&kmmv1beta1.Module{}).
-		Owns(&kmmv1beta1.NodeModulesConfig{}).
-		Owns(&buildv1.Build{}, builder.WithPredicates(filter.ModuleNMCReconcileBuildPredicate())).
-		Watches(
-			&v1.Node{},
-			handler.EnqueueRequestsFromMapFunc(mnr.filter.FindModulesForNMCNodeChange),
-			builder.WithPredicates(
-				filter.ModuleNMCReconcilerNodePredicate(),
-			),
-		).
-		Named(ModuleNMCReconcilerName).
-		Complete(mnr)
 }

--- a/internal/controllers/module_nmc_reconciler_test.go
+++ b/internal/controllers/module_nmc_reconciler_test.go
@@ -321,13 +321,20 @@ var _ = Describe("getNodesListBySelector", func() {
 })
 
 var _ = Describe("finalizeModule", func() {
+	const (
+		moduleName      = "moduleName"
+		moduleNamespace = "moduleNamespace"
+	)
+
 	var (
-		ctx    context.Context
-		ctrl   *gomock.Controller
-		clnt   *client.MockClient
-		helper *nmc.MockHelper
-		mnrh   moduleNMCReconcilerHelperAPI
-		mod    *kmmv1beta1.Module
+		ctx                    context.Context
+		ctrl                   *gomock.Controller
+		clnt                   *client.MockClient
+		helper                 *nmc.MockHelper
+		mnrh                   moduleNMCReconcilerHelperAPI
+		mod                    *kmmv1beta1.Module
+		matchConfiguredModules = map[string]string{nmc.ModuleConfiguredLabel(moduleNamespace, moduleName): ""}
+		matchLoadedModules     = map[string]string{nmc.ModuleInUseLabel(moduleNamespace, moduleName): ""}
 	)
 
 	BeforeEach(func() {
@@ -337,12 +344,15 @@ var _ = Describe("finalizeModule", func() {
 		helper = nmc.NewMockHelper(ctrl)
 		mnrh = newModuleNMCReconcilerHelper(clnt, nil, nil, helper, nil, scheme)
 		mod = &kmmv1beta1.Module{
-			ObjectMeta: metav1.ObjectMeta{Name: "moduleName", Namespace: "moduleNamespace"},
+			ObjectMeta: metav1.ObjectMeta{Name: moduleName, Namespace: moduleNamespace},
 		}
 	})
 
 	It("failed to get list of NMCs", func() {
-		clnt.EXPECT().List(ctx, gomock.Any()).Return(fmt.Errorf("some error"))
+		clnt.
+			EXPECT().
+			List(ctx, &kmmv1beta1.NodeModulesConfigList{}, matchConfiguredModules).
+			Return(fmt.Errorf("some error"))
 
 		err := mnrh.finalizeModule(ctx, mod)
 
@@ -376,12 +386,13 @@ var _ = Describe("finalizeModule", func() {
 
 	It("no nmcs, patch successfull", func() {
 		gomock.InOrder(
-			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			clnt.EXPECT().List(ctx, &kmmv1beta1.NodeModulesConfigList{}, matchConfiguredModules).DoAndReturn(
 				func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
 					list.Items = []kmmv1beta1.NodeModulesConfig{}
 					return nil
 				},
 			),
+			clnt.EXPECT().List(ctx, &kmmv1beta1.NodeModulesConfigList{}, matchLoadedModules),
 			clnt.EXPECT().Patch(ctx, mod, gomock.Any()).Return(nil),
 		)
 
@@ -390,14 +401,38 @@ var _ = Describe("finalizeModule", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("no nmcs, failed", func() {
+	It("some nmcs have the Module loaded, does not patch", func() {
 		gomock.InOrder(
-			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			clnt.EXPECT().List(ctx, &kmmv1beta1.NodeModulesConfigList{}, matchConfiguredModules).DoAndReturn(
+				func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
+					list.Items = make([]kmmv1beta1.NodeModulesConfig, 0)
+					return nil
+				},
+			),
+			clnt.EXPECT().List(ctx, &kmmv1beta1.NodeModulesConfigList{}, matchLoadedModules).DoAndReturn(
+				func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
+					list.Items = make([]kmmv1beta1.NodeModulesConfig, 1)
+					return nil
+				},
+			),
+		)
+
+		Expect(
+			mnrh.finalizeModule(ctx, mod),
+		).NotTo(
+			HaveOccurred(),
+		)
+	})
+
+	It("no nmcs, patch failed", func() {
+		gomock.InOrder(
+			clnt.EXPECT().List(ctx, &kmmv1beta1.NodeModulesConfigList{}, matchConfiguredModules).DoAndReturn(
 				func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
 					list.Items = []kmmv1beta1.NodeModulesConfig{}
 					return nil
 				},
 			),
+			clnt.EXPECT().List(ctx, &kmmv1beta1.NodeModulesConfigList{}, matchLoadedModules),
 			clnt.EXPECT().Patch(ctx, mod, gomock.Any()).Return(fmt.Errorf("some error")),
 		)
 
@@ -545,6 +580,11 @@ var _ = Describe("prepareSchedulingData", func() {
 })
 
 var _ = Describe("enableModuleOnNode", func() {
+	const (
+		moduleNamespace = "moduleNamespace"
+		moduleName      = "moduleName"
+	)
+
 	var (
 		ctx                  context.Context
 		ctrl                 *gomock.Controller
@@ -573,8 +613,8 @@ var _ = Describe("enableModuleOnNode", func() {
 		ctx = context.Background()
 		mld = &api.ModuleLoaderData{
 			KernelVersion:        kernelVersion,
-			Name:                 "moduleName",
-			Namespace:            "moduleNamespace",
+			Name:                 moduleName,
+			Namespace:            moduleNamespace,
 			InTreeModuleToRemove: "InTreeModuleToRemove",
 			ContainerImage:       "containerImage",
 		}
@@ -626,10 +666,24 @@ var _ = Describe("enableModuleOnNode", func() {
 	})
 
 	It("NMC exists", func() {
-		nmc := &kmmv1beta1.NodeModulesConfig{
+		nmcObj := &kmmv1beta1.NodeModulesConfig{
 			ObjectMeta: metav1.ObjectMeta{Name: node.Name},
 		}
+
 		authGetter := &auth.MockRegistryAuthGetter{}
+
+		nmcWithLabels := *nmcObj
+		nmcWithLabels.SetLabels(map[string]string{
+			nmc.ModuleConfiguredLabel(moduleNamespace, moduleName): "",
+			nmc.ModuleInUseLabel(moduleNamespace, moduleName):      "",
+		})
+
+		Expect(
+			controllerutil.SetOwnerReference(&node, &nmcWithLabels, scheme),
+		).NotTo(
+			HaveOccurred(),
+		)
+
 		gomock.InOrder(
 			authFactory.EXPECT().NewRegistryAuthGetterFrom(mld).Return(authGetter),
 			rgst.EXPECT().ImageExists(ctx, mld.ContainerImage, gomock.Any(), authGetter).Return(true, nil),
@@ -639,8 +693,8 @@ var _ = Describe("enableModuleOnNode", func() {
 					return nil
 				},
 			),
-			helper.EXPECT().SetModuleConfig(nmc, mld, expectedModuleConfig).Return(nil),
-			clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(nil),
+			helper.EXPECT().SetModuleConfig(nmcObj, mld, expectedModuleConfig).Return(nil),
+			clnt.EXPECT().Patch(ctx, &nmcWithLabels, gomock.Any()).Return(nil),
 		)
 
 		err := mnrh.enableModuleOnNode(ctx, mld, &node)
@@ -747,5 +801,31 @@ var _ = Describe("removeModuleFromNMC", func() {
 
 		err := mnrh.removeModuleFromNMC(ctx, nmc, moduleNamespace, moduleName)
 		Expect(err).To(HaveOccurred())
+	})
+
+	It("removes the configured label", func() {
+		nmc := &kmmv1beta1.NodeModulesConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   nmcName,
+				Labels: map[string]string{nmc.ModuleConfiguredLabel(moduleNamespace, moduleName): ""},
+			},
+		}
+
+		nmcWithoutLabel := *nmc
+		nmcWithoutLabel.SetLabels(make(map[string]string))
+
+		gomock.InOrder(
+			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ interface{}, _ interface{}, nmc *kmmv1beta1.NodeModulesConfig, _ ...ctrlclient.GetOption) error {
+					nmc.SetName(nmcName)
+					return nil
+				},
+			),
+			helper.EXPECT().RemoveModuleConfig(nmc, moduleNamespace, moduleName).Return(nil),
+			clnt.EXPECT().Patch(ctx, &nmcWithoutLabel, gomock.Any()),
+		)
+
+		err := mnrh.removeModuleFromNMC(ctx, nmc, moduleNamespace, moduleName)
+		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/internal/controllers/nmc_reconciler_test.go
+++ b/internal/controllers/nmc_reconciler_test.go
@@ -15,6 +15,7 @@ import (
 	testclient "github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/config"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/nmc"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/ocp/ca"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/worker"
 	"go.uber.org/mock/gomock"
@@ -35,7 +36,7 @@ const nmcName = "nmc"
 var _ = Describe("NodeModulesConfigReconciler_Reconcile", func() {
 	var (
 		kubeClient *testclient.MockClient
-		wh         *MockworkerHelper
+		wh         *MocknmcReconcilerHelper
 
 		r *NMCReconciler
 
@@ -47,7 +48,7 @@ var _ = Describe("NodeModulesConfigReconciler_Reconcile", func() {
 	BeforeEach(func() {
 		ctrl := gomock.NewController(GinkgoT())
 		kubeClient = testclient.NewMockClient(ctrl)
-		wh = NewMockworkerHelper(ctrl)
+		wh = NewMocknmcReconcilerHelper(ctrl)
 		r = &NMCReconciler{
 			client: kubeClient,
 			helper: wh,
@@ -147,7 +148,8 @@ var _ = Describe("NodeModulesConfigReconciler_Reconcile", func() {
 			wh.EXPECT().SyncStatus(ctx, nmc),
 			wh.EXPECT().ProcessModuleSpec(contextWithValueMatch, nmc, &spec0, &status0),
 			wh.EXPECT().ProcessModuleSpec(contextWithValueMatch, nmc, &spec1, nil),
-			wh.EXPECT().ProcessOrphanModuleStatus(contextWithValueMatch, nmc, &status2),
+			wh.EXPECT().ProcessUnconfiguredModuleStatus(contextWithValueMatch, nmc, &status2),
+			wh.EXPECT().GarbageCollectInUseLabels(ctx, nmc),
 		)
 
 		Expect(
@@ -174,7 +176,95 @@ var moduleConfig = kmmv1beta1.ModuleConfig{
 	},
 }
 
-var _ = Describe("workerHelper_ProcessModuleSpec", func() {
+var _ = Describe("nmcReconcilerHelperImpl_GarbageCollectInUseLabels", func() {
+	var (
+		ctx = context.TODO()
+
+		client *testclient.MockClient
+		wh     nmcReconcilerHelper
+	)
+
+	BeforeEach(func() {
+		ctrl := gomock.NewController(GinkgoT())
+		client = testclient.NewMockClient(ctrl)
+		wh = newWorkerHelper(client, nil)
+	})
+
+	It("should do nothing if no labels should be collected", func() {
+		nmcObj := &kmmv1beta1.NodeModulesConfig{
+
+			Status: kmmv1beta1.NodeModulesConfigStatus{
+				Modules: make([]kmmv1beta1.NodeModuleStatus, 0),
+			},
+		}
+
+		Expect(
+			wh.GarbageCollectInUseLabels(ctx, nmcObj),
+		).NotTo(
+			HaveOccurred(),
+		)
+	})
+
+	It("should work as expected", func() {
+		bInUse := nmc.ModuleInUseLabel("b", "b")
+		cInUse := nmc.ModuleInUseLabel("c", "c")
+
+		nmcObj := &kmmv1beta1.NodeModulesConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					nmc.ModuleInUseLabel("a", "a"): "",
+					bInUse:                         "",
+					cInUse:                         "",
+				},
+			},
+			Spec: kmmv1beta1.NodeModulesConfigSpec{
+				Modules: []kmmv1beta1.NodeModuleSpec{
+					{
+						ModuleItem: kmmv1beta1.ModuleItem{
+							Namespace: "b",
+							Name:      "b",
+						},
+					},
+				},
+			},
+			Status: kmmv1beta1.NodeModulesConfigStatus{
+				Modules: []kmmv1beta1.NodeModuleStatus{
+					{
+						ModuleItem: kmmv1beta1.ModuleItem{
+							Namespace: "c",
+							Name:      "c",
+						},
+					},
+					{
+						ModuleItem: kmmv1beta1.ModuleItem{
+							Namespace: "d",
+							Name:      "d",
+						},
+					},
+				},
+			},
+		}
+
+		client.EXPECT().Patch(ctx, nmcObj, gomock.Any())
+
+		Expect(
+			wh.GarbageCollectInUseLabels(ctx, nmcObj),
+		).NotTo(
+			HaveOccurred(),
+		)
+
+		Expect(nmcObj.Labels).To(
+			Equal(
+				map[string]string{
+					bInUse: "",
+					cInUse: "",
+				},
+			),
+		)
+	})
+})
+
+var _ = Describe("nmcReconcilerHelperImpl_ProcessModuleSpec", func() {
 	const (
 		name      = "name"
 		namespace = "namespace"
@@ -185,7 +275,7 @@ var _ = Describe("workerHelper_ProcessModuleSpec", func() {
 
 		client *testclient.MockClient
 		pm     *MockpodManager
-		wh     workerHelper
+		wh     nmcReconcilerHelper
 	)
 
 	BeforeEach(func() {
@@ -213,7 +303,7 @@ var _ = Describe("workerHelper_ProcessModuleSpec", func() {
 		)
 	})
 
-	It("should create a loader Pod if inStatus is false, but the Config is not define (nil)", func() {
+	It("should create a loader Pod if inProgress is false, but the Config is not define (nil)", func() {
 		nmc := &kmmv1beta1.NodeModulesConfig{}
 		spec := &kmmv1beta1.NodeModuleSpec{
 			ModuleItem: kmmv1beta1.ModuleItem{
@@ -378,7 +468,7 @@ var _ = Describe("workerHelper_ProcessModuleSpec", func() {
 	)
 })
 
-var _ = Describe("workerHelper_ProcessOrphanModuleStatus", func() {
+var _ = Describe("nmcReconcilerHelperImpl_ProcessUnconfiguredModuleStatus", func() {
 	ctx := context.TODO()
 
 	It("should do nothing if the status sync is in progress", func() {
@@ -386,7 +476,7 @@ var _ = Describe("workerHelper_ProcessOrphanModuleStatus", func() {
 		status := &kmmv1beta1.NodeModuleStatus{InProgress: true}
 
 		Expect(
-			newWorkerHelper(nil, nil).ProcessOrphanModuleStatus(ctx, nmc, status),
+			newWorkerHelper(nil, nil).ProcessUnconfiguredModuleStatus(ctx, nmc, status),
 		).NotTo(
 			HaveOccurred(),
 		)
@@ -402,7 +492,7 @@ var _ = Describe("workerHelper_ProcessOrphanModuleStatus", func() {
 		client.EXPECT().Status().Return(sw)
 		sw.EXPECT().Patch(ctx, nmc, gomock.Any())
 		Expect(
-			newWorkerHelper(client, nil).ProcessOrphanModuleStatus(ctx, nmc, status),
+			newWorkerHelper(client, nil).ProcessUnconfiguredModuleStatus(ctx, nmc, status),
 		).NotTo(
 			HaveOccurred(),
 		)
@@ -422,22 +512,22 @@ var _ = Describe("workerHelper_ProcessOrphanModuleStatus", func() {
 		pm.EXPECT().CreateUnloaderPod(ctx, nmc, status)
 
 		Expect(
-			wh.ProcessOrphanModuleStatus(ctx, nmc, status),
+			wh.ProcessUnconfiguredModuleStatus(ctx, nmc, status),
 		).NotTo(
 			HaveOccurred(),
 		)
 	})
 })
 
-var _ = Describe("workerHelper_SyncStatus", func() {
+var _ = Describe("nmcReconcilerHelperImpl_SyncStatus", func() {
 	var (
 		ctx = context.TODO()
 
 		ctrl       *gomock.Controller
 		kubeClient *testclient.MockClient
 		pm         *MockpodManager
-		wh         workerHelper
 		sw         *testclient.MockStatusWriter
+		wh         nmcReconcilerHelper
 	)
 
 	BeforeEach(func() {
@@ -574,7 +664,7 @@ var _ = Describe("workerHelper_SyncStatus", func() {
 		Expect(nmc.Status.Modules[1].InProgress).To(BeTrue())
 	})
 
-	It("should remove the status if an unloader pod was successful", func() {
+	It("should remove the status and label if an unloader pod was successful", func() {
 		const (
 			modName      = "module"
 			modNamespace = "namespace"
@@ -708,7 +798,7 @@ var _ = Describe("workerHelper_SyncStatus", func() {
 	})
 })
 
-var _ = Describe("workerHelper_RemoveOrphanFinalizers", func() {
+var _ = Describe("nmcReconcilerHelperImpl_RemoveOrphanFinalizers", func() {
 	const nodeName = "node-name"
 
 	var (
@@ -716,7 +806,7 @@ var _ = Describe("workerHelper_RemoveOrphanFinalizers", func() {
 
 		kubeClient *testclient.MockClient
 		pm         *MockpodManager
-		wh         workerHelper
+		wh         nmcReconcilerHelper
 	)
 
 	BeforeEach(func() {

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -126,6 +126,28 @@ func (f *Filter) ModuleReconcilerNodePredicate(kernelLabel string) predicate.Pre
 	)
 }
 
+func ListModulesForNMC(_ context.Context, obj client.Object) []reconcile.Request {
+	modules := sets.New[reconcile.Request]()
+
+	for k := range obj.GetLabels() {
+		if ok, ns, name := nmc.IsModuleConfiguredLabel(k); ok {
+			modules.Insert(reconcile.Request{
+				NamespacedName: types.NamespacedName{Namespace: ns, Name: name},
+			})
+
+			continue
+		}
+
+		if ok, ns, name := nmc.IsModuleInUseLabel(k); ok {
+			modules.Insert(reconcile.Request{
+				NamespacedName: types.NamespacedName{Namespace: ns, Name: name},
+			})
+		}
+	}
+
+	return modules.UnsortedList()
+}
+
 func ModuleNMCReconcilerNodePredicate() predicate.Predicate {
 	return predicate.And(
 		skipDeletions,

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -174,6 +174,41 @@ var _ = Describe("kmmClusterClaimChanged", func() {
 	)
 })
 
+var _ = Describe("ListModulesForNMC", func() {
+	const (
+		namespace0 = "namespace0"
+		name0      = "name0"
+		namespace1 = "namespace1"
+		name1      = "name1"
+		namespace2 = "namespace2"
+		name2      = "name2"
+	)
+
+	It("should work as expected", func() {
+		nmcObj := &kmmv1beta1.NodeModulesConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"abc": "def",
+					nmc.ModuleConfiguredLabel(namespace0, name0): "",
+					nmc.ModuleInUseLabel(namespace0, name0):      "",
+					nmc.ModuleConfiguredLabel(namespace1, name1): "",
+					nmc.ModuleInUseLabel(namespace2, name2):      "",
+				},
+			},
+		}
+
+		Expect(
+			ListModulesForNMC(context.TODO(), nmcObj),
+		).To(
+			ConsistOf(
+				reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace0, Name: name0}},
+				reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace1, Name: name1}},
+				reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace2, Name: name2}},
+			),
+		)
+	})
+})
+
 var _ = Describe("ModuleReconcilerNodePredicate", func() {
 	const kernelLabel = "kernel-label"
 	var p predicate.Predicate

--- a/internal/filter/suite_test.go
+++ b/internal/filter/suite_test.go
@@ -5,18 +5,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/test"
-	"k8s.io/apimachinery/pkg/runtime"
 )
-
-var scheme *runtime.Scheme
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-
-	var err error
-	scheme, err = test.TestScheme()
-	Expect(err).NotTo(HaveOccurred())
-
 	RunSpecs(t, "Filter Suite")
 }

--- a/internal/labels/labels.go
+++ b/internal/labels/labels.go
@@ -1,0 +1,27 @@
+package labels
+
+import "sigs.k8s.io/controller-runtime/pkg/client"
+
+func RemoveLabel(obj client.Object, key string) {
+	labels := obj.GetLabels()
+
+	if labels == nil {
+		return
+	}
+
+	delete(labels, key)
+
+	obj.SetLabels(labels)
+}
+
+func SetLabel(obj client.Object, key, value string) {
+	labels := obj.GetLabels()
+
+	if labels == nil {
+		labels = make(map[string]string, 1)
+	}
+
+	labels[key] = value
+
+	obj.SetLabels(labels)
+}

--- a/internal/labels/labels_test.go
+++ b/internal/labels/labels_test.go
@@ -1,0 +1,55 @@
+package labels
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = Describe("SetLabel", func() {
+	const key = "test-key"
+
+	DescribeTable(
+		"should work as expected",
+		func(labels map[string]string, key, value string) {
+			obj := &unstructured.Unstructured{}
+
+			obj.SetLabels(labels)
+
+			SetLabel(obj, key, value)
+
+			Expect(
+				obj.GetLabels(),
+			).To(
+				HaveKeyWithValue(key, value),
+			)
+		},
+		Entry("nil labels", nil, key, "test value"),
+		Entry("empty labels", make(map[string]string), key, "test value"),
+		Entry("existing label", map[string]string{key: "some-other-value"}, key, "test value"),
+	)
+})
+
+var _ = Describe("RemoveLabel", func() {
+	const key = "test-key"
+
+	DescribeTable(
+		"should work as expected",
+		func(labels map[string]string, key string) {
+			obj := &unstructured.Unstructured{}
+
+			obj.SetLabels(labels)
+
+			RemoveLabel(obj, key)
+
+			Expect(
+				obj.GetLabels(),
+			).NotTo(
+				HaveKey(key),
+			)
+		},
+		Entry("nil labels", nil, key),
+		Entry("empty labels", make(map[string]string), key),
+		Entry("existing label", map[string]string{key: "some-other-value"}, key),
+	)
+})

--- a/internal/labels/suite_test.go
+++ b/internal/labels/suite_test.go
@@ -1,4 +1,4 @@
-package nmc
+package labels
 
 import (
 	"testing"
@@ -9,5 +9,5 @@ import (
 
 func TestSuite(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "NMC Suite")
+	RunSpecs(t, "Labels Suite")
 }

--- a/internal/nmc/helper.go
+++ b/internal/nmc/helper.go
@@ -6,7 +6,6 @@ import (
 
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -62,7 +61,7 @@ func (h *helper) SetModuleConfig(
 		nmc.Spec.Modules = append(nmc.Spec.Modules, nms)
 		foundEntry = &nmc.Spec.Modules[len(nmc.Spec.Modules)-1]
 	}
-	setLabel(nmc, mld.Namespace, mld.Name)
+
 	foundEntry.Config = *moduleConfig
 
 	return nil
@@ -73,7 +72,6 @@ func (h *helper) RemoveModuleConfig(nmc *kmmv1beta1.NodeModulesConfig, namespace
 	if foundEntry != nil {
 		nmc.Spec.Modules = append(nmc.Spec.Modules[:index], nmc.Spec.Modules[index+1:]...)
 	}
-	removeLabel(nmc, namespace, name)
 	return nil
 }
 
@@ -125,24 +123,5 @@ func SetModuleStatus(statuses *[]kmmv1beta1.NodeModuleStatus, status kmmv1beta1.
 		*s = status
 	} else {
 		*statuses = append(*statuses, status)
-	}
-}
-
-func setLabel(nmc *kmmv1beta1.NodeModulesConfig, namespace, name string) {
-	moduleNMCLabel := utils.GetModuleNMCLabel(namespace, name)
-	nmcLabels := nmc.GetLabels()
-	if nmcLabels == nil {
-		nmcLabels = map[string]string{}
-	}
-	nmcLabels[moduleNMCLabel] = ""
-	nmc.SetLabels(nmcLabels)
-}
-
-func removeLabel(nmc *kmmv1beta1.NodeModulesConfig, namespace, name string) {
-	moduleNMCLabel := utils.GetModuleNMCLabel(namespace, name)
-	nmcLabels := nmc.GetLabels()
-	if nmcLabels != nil {
-		delete(nmcLabels, moduleNMCLabel)
-		nmc.SetLabels(nmcLabels)
 	}
 }

--- a/internal/nmc/helper_test.go
+++ b/internal/nmc/helper_test.go
@@ -9,7 +9,6 @@ import (
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	"go.uber.org/mock/gomock"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -99,7 +98,6 @@ var _ = Describe("SetModuleConfig", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(nmc.Spec.Modules)).To(Equal(3))
 		Expect(nmc.Spec.Modules[2].Config.InTreeModuleToRemove).To(Equal("in-tree-module"))
-		Expect(nmc.GetLabels()).To(HaveKeyWithValue(utils.GetModuleNMCLabel(namespace, name), ""))
 	})
 
 	It("changing existing module config", func() {
@@ -126,7 +124,6 @@ var _ = Describe("SetModuleConfig", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(nmc.Spec.Modules)).To(Equal(2))
 		Expect(nmc.Spec.Modules[1].Config.InTreeModuleToRemove).To(Equal("in-tree-module"))
-		Expect(nmc.GetLabels()).To(HaveKeyWithValue(utils.GetModuleNMCLabel(namespace, name), ""))
 	})
 })
 
@@ -166,11 +163,10 @@ var _ = Describe("RemoveModuleConfig", func() {
 		Expect(len(nmc.Spec.Modules)).To(Equal(2))
 		Expect(nmc.Spec.Modules[0].Config.InTreeModuleToRemove).To(Equal("some-in-tree-module-1"))
 		Expect(nmc.Spec.Modules[1].Config.InTreeModuleToRemove).To(Equal("some-in-tree-module-2"))
-		Expect(nmc.GetLabels()).NotTo(HaveKeyWithValue(utils.GetModuleNMCLabel(namespace, name), ""))
 	})
 
 	It("deleting existing module", func() {
-		nmc.SetLabels(map[string]string{utils.GetModuleNMCLabel(namespace, name): ""})
+		nmc.SetLabels(map[string]string{ModuleConfiguredLabel(namespace, name): ""})
 		nmc.Spec.Modules = []kmmv1beta1.NodeModuleSpec{
 			{
 				ModuleItem: kmmv1beta1.ModuleItem{
@@ -193,7 +189,6 @@ var _ = Describe("RemoveModuleConfig", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(nmc.Spec.Modules)).To(Equal(1))
 		Expect(nmc.Spec.Modules[0].Config.InTreeModuleToRemove).To(Equal("some-in-tree-module-1"))
-		Expect(nmc.GetLabels()).NotTo(HaveKeyWithValue(utils.GetModuleNMCLabel(namespace, name), ""))
 	})
 })
 

--- a/internal/nmc/labels.go
+++ b/internal/nmc/labels.go
@@ -1,0 +1,39 @@
+package nmc
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var (
+	reConfiguredLabel = regexp.MustCompile(`^beta\.kmm\.node\.kubernetes\.io/([a-zA-Z0-9-]+)\.([a-zA-Z0-9-]+)\.module-configured$`)
+	reInUseLabel      = regexp.MustCompile(`^beta\.kmm\.node\.kubernetes\.io/([a-zA-Z0-9-]+)\.([a-zA-Z0-9-]+)\.module-in-use$`)
+)
+
+func IsModuleConfiguredLabel(s string) (bool, string, string) {
+	res := reConfiguredLabel.FindStringSubmatch(s)
+
+	if len(res) != 3 {
+		return false, "", ""
+	}
+
+	return true, res[1], res[2]
+}
+
+func IsModuleInUseLabel(s string) (bool, string, string) {
+	res := reInUseLabel.FindStringSubmatch(s)
+
+	if len(res) != 3 {
+		return false, "", ""
+	}
+
+	return true, res[1], res[2]
+}
+
+func ModuleConfiguredLabel(namespace, name string) string {
+	return fmt.Sprintf("beta.kmm.node.kubernetes.io/%s.%s.module-configured", namespace, name)
+}
+
+func ModuleInUseLabel(namespace, name string) string {
+	return fmt.Sprintf("beta.kmm.node.kubernetes.io/%s.%s.module-in-use", namespace, name)
+}

--- a/internal/nmc/labels_test.go
+++ b/internal/nmc/labels_test.go
@@ -1,0 +1,74 @@
+package nmc
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ModuleConfiguredLabel", func() {
+	It("should work as expected", func() {
+
+		Expect(
+			ModuleConfiguredLabel("a", "b"),
+		).To(
+			Equal("beta.kmm.node.kubernetes.io/a.b.module-configured"),
+		)
+	})
+})
+
+var _ = Describe("ModuleInUseLabel", func() {
+	It("should work as expected", func() {
+
+		Expect(
+			ModuleInUseLabel("a", "b"),
+		).To(
+			Equal("beta.kmm.node.kubernetes.io/a.b.module-in-use"),
+		)
+	})
+})
+
+var _ = Describe("IsModuleConfiguredLabel", func() {
+	DescribeTable(
+		"should work as expected",
+		func(input string, expectedOK bool, expectedNS, expectedName string) {
+			ok, ns, name := IsModuleConfiguredLabel(input)
+
+			if !expectedOK {
+				Expect(ok).To(BeFalse())
+				return
+			}
+
+			Expect(ok).To(BeTrue())
+			Expect(ns).To(Equal(expectedNS))
+			Expect(name).To(Equal(expectedName))
+		},
+		Entry(nil, "a.b.module-in-use", false, "", ""),
+		Entry(nil, "beta.kmm.node.kubernetes.io/a.b.module-configured", true, "a", "b"),
+		Entry(nil, "beta.kmm.node.kubernetes.io/..module-configured", false, "", ""),
+		Entry(nil, "beta.kmm.node.kubernetes.io/a123.b456.module-configured", true, "a123", "b456"),
+		Entry(nil, "beta.kmm.node.kubernetes.io/with-hypen.withouthypen.module-configured", true, "with-hypen", "withouthypen"),
+	)
+})
+
+var _ = Describe("IsModuleInUseLabel", func() {
+	DescribeTable(
+		"should work as expected",
+		func(input string, expectedOK bool, expectedNS, expectedName string) {
+			ok, ns, name := IsModuleInUseLabel(input)
+
+			if !expectedOK {
+				Expect(ok).To(BeFalse())
+				return
+			}
+
+			Expect(ok).To(BeTrue())
+			Expect(ns).To(Equal(expectedNS))
+			Expect(name).To(Equal(expectedName))
+		},
+		Entry(nil, "a.b.module-in-use", false, "", ""),
+		Entry(nil, "beta.kmm.node.kubernetes.io/a.b.module-in-use", true, "a", "b"),
+		Entry(nil, "beta.kmm.node.kubernetes.io/..module-in-use", false, "", ""),
+		Entry(nil, "beta.kmm.node.kubernetes.io/a123.b456.module-in-use", true, "a123", "b456"),
+		Entry(nil, "beta.kmm.node.kubernetes.io/with-hypen.withouthypen.module-in-use", true, "with-hypen", "withouthypen"),
+	)
+})

--- a/internal/utils/kmmlabels.go
+++ b/internal/utils/kmmlabels.go
@@ -54,7 +54,3 @@ func GetNodesVersionLabels(nodeLabels map[string]string) map[string]string {
 	}
 	return versionLabels
 }
-
-func GetModuleNMCLabel(namespace, name string) string {
-	return fmt.Sprintf("%s.%s.%s", constants.ModuleNMCLabelPrefix, namespace, name)
-}


### PR DESCRIPTION
Wait for kmods to be unloaded on all nodes to delete a Module. This is implemented through 2 labels:
- `beta.kmm.node.kubernetes.io/<ns>.<name>.module-configured`
- `beta.kmm.node.kubernetes.io/<ns>.<name>.module-in-use`

Both labels are set by the Module-NMC reconciler when an entry is added to the NMC spec.
The first label is removed by the Module-NMC reconciler when, for any reason, the NMC is not targeted by the Module anymore. The second label is removed by the NMC reconciler when the unloading worker pod is successful and the kmod is not present in the spec list anymore.
For the Module finalizer to be removed, no NMC must carry neither of these 2 labels.

/cc @yevgeny-shnaidman