### PR TITLE
Implementing ordered upgrade feature for V2 (#556)

### DIFF
--- a/internal/controllers/module_nmc_reconciler_test.go
+++ b/internal/controllers/module_nmc_reconciler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/module"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/nmc"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/registry"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	"go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -60,9 +61,8 @@ var _ = Describe("Reconcile", func() {
 	targetedNodes := []v1.Node{node}
 	currentNMCs := sets.New[string](nodeName)
 	mld := api.ModuleLoaderData{KernelVersion: "some version"}
-	enableSchedulingData := schedulingData{mld: &mld, node: &node}
-	disableSchedulingData := schedulingData{mld: nil, nmcExists: true}
-	disableSchedulingDataNoNMC := schedulingData{mld: nil, nmcExists: false}
+	enableSchedulingData := schedulingData{action: actionAdd, mld: &mld, node: &node}
+	disableSchedulingData := schedulingData{action: actionDelete, mld: nil}
 
 	It("should return ok if module has been deleted", func() {
 		mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(nil, apierrors.NewNotFound(schema.GroupResource{}, "whatever"))
@@ -163,7 +163,7 @@ var _ = Describe("Reconcile", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("Good flow, should not run on node, nmc exists", func() {
+	It("Good flow, should not run on node", func() {
 		nmcMLDConfigs := map[string]schedulingData{nodeName: disableSchedulingData}
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(&mod, nil),
@@ -179,23 +179,6 @@ var _ = Describe("Reconcile", func() {
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).NotTo(HaveOccurred())
 	})
-
-	It("Good flow, should not run on node, nmc does not exist", func() {
-		nmcMLDConfigs := map[string]schedulingData{nodeName: disableSchedulingDataNoNMC}
-		gomock.InOrder(
-			mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(&mod, nil),
-			mockReconHelper.EXPECT().setFinalizer(ctx, &mod).Return(nil),
-			mockReconHelper.EXPECT().getNodesListBySelector(ctx, &mod).Return(targetedNodes, nil),
-			mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, &mod).Return(currentNMCs, nil),
-			mockReconHelper.EXPECT().prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs).Return(nmcMLDConfigs, nil),
-		)
-
-		res, err := mnr.Reconcile(ctx, req)
-
-		Expect(res).To(Equal(reconcile.Result{}))
-		Expect(err).NotTo(HaveOccurred())
-	})
-
 })
 
 var _ = Describe("getRequestedModule", func() {
@@ -494,12 +477,20 @@ var _ = Describe("getNMCsByModuleSet", func() {
 })
 
 var _ = Describe("prepareSchedulingData", func() {
+	const (
+		kernelVersion   = "some kernel version"
+		nodeName        = "nodeName"
+		moduleName      = "moduleName"
+		moduleNamespace = "moduleNamespace"
+	)
 	var (
-		ctrl       *gomock.Controller
-		clnt       *client.MockClient
-		mockKernel *module.MockKernelMapper
-		mockHelper *nmc.MockHelper
-		mnrh       moduleNMCReconcilerHelperAPI
+		ctrl          *gomock.Controller
+		clnt          *client.MockClient
+		mockKernel    *module.MockKernelMapper
+		mockHelper    *nmc.MockHelper
+		mnrh          moduleNMCReconcilerHelperAPI
+		node          v1.Node
+		targetedNodes []v1.Node
 	)
 
 	BeforeEach(func() {
@@ -508,26 +499,26 @@ var _ = Describe("prepareSchedulingData", func() {
 		mockKernel = module.NewMockKernelMapper(ctrl)
 		mockHelper = nmc.NewMockHelper(ctrl)
 		mnrh = newModuleNMCReconcilerHelper(clnt, mockKernel, nil, mockHelper, nil, scheme)
+		node = v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: nodeName},
+			Status: v1.NodeStatus{
+				NodeInfo: v1.NodeSystemInfo{KernelVersion: kernelVersion},
+			},
+		}
+		targetedNodes = []v1.Node{node}
+		fmt.Printf("YEV - kernel version <%s>\n", node.Status.NodeInfo.KernelVersion)
 	})
-
-	const kernelVersion = "some kernel version"
-	const nodeName = "nodeName"
 
 	ctx := context.Background()
 	mod := kmmv1beta1.Module{}
-	node := v1.Node{
-		ObjectMeta: metav1.ObjectMeta{Name: nodeName},
-		Status: v1.NodeStatus{
-			NodeInfo: v1.NodeSystemInfo{KernelVersion: kernelVersion},
-		},
-	}
-	targetedNodes := []v1.Node{node}
-	mld := api.ModuleLoaderData{KernelVersion: "some version"}
+	//targetedNodes := []v1.Node{node}
+	mld := api.ModuleLoaderData{KernelVersion: "some version", Name: moduleName, Namespace: moduleNamespace}
 
 	It("failed to determine mld", func() {
 		currentNMCs := sets.New[string](nodeName)
 		mockKernel.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(nil, fmt.Errorf("some error"))
 
+		fmt.Printf("YEV - in test, before call: <%s>\n", targetedNodes[0].Status.NodeInfo.KernelVersion)
 		scheduleData, errs := mnrh.prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs)
 
 		Expect(len(errs)).To(Equal(1))
@@ -540,7 +531,7 @@ var _ = Describe("prepareSchedulingData", func() {
 
 		scheduleData, errs := mnrh.prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs)
 
-		expectedScheduleData := map[string]schedulingData{nodeName: schedulingData{mld: nil, node: &node, nmcExists: true}}
+		expectedScheduleData := map[string]schedulingData{nodeName: schedulingData{action: actionDelete}}
 		Expect(errs).To(BeEmpty())
 		Expect(scheduleData).To(Equal(expectedScheduleData))
 	})
@@ -551,7 +542,7 @@ var _ = Describe("prepareSchedulingData", func() {
 
 		scheduleData, errs := mnrh.prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs)
 
-		expectedScheduleData := map[string]schedulingData{nodeName: schedulingData{mld: &mld, node: &node, nmcExists: true}}
+		expectedScheduleData := map[string]schedulingData{nodeName: schedulingData{action: actionAdd, mld: &mld, node: &node}}
 		Expect(errs).To(BeEmpty())
 		Expect(scheduleData).To(Equal(expectedScheduleData))
 	})
@@ -563,8 +554,8 @@ var _ = Describe("prepareSchedulingData", func() {
 		scheduleData, errs := mnrh.prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs)
 
 		Expect(errs).To(BeEmpty())
-		Expect(scheduleData).To(HaveKeyWithValue(nodeName, schedulingData{mld: &mld, node: &node, nmcExists: false}))
-		Expect(scheduleData).To(HaveKeyWithValue("some other node", schedulingData{mld: nil, nmcExists: true}))
+		Expect(scheduleData).To(HaveKeyWithValue(nodeName, schedulingData{action: actionAdd, mld: &mld, node: &node}))
+		Expect(scheduleData).To(HaveKeyWithValue("some other node", schedulingData{action: actionDelete}))
 	})
 
 	It("failed to determine mld for one of the nodes/nmcs", func() {
@@ -574,8 +565,45 @@ var _ = Describe("prepareSchedulingData", func() {
 		scheduleData, errs := mnrh.prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs)
 
 		Expect(errs).NotTo(BeEmpty())
-		expectedScheduleData := map[string]schedulingData{"some other node": schedulingData{mld: nil, nmcExists: true}}
+		expectedScheduleData := map[string]schedulingData{"some other node": schedulingData{action: actionDelete}}
 		Expect(scheduleData).To(Equal(expectedScheduleData))
+	})
+
+	It("module version exists, moduleLoader version label exists, versions are equal", func() {
+		node.SetLabels(map[string]string{utils.GetModuleLoaderVersionLabelName(moduleNamespace, moduleName): "moduleVersion1"})
+		targetedNodes[0] = node
+		currentNMCs := sets.New[string](nodeName)
+		mld.ModuleVersion = "moduleVersion1"
+		mockKernel.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil)
+
+		scheduleData, errs := mnrh.prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs)
+
+		Expect(errs).To(BeEmpty())
+		Expect(scheduleData).To(HaveKeyWithValue(nodeName, schedulingData{action: actionAdd, mld: &mld, node: &node}))
+	})
+
+	It("module version exists, moduleLoader version label exists, versions are different", func() {
+		node.SetLabels(map[string]string{utils.GetModuleLoaderVersionLabelName(moduleNamespace, moduleName): "moduleVersion1"})
+		targetedNodes[0] = node
+		currentNMCs := sets.New[string](nodeName)
+		mld.ModuleVersion = "moduleVersion2"
+		mockKernel.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil)
+
+		scheduleData, errs := mnrh.prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs)
+
+		Expect(errs).To(BeEmpty())
+		Expect(scheduleData).To(HaveKeyWithValue(nodeName, schedulingData{}))
+	})
+
+	It("module version exists, moduleLoader version label does not exist", func() {
+		currentNMCs := sets.New[string](nodeName)
+		mld.ModuleVersion = "moduleVersion2"
+		mockKernel.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(&mld, nil)
+
+		scheduleData, errs := mnrh.prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs)
+
+		Expect(errs).To(BeEmpty())
+		Expect(scheduleData).To(HaveKeyWithValue(nodeName, schedulingData{action: actionDelete}))
 	})
 })
 

--- a/internal/utils/kmmlabels.go
+++ b/internal/utils/kmmlabels.go
@@ -54,3 +54,14 @@ func GetNodesVersionLabels(nodeLabels map[string]string) map[string]string {
 	}
 	return versionLabels
 }
