### PR TITLE
Changing daemonsets GarbageCollector for v2 (#558)

### DIFF
--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -29,7 +29,6 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -370,9 +369,7 @@ func (mrh *moduleReconcilerHelper) garbageCollect(ctx context.Context,
 	existingDS []appsv1.DaemonSet) error {
 	logger := log.FromContext(ctx)
 	// Garbage collect old DaemonSets for which there are no nodes.
-	validKernels := sets.KeySet[string](mldMappings)
-
-	deleted, err := mrh.daemonAPI.GarbageCollect(ctx, mod, existingDS, validKernels)
+	deleted, err := mrh.daemonAPI.GarbageCollect(ctx, mod, existingDS)
 	if err != nil {
 		return fmt.Errorf("could not garbage collect DaemonSets: %v", err)
 	}

--- a/internal/controllers/module_reconciler_test.go
+++ b/internal/controllers/module_reconciler_test.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -647,9 +646,8 @@ var _ = Describe("ModuleReconciler_garbageCollect", func() {
 			"kernelVersion1": &api.ModuleLoaderData{}, "kernelVersion2": &api.ModuleLoaderData{},
 		}
 		existingDS := []appsv1.DaemonSet{appsv1.DaemonSet{}, appsv1.DaemonSet{}}
-		kernelSet := sets.New("kernelVersion1", "kernelVersion2")
 		gomock.InOrder(
-			mockDC.EXPECT().GarbageCollect(context.Background(), mod, existingDS, kernelSet).Return(nil, nil),
+			mockDC.EXPECT().GarbageCollect(context.Background(), mod, existingDS).Return(nil, nil),
 			mockBM.EXPECT().GarbageCollect(context.Background(), mod.Name, mod.Namespace, mod).Return(nil, nil),
 			mockSM.EXPECT().GarbageCollect(context.Background(), mod.Name, mod.Namespace, mod).Return(nil, nil),
 		)
@@ -665,12 +663,11 @@ var _ = Describe("ModuleReconciler_garbageCollect", func() {
 			"kernelVersion1": &api.ModuleLoaderData{}, "kernelVersion2": &api.ModuleLoaderData{},
 		}
 		existingDS := []appsv1.DaemonSet{appsv1.DaemonSet{}, appsv1.DaemonSet{}}
-		kernelSet := sets.New("kernelVersion1", "kernelVersion2")
 		if dcError {
-			mockDC.EXPECT().GarbageCollect(context.Background(), mod, existingDS, kernelSet).Return(nil, returnedError)
+			mockDC.EXPECT().GarbageCollect(context.Background(), mod, existingDS).Return(nil, returnedError)
 			goto executeTestFunction
 		}
-		mockDC.EXPECT().GarbageCollect(context.Background(), mod, existingDS, kernelSet).Return(nil, nil)
+		mockDC.EXPECT().GarbageCollect(context.Background(), mod, existingDS).Return(nil, nil)
 		if buildError {
 			mockBM.EXPECT().GarbageCollect(context.Background(), mod.Name, mod.Namespace, mod).Return(nil, returnedError)
 			goto executeTestFunction

--- a/internal/daemonset/daemonset.go
+++ b/internal/daemonset/daemonset.go
@@ -12,7 +12,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -28,7 +27,7 @@ const (
 //go:generate mockgen -source=daemonset.go -package=daemonset -destination=mock_daemonset.go
 
 type DaemonSetCreator interface {
-	GarbageCollect(ctx context.Context, mod *kmmv1beta1.Module, existingDS []appsv1.DaemonSet, validKernels sets.Set[string]) ([]string, error)
+	GarbageCollect(ctx context.Context, mod *kmmv1beta1.Module, existingDS []appsv1.DaemonSet) ([]string, error)
 	GetModuleDaemonSets(ctx context.Context, name, namespace string) ([]appsv1.DaemonSet, error)
 	SetDevicePluginAsDesired(ctx context.Context, ds *appsv1.DaemonSet, mod *kmmv1beta1.Module, useDefaultSA bool) error
 	GetNodeLabelFromPod(pod *v1.Pod, moduleName string, useDeprecatedLabel bool) string
@@ -48,7 +47,7 @@ func NewCreator(client client.Client, kernelLabel string, scheme *runtime.Scheme
 	}
 }
 
-func (dc *daemonSetGenerator) GarbageCollect(ctx context.Context, mod *kmmv1beta1.Module, existingDS []appsv1.DaemonSet, validKernels sets.Set[string]) ([]string, error) {
+func (dc *daemonSetGenerator) GarbageCollect(ctx context.Context, mod *kmmv1beta1.Module, existingDS []appsv1.DaemonSet) ([]string, error) {
 	deleted := make([]string, 0)
 
 	for _, ds := range existingDS {
@@ -193,10 +192,7 @@ func getDevicePluginNodeLabel(namespace, moduleName string, useDeprecatedLabel b
 func isOlderVersionUnusedDaemonset(ds *appsv1.DaemonSet, moduleVersion string) bool {
 	moduleName := ds.Labels[constants.ModuleNameLabel]
 	moduleNamespace := ds.Namespace
-	versionLabel := utils.GetModuleLoaderVersionLabelName(moduleNamespace, moduleName)
-	if IsDevicePluginDS(ds) {
-		versionLabel = utils.GetDevicePluginVersionLabelName(moduleNamespace, moduleName)
-	}
+	versionLabel := utils.GetDevicePluginVersionLabelName(moduleNamespace, moduleName)
 	return ds.Labels[versionLabel] != moduleVersion && ds.Status.DesiredNumberScheduled == 0
 }
 

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -16,7 +16,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/pointer"
 )
 
@@ -319,23 +318,9 @@ var _ = Describe("GarbageCollect", func() {
 			},
 		},
 	}
-	moduleLoaderVersionLabel := utils.GetModuleLoaderVersionLabelName(mod.Namespace, mod.Name)
 	devicePluginVersionLabel := utils.GetDevicePluginVersionLabelName(mod.Namespace, mod.Name)
 
-	DescribeTable("device-plugin and module-loader GC", func(devicePluginFormerLabel, moduleLoaderFormerLabel, moduleLoaderInvalidKernel bool,
-		devicePluginFormerDesired, moduleLoaderFormerDesired int) {
-		moduleLoaderDS := appsv1.DaemonSet{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "moduleLoader",
-				Namespace: "namespace",
-				Labels: map[string]string{
-					kernelLabel:               legitKernelVersion,
-					constants.DaemonSetRole:   constants.ModuleLoaderRoleLabelValue,
-					moduleLoaderVersionLabel:  currentModuleVersion,
-					constants.ModuleNameLabel: mod.Name,
-				},
-			},
-		}
+	DescribeTable("device-plugin GC", func(devicePluginFormerLabel bool, devicePluginFormerDesired int) {
 		devicePluginDS := appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "devicePlugin",
@@ -348,10 +333,8 @@ var _ = Describe("GarbageCollect", func() {
 			},
 		}
 		devicePluginFormerVersionDS := &appsv1.DaemonSet{}
-		moduleLoaderFormerVersionDS := &appsv1.DaemonSet{}
-		moduleLoaderIllegalKernelVersionDS := &appsv1.DaemonSet{}
 
-		existingDS := []appsv1.DaemonSet{moduleLoaderDS, devicePluginDS}
+		existingDS := []appsv1.DaemonSet{devicePluginDS}
 		expectedDeleteNames := []string{}
 		if devicePluginFormerLabel {
 			devicePluginFormerVersionDS = devicePluginDS.DeepCopy()
@@ -360,65 +343,34 @@ var _ = Describe("GarbageCollect", func() {
 			devicePluginFormerVersionDS.Status.DesiredNumberScheduled = int32(devicePluginFormerDesired)
 			existingDS = append(existingDS, *devicePluginFormerVersionDS)
 		}
-		if moduleLoaderFormerLabel {
-			moduleLoaderFormerVersionDS = moduleLoaderDS.DeepCopy()
-			moduleLoaderFormerVersionDS.SetName("moduleLoaderFormer")
-			moduleLoaderFormerVersionDS.Labels[moduleLoaderVersionLabel] = "former label"
-			moduleLoaderFormerVersionDS.Status.DesiredNumberScheduled = int32(moduleLoaderFormerDesired)
-			existingDS = append(existingDS, *moduleLoaderFormerVersionDS)
-		}
-		if moduleLoaderInvalidKernel {
-			moduleLoaderIllegalKernelVersionDS = moduleLoaderDS.DeepCopy()
-			moduleLoaderIllegalKernelVersionDS.SetName("moduleLoaderInvalidKernel")
-			moduleLoaderIllegalKernelVersionDS.Labels[kernelLabel] = notLegitKernelVersion
-			existingDS = append(existingDS, *moduleLoaderIllegalKernelVersionDS)
-		}
-
 		if devicePluginFormerLabel && devicePluginFormerDesired == 0 {
 			expectedDeleteNames = append(expectedDeleteNames, "devicePluginFormer")
 			clnt.EXPECT().Delete(context.Background(), devicePluginFormerVersionDS).Return(nil)
 		}
-		if moduleLoaderFormerLabel && moduleLoaderFormerDesired == 0 {
-			expectedDeleteNames = append(expectedDeleteNames, "moduleLoaderFormer")
-			clnt.EXPECT().Delete(context.Background(), moduleLoaderFormerVersionDS).Return(nil)
-		}
-		if moduleLoaderInvalidKernel {
-			expectedDeleteNames = append(expectedDeleteNames, "moduleLoaderInvalidKernel")
-			clnt.EXPECT().Delete(context.Background(), moduleLoaderIllegalKernelVersionDS).Return(nil)
-		}
 
-		res, err := dc.GarbageCollect(context.Background(), mod, existingDS, sets.New[string](legitKernelVersion))
+		res, err := dc.GarbageCollect(context.Background(), mod, existingDS)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(res).To(Equal(expectedDeleteNames))
 	},
-		Entry("no deletes", false, false, false, 0, 0),
-		Entry("former device plugin", true, false, false, 0, 0),
-		Entry("former device plugin has desired", true, false, false, 1, 0),
-		Entry("former module loader", false, true, false, 0, 0),
-		Entry("former module loader has desired", false, true, false, 0, 1),
+		Entry("no deletes", false, 0),
+		Entry("former device plugin", true, 0),
+		Entry("former device plugin has desired", true, 1),
 	)
 
 	It("should return an error if a deletion failed", func() {
 		deleteDS := appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "moduleLoader",
+				Name:      "devicePlugin",
 				Namespace: "namespace",
-				Labels:    map[string]string{kernelLabel: notLegitKernelVersion, constants.DaemonSetRole: constants.ModuleLoaderRoleLabelValue, moduleLoaderVersionLabel: currentModuleVersion},
+				Labels:    map[string]string{constants.DaemonSetRole: constants.DevicePluginRoleLabelValue, devicePluginVersionLabel: "formerVersion"},
 			},
 		}
 		clnt.EXPECT().Delete(context.Background(), &deleteDS).Return(fmt.Errorf("some error"))
 
 		existingDS := []appsv1.DaemonSet{deleteDS}
 
-		_, err := dc.GarbageCollect(context.Background(), mod, existingDS, sets.New[string](legitKernelVersion))
-		Expect(err).To(HaveOccurred())
-
-		deleteDS.Labels[moduleLoaderVersionLabel] = "former label"
-		clnt.EXPECT().Delete(context.Background(), &deleteDS).Return(fmt.Errorf("some error"))
-
-		existingDS = []appsv1.DaemonSet{deleteDS}
-		_, err = dc.GarbageCollect(context.Background(), mod, existingDS, sets.New[string](legitKernelVersion))
+		_, err := dc.GarbageCollect(context.Background(), mod, existingDS)
 		Expect(err).To(HaveOccurred())
 	})
 })

--- a/internal/daemonset/mock_daemonset.go
+++ b/internal/daemonset/mock_daemonset.go
@@ -12,7 +12,6 @@ import (
 	gomock "go.uber.org/mock/gomock"
 	v1 "k8s.io/api/apps/v1"
 	v10 "k8s.io/api/core/v1"
-	sets "k8s.io/apimachinery/pkg/util/sets"
 )
 
 // MockDaemonSetCreator is a mock of DaemonSetCreator interface.
@@ -39,18 +38,18 @@ func (m *MockDaemonSetCreator) EXPECT() *MockDaemonSetCreatorMockRecorder {
 }
 
 // GarbageCollect mocks base method.
-func (m *MockDaemonSetCreator) GarbageCollect(ctx context.Context, mod *v1beta1.Module, existingDS []v1.DaemonSet, validKernels sets.Set[string]) ([]string, error) {
+func (m *MockDaemonSetCreator) GarbageCollect(ctx context.Context, mod *v1beta1.Module, existingDS []v1.DaemonSet) ([]string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GarbageCollect", ctx, mod, existingDS, validKernels)
+	ret := m.ctrl.Call(m, "GarbageCollect", ctx, mod, existingDS)
 	ret0, _ := ret[0].([]string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GarbageCollect indicates an expected call of GarbageCollect.
-func (mr *MockDaemonSetCreatorMockRecorder) GarbageCollect(ctx, mod, existingDS, validKernels interface{}) *gomock.Call {
+func (mr *MockDaemonSetCreatorMockRecorder) GarbageCollect(ctx, mod, existingDS interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockDaemonSetCreator)(nil).GarbageCollect), ctx, mod, existingDS, validKernels)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GarbageCollect", reflect.TypeOf((*MockDaemonSetCreator)(nil).GarbageCollect), ctx, mod, existingDS)
 }
 
 // GetModuleDaemonSets mocks base method.


### PR DESCRIPTION
KMM V2 does not contain Daemonset for ModuleLoader anymore, only for DevicePlugin. This PR changes implementatio n of GarbageCollector function in daemonset package and the appropriate unit-tests. The changes for the GC function include:
1) no need to handle Module Loader daemonsets, including Module Version
   use case
2) no need verifying kernel versions of the nodes, which means changes
   to the GC function input parameters