+
+func GetNodesModuleLoaderVersionLabel(nodeLabels map[string]string, namespace, name string) (string, bool) {
+	if nodeLabels == nil {
+		return "", false
+	}
+	labelValue, ok := nodeLabels[GetModuleLoaderVersionLabelName(namespace, name)]
+	if !ok {
+		return "", false
+	}
+	return labelValue, true
+}


### PR DESCRIPTION
Current implementation involves creating a daemonset per module version, and setting ModuleLoader/DevicePlugin labels for the version value into the Daemosets selector fields. NodeLabelModuleVersion controller adds/removes appropriate labels from nodes based on customer input.

In V2, device plugin ordered upgrade implmentation will remain the same. For kernel modules, module-nmc reconciler will decide how to change NMCs based on the labels' changes of the nodes (provided by NodeLabelModuleVersion controler).

Module-NMC will use the following decicion-making table to update NCM: 1) if module is targeting the node, but kernel is not suitable - delete
   from NMC
2) if module is targeting the node, but the version is missing from
   Module (not an ordered upgrade) - add to NMC
3) if module is targeting the node, module loader version label is
   present on the node and its value equal to Module's version - add to
   NMC
4) if module is targeting the node, module loader version label is
   present on the node and its value is not equal to Module's version
   (meaning that the old version should be running) - no update to NMC.
5) if module is targeting the node, module loader version label is not
   present on the node, and Module's version is defined (meaning that
   currently no version should be running on the node) - delete from NMC