### PR TITLE
Continuing adaption of ordered upgrade to KMM V2 (#563)

### DIFF
--- a/api/v1beta1/module_webhook_test.go
+++ b/api/v1beta1/module_webhook_test.go
@@ -63,7 +63,7 @@ var _ = Describe("maxCombinedLength", func() {
 			utils.GetModuleVersionLabelName("", ""),
 		)
 
-		if l := getLengthAfterSlash(utils.GetModuleLoaderVersionLabelName("", "")); l > baseLength {
+		if l := getLengthAfterSlash(utils.GetWorkerPodVersionLabelName("", "")); l > baseLength {
 			baseLength = l
 		}
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -10,7 +10,7 @@ const (
 	KernelLabel                  = "kmm.node.kubernetes.io/kernel-version.full"
 	BuildTypeLabel               = "kmm.openshift.io/build.type"
 
-	ModuleLoaderVersionLabelPrefix = "beta.kmm.node.kubernetes.io/version-module-loader"
+	WorkerPodVersionLabelPrefix    = "beta.kmm.node.kubernetes.io/version-worker-pod"
 	DevicePluginVersionLabelPrefix = "beta.kmm.node.kubernetes.io/version-device-plugin"
 	ModuleVersionLabelPrefix       = "kmm.node.kubernetes.io/version-module"
 

--- a/internal/controllers/mock_node_label_module_version_reconciler.go
+++ b/internal/controllers/mock_node_label_module_version_reconciler.go
@@ -35,6 +35,21 @@ func (m *MocknodeLabelModuleVersionHelperAPI) EXPECT() *MocknodeLabelModuleVersi
 	return m.recorder
 }
 
+// getDevicePluginPods mocks base method.
+func (m *MocknodeLabelModuleVersionHelperAPI) getDevicePluginPods(ctx context.Context, nodeName string) ([]v1.Pod, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getDevicePluginPods", ctx, nodeName)
+	ret0, _ := ret[0].([]v1.Pod)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// getDevicePluginPods indicates an expected call of getDevicePluginPods.
+func (mr *MocknodeLabelModuleVersionHelperAPIMockRecorder) getDevicePluginPods(ctx, nodeName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getDevicePluginPods", reflect.TypeOf((*MocknodeLabelModuleVersionHelperAPI)(nil).getDevicePluginPods), ctx, nodeName)
+}
+
 // getLabelsPerModules mocks base method.
 func (m *MocknodeLabelModuleVersionHelperAPI) getLabelsPerModules(ctx context.Context, nodeLabels map[string]string) map[string]*modulesVersionLabels {
 	m.ctrl.T.Helper()
@@ -49,33 +64,18 @@ func (mr *MocknodeLabelModuleVersionHelperAPIMockRecorder) getLabelsPerModules(c
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getLabelsPerModules", reflect.TypeOf((*MocknodeLabelModuleVersionHelperAPI)(nil).getLabelsPerModules), ctx, nodeLabels)
 }
 
-// getModuleLoaderAndDevicePluginPods mocks base method.
-func (m *MocknodeLabelModuleVersionHelperAPI) getModuleLoaderAndDevicePluginPods(ctx context.Context, nodeName string) ([]v1.Pod, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "getModuleLoaderAndDevicePluginPods", ctx, nodeName)
-	ret0, _ := ret[0].([]v1.Pod)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// getModuleLoaderAndDevicePluginPods indicates an expected call of getModuleLoaderAndDevicePluginPods.
-func (mr *MocknodeLabelModuleVersionHelperAPIMockRecorder) getModuleLoaderAndDevicePluginPods(ctx, nodeName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getModuleLoaderAndDevicePluginPods", reflect.TypeOf((*MocknodeLabelModuleVersionHelperAPI)(nil).getModuleLoaderAndDevicePluginPods), ctx, nodeName)
-}
-
 // reconcileLabels mocks base method.
-func (m *MocknodeLabelModuleVersionHelperAPI) reconcileLabels(modulesLabels map[string]*modulesVersionLabels, moduleLoaderPods []v1.Pod) *reconcileLabelsResult {
+func (m *MocknodeLabelModuleVersionHelperAPI) reconcileLabels(modulesLabels map[string]*modulesVersionLabels, devicePluginPods []v1.Pod) *reconcileLabelsResult {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "reconcileLabels", modulesLabels, moduleLoaderPods)
+	ret := m.ctrl.Call(m, "reconcileLabels", modulesLabels, devicePluginPods)
 	ret0, _ := ret[0].(*reconcileLabelsResult)
 	return ret0
 }
 
 // reconcileLabels indicates an expected call of reconcileLabels.
-func (mr *MocknodeLabelModuleVersionHelperAPIMockRecorder) reconcileLabels(modulesLabels, moduleLoaderPods interface{}) *gomock.Call {
+func (mr *MocknodeLabelModuleVersionHelperAPIMockRecorder) reconcileLabels(modulesLabels, devicePluginPods interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "reconcileLabels", reflect.TypeOf((*MocknodeLabelModuleVersionHelperAPI)(nil).reconcileLabels), modulesLabels, moduleLoaderPods)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "reconcileLabels", reflect.TypeOf((*MocknodeLabelModuleVersionHelperAPI)(nil).reconcileLabels), modulesLabels, devicePluginPods)
 }
 
 // updateNodeLabels mocks base method.

--- a/internal/controllers/module_nmc_reconciler.go
+++ b/internal/controllers/module_nmc_reconciler.go
@@ -403,7 +403,7 @@ func prepareNodeSchedulingData(node *v1.Node, mld *api.ModuleLoaderData, current
 	versionLabel := ""
 	present := false
 	if mld != nil {
-		versionLabel, present = utils.GetNodesModuleLoaderVersionLabel(node.GetLabels(), mld.Namespace, mld.Name)
+		versionLabel, present = utils.GetNodeWorkerPodVersionLabel(node.GetLabels(), mld.Namespace, mld.Name)
 	}
 	switch {
 	case mld == nil && currentNMCs.Has(node.Name):

--- a/internal/controllers/module_nmc_reconciler_test.go
+++ b/internal/controllers/module_nmc_reconciler_test.go
@@ -506,7 +506,6 @@ var _ = Describe("prepareSchedulingData", func() {
 			},
 		}
 		targetedNodes = []v1.Node{node}
-		fmt.Printf("YEV - kernel version <%s>\n", node.Status.NodeInfo.KernelVersion)
 	})
 
 	ctx := context.Background()
@@ -518,7 +517,6 @@ var _ = Describe("prepareSchedulingData", func() {
 		currentNMCs := sets.New[string](nodeName)
 		mockKernel.EXPECT().GetModuleLoaderDataForKernel(&mod, kernelVersion).Return(nil, fmt.Errorf("some error"))
 
-		fmt.Printf("YEV - in test, before call: <%s>\n", targetedNodes[0].Status.NodeInfo.KernelVersion)
 		scheduleData, errs := mnrh.prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs)
 
 		Expect(len(errs)).To(Equal(1))
@@ -569,8 +567,8 @@ var _ = Describe("prepareSchedulingData", func() {
 		Expect(scheduleData).To(Equal(expectedScheduleData))
 	})
 
-	It("module version exists, moduleLoader version label exists, versions are equal", func() {
-		node.SetLabels(map[string]string{utils.GetModuleLoaderVersionLabelName(moduleNamespace, moduleName): "moduleVersion1"})
+	It("module version exists, workerPod version label exists, versions are equal", func() {
+		node.SetLabels(map[string]string{utils.GetWorkerPodVersionLabelName(moduleNamespace, moduleName): "moduleVersion1"})
 		targetedNodes[0] = node
 		currentNMCs := sets.New[string](nodeName)
 		mld.ModuleVersion = "moduleVersion1"
@@ -582,8 +580,8 @@ var _ = Describe("prepareSchedulingData", func() {
 		Expect(scheduleData).To(HaveKeyWithValue(nodeName, schedulingData{action: actionAdd, mld: &mld, node: &node}))
 	})
 
-	It("module version exists, moduleLoader version label exists, versions are different", func() {
-		node.SetLabels(map[string]string{utils.GetModuleLoaderVersionLabelName(moduleNamespace, moduleName): "moduleVersion1"})
+	It("module version exists, workerPod version label exists, versions are different", func() {
+		node.SetLabels(map[string]string{utils.GetWorkerPodVersionLabelName(moduleNamespace, moduleName): "moduleVersion1"})
 		targetedNodes[0] = node
 		currentNMCs := sets.New[string](nodeName)
 		mld.ModuleVersion = "moduleVersion2"

--- a/internal/controllers/module_reconciler_test.go
+++ b/internal/controllers/module_reconciler_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/build"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/daemonset"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/metrics"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/module"
@@ -792,11 +791,6 @@ var _ = Describe("ModuleReconciler_getExistingDS", func() {
 		moduleVersion   = "moduleVersion"
 	)
 
-	moduleLoaderLabels := map[string]string{
-		constants.KernelLabel: kernelVersion,
-		utils.GetModuleLoaderVersionLabelName(moduleNamespace, moduleName): moduleVersion,
-	}
-
 	devicePluginLabels := map[string]string{
 		utils.GetDevicePluginVersionLabelName(moduleNamespace, moduleName): moduleVersion,
 	}
@@ -805,44 +799,23 @@ var _ = Describe("ModuleReconciler_getExistingDS", func() {
 		ObjectMeta: metav1.ObjectMeta{Namespace: moduleNamespace, Name: moduleName},
 	}
 
-	It("empty list", func() {
+	It("various scenarios", func() {
 		By("empty daemonset list")
-		res := getExistingDS(nil, moduleNamespace, moduleName, kernelVersion, moduleVersion, false)
+		res := getExistingDS(nil, moduleNamespace, moduleName, moduleVersion)
 		Expect(res).To(BeNil())
-
-		By("module loader, kernel version and module version are equal")
-		ds.SetLabels(moduleLoaderLabels)
-		res = getExistingDS([]appsv1.DaemonSet{ds}, moduleNamespace, moduleName, kernelVersion, moduleVersion, false)
-		Expect(res).To(Equal(&ds))
-
-		By("module loader, kernel version not equal, module version equal")
-		res = getExistingDS([]appsv1.DaemonSet{ds}, moduleNamespace, moduleName, "some version", moduleVersion, false)
-		Expect(res).To(BeNil())
-
-		By("module loader, kernel version equal, module version not equal")
-		res = getExistingDS([]appsv1.DaemonSet{ds}, moduleNamespace, moduleName, kernelVersion, "some version", false)
-		Expect(res).To(BeNil())
-
-		By("module loader, kernel version equal, module version label missing and module version parameter is empty")
-		newLabels := map[string]string{
-			constants.KernelLabel: kernelVersion,
-		}
-		ds.SetLabels(newLabels)
-		res = getExistingDS([]appsv1.DaemonSet{ds}, moduleNamespace, moduleName, kernelVersion, "", false)
-		Expect(res).To(Equal(&ds))
 
 		By("device plugin, module version equal")
 		ds.SetLabels(devicePluginLabels)
-		res = getExistingDS([]appsv1.DaemonSet{ds}, moduleNamespace, moduleName, "", moduleVersion, true)
+		res = getExistingDS([]appsv1.DaemonSet{ds}, moduleNamespace, moduleName, moduleVersion)
 		Expect(res).To(Equal(&ds))
 
 		By("device plugin, module version not equal")
-		res = getExistingDS([]appsv1.DaemonSet{ds}, moduleNamespace, moduleName, "", "some version", true)
+		res = getExistingDS([]appsv1.DaemonSet{ds}, moduleNamespace, moduleName, "some version")
 		Expect(res).To(BeNil())
 
 		By("device plugin, module version label missing, and module version parameter is empty")
 		ds.SetLabels(map[string]string{})
-		res = getExistingDS([]appsv1.DaemonSet{ds}, moduleNamespace, moduleName, "", "", true)
+		res = getExistingDS([]appsv1.DaemonSet{ds}, moduleNamespace, moduleName, "")
 		Expect(res).To(Equal(&ds))
 	})
 })

--- a/internal/controllers/module_version_label_action_table.go
+++ b/internal/controllers/module_version_label_action_table.go
@@ -14,7 +14,7 @@ const (
 
 type labelActionKey struct {
 	module       string
-	moduleLoader string
+	workerPod    string
 	devicePlugin string
 }
 
@@ -26,41 +26,41 @@ type labelAction struct {
 var labelActionTable = map[labelActionKey]labelAction{
 	labelActionKey{
 		module:       labelMissing,
-		moduleLoader: labelMissing,
+		workerPod:    labelMissing,
 		devicePlugin: labelMissing}: labelAction{getLabelName: nil, action: noneAction},
 
 	labelActionKey{
 		module:       labelMissing,
-		moduleLoader: labelPresent,
+		workerPod:    labelPresent,
 		devicePlugin: labelPresent}: labelAction{getLabelName: utils.GetDevicePluginVersionLabelName, action: deleteAction},
 
 	labelActionKey{
 		module:       labelMissing,
-		moduleLoader: labelPresent,
-		devicePlugin: labelMissing}: labelAction{getLabelName: utils.GetModuleLoaderVersionLabelName, action: deleteAction},
+		workerPod:    labelPresent,
+		devicePlugin: labelMissing}: labelAction{getLabelName: utils.GetWorkerPodVersionLabelName, action: deleteAction},
 
 	labelActionKey{
 		module:       labelPresent,
-		moduleLoader: labelMissing,
-		devicePlugin: labelMissing}: labelAction{getLabelName: utils.GetModuleLoaderVersionLabelName, action: addAction},
+		workerPod:    labelMissing,
+		devicePlugin: labelMissing}: labelAction{getLabelName: utils.GetWorkerPodVersionLabelName, action: addAction},
 
 	labelActionKey{
 		module:       labelPresent,
-		moduleLoader: labelPresent,
+		workerPod:    labelPresent,
 		devicePlugin: labelMissing}: labelAction{getLabelName: utils.GetDevicePluginVersionLabelName, action: addAction},
 
 	labelActionKey{
 		module:       labelPresent,
-		moduleLoader: labelPresent,
+		workerPod:    labelPresent,
 		devicePlugin: labelPresent}: labelAction{getLabelName: nil, action: noneAction},
 
 	labelActionKey{
 		module:       labelPresent,
-		moduleLoader: labelDifferent,
+		workerPod:    labelDifferent,
 		devicePlugin: labelDifferent}: labelAction{getLabelName: utils.GetDevicePluginVersionLabelName, action: deleteAction},
 
 	labelActionKey{
 		module:       labelPresent,
-		moduleLoader: labelDifferent,
-		devicePlugin: labelMissing}: labelAction{getLabelName: utils.GetModuleLoaderVersionLabelName, action: deleteAction},
+		workerPod:    labelDifferent,
+		devicePlugin: labelMissing}: labelAction{getLabelName: utils.GetWorkerPodVersionLabelName, action: deleteAction},
 }

--- a/internal/controllers/node_label_module_version_reconciler_test.go
+++ b/internal/controllers/node_label_module_version_reconciler_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Reconcile", func() {
 		labelsPerModules := map[string]*modulesVersionLabels{
 			"moduleNameNamespace": &modulesVersionLabels{name: "name", namespace: "namespace"},
 		}
-		moduleLoaderPods := []v1.Pod{v1.Pod{}}
+		devicePluginPods := []v1.Pod{v1.Pod{}}
 		reconcileLabelsResult := &reconcileLabelsResult{requeue: requeue}
 		expectedRes := ctrl.Result{Requeue: requeue}
 		if getNodeError {
@@ -64,11 +64,11 @@ var _ = Describe("Reconcile", func() {
 		)
 		mockHelper.EXPECT().getLabelsPerModules(ctx, nodeLabels).Return(labelsPerModules)
 		if getMLPodsError {
-			mockHelper.EXPECT().getModuleLoaderAndDevicePluginPods(ctx, nodeName).Return(nil, fmt.Errorf("some error"))
+			mockHelper.EXPECT().getDevicePluginPods(ctx, nodeName).Return(nil, fmt.Errorf("some error"))
 			goto executeTestFunction
 		}
-		mockHelper.EXPECT().getModuleLoaderAndDevicePluginPods(ctx, nodeName).Return(moduleLoaderPods, nil)
-		mockHelper.EXPECT().reconcileLabels(labelsPerModules, moduleLoaderPods).Return(reconcileLabelsResult)
+		mockHelper.EXPECT().getDevicePluginPods(ctx, nodeName).Return(devicePluginPods, nil)
+		mockHelper.EXPECT().reconcileLabels(labelsPerModules, devicePluginPods).Return(reconcileLabelsResult)
 		if upDateNodeLabelsErrors {
 			mockHelper.EXPECT().updateNodeLabels(ctx, nodeName, reconcileLabelsResult).Return(fmt.Errorf("some error"))
 			goto executeTestFunction
@@ -104,10 +104,10 @@ var _ = Describe("getLabelsPerModules", func() {
 	nodeLabels := map[string]string{
 		"some label 1": "some value1",
 		"some label 2": "",
-		"beta.kmm.node.kubernetes.io/version-module-loader.namespace1.module1": "1",
+		"beta.kmm.node.kubernetes.io/version-worker-pod.namespace1.module1":    "1",
 		"beta.kmm.node.kubernetes.io/version-device-plugin.namespace1.module1": "1",
 		"kmm.node.kubernetes.io/version-module.namespace1.module1":             "1",
-		"beta.kmm.node.kubernetes.io/version-module-loader.namespace2.module2": "3",
+		"beta.kmm.node.kubernetes.io/version-worker-pod.namespace2.module2":    "3",
 		"kmm.node.kubernetes.io/version-module.namespace2.module2":             "3",
 		"beta.kmm.node.kubernetes.io/version-device-plugin.namespace3.module3": "4",
 		"kmm.node.kubernetes.io/version-module.namespace5.module5":             "10",
@@ -119,14 +119,14 @@ var _ = Describe("getLabelsPerModules", func() {
 				name:                     "module1",
 				namespace:                "namespace1",
 				moduleVersionLabel:       "1",
-				moduleLoaderVersionLabel: "1",
+				workerPodVersionLabel:    "1",
 				devicePluginVersionLabel: "1",
 			},
 			"namespace2-module2": &modulesVersionLabels{
-				name:                     "module2",
-				namespace:                "namespace2",
-				moduleVersionLabel:       "3",
-				moduleLoaderVersionLabel: "3",
+				name:                  "module2",
+				namespace:             "namespace2",
+				moduleVersionLabel:    "3",
+				workerPodVersionLabel: "3",
 			},
 			"namespace3-module3": &modulesVersionLabels{
 				name:                     "module3",
@@ -148,7 +148,7 @@ var _ = Describe("getLabelsPerModules", func() {
 	})
 })
 
-var _ = Describe("getModuleLoaderAndDevicePluginPods", func() {
+var _ = Describe("getDevicePluginPods", func() {
 	const (
 		nodeName = "node-name"
 	)
@@ -171,7 +171,7 @@ var _ = Describe("getModuleLoaderAndDevicePluginPods", func() {
 		labelSelector := client.HasLabels{constants.DaemonSetRole}
 		kubeClient.EXPECT().List(ctx, gomock.Any(), labelSelector, fieldSelector)
 
-		_, err := helper.getModuleLoaderAndDevicePluginPods(ctx, nodeName)
+		_, err := helper.getDevicePluginPods(ctx, nodeName)
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -180,7 +180,7 @@ var _ = Describe("getModuleLoaderAndDevicePluginPods", func() {
 		labelSelector := client.HasLabels{constants.DaemonSetRole}
 		kubeClient.EXPECT().List(ctx, gomock.Any(), labelSelector, fieldSelector).Return(fmt.Errorf("some error"))
 
-		res, err := helper.getModuleLoaderAndDevicePluginPods(ctx, nodeName)
+		res, err := helper.getDevicePluginPods(ctx, nodeName)
 		Expect(err).To(HaveOccurred())
 		Expect(res).To(BeNil())
 	})
@@ -188,13 +188,13 @@ var _ = Describe("getModuleLoaderAndDevicePluginPods", func() {
 })
 
 var _ = Describe("getLabelAndAction", func() {
-	DescribeTable("reconciler flow", func(moduleVersionValue, moduleLoaderVersionValue, devicePluginVersionValue string,
+	DescribeTable("reconciler flow", func(moduleVersionValue, workerPodVersionValue, devicePluginVersionValue string,
 		expectedLabelFunc func(string, string) string, expectedLabelValue, expectedAction string) {
 		moduleLabels := &modulesVersionLabels{
 			name:                     "moduleName",
 			namespace:                "moduleNamespace",
 			moduleVersionLabel:       moduleVersionValue,
-			moduleLoaderVersionLabel: moduleLoaderVersionValue,
+			workerPodVersionLabel:    workerPodVersionValue,
 			devicePluginVersionLabel: devicePluginVersionValue,
 		}
 		expectedLabel := ""
@@ -209,13 +209,13 @@ var _ = Describe("getLabelAndAction", func() {
 		Expect(action).To(Equal(expectedAction))
 	},
 		Entry("all labels present with the same label", "1", "1", "1", nil, "", noneAction),
-		Entry("module version missing, module loader present, device plugin present", "", "1", "1", utils.GetDevicePluginVersionLabelName, "", deleteAction),
-		Entry("module version missing, module loader present, device plugin missing", "", "1", "", utils.GetModuleLoaderVersionLabelName, "", deleteAction),
+		Entry("module version missing, worker pod present, device plugin present", "", "1", "1", utils.GetDevicePluginVersionLabelName, "", deleteAction),
+		Entry("module version missing, worker pod present, device plugin missing", "", "1", "", utils.GetWorkerPodVersionLabelName, "", deleteAction),
 		Entry("all labels missing", "", "", "", nil, "", noneAction),
-		Entry("module version present, module loader missing, device plugin missing", "1", "", "", utils.GetModuleLoaderVersionLabelName, "1", addAction),
-		Entry("module version present, module loader present, device plugin missing", "1", "1", "", utils.GetDevicePluginVersionLabelName, "1", addAction),
-		Entry("module version present, module loader different, device plugin different", "2", "1", "1", utils.GetDevicePluginVersionLabelName, "", deleteAction),
-		Entry("module version present, module loader different, device plugin missing", "2", "1", "", utils.GetModuleLoaderVersionLabelName, "", deleteAction),
+		Entry("module version present, worker pod missing, device plugin missing", "1", "", "", utils.GetWorkerPodVersionLabelName, "1", addAction),
+		Entry("module version present, worker pod present, device plugin missing", "1", "1", "", utils.GetDevicePluginVersionLabelName, "1", addAction),
+		Entry("module version present, worker pod different, device plugin different", "2", "1", "1", utils.GetDevicePluginVersionLabelName, "", deleteAction),
+		Entry("module version present, worker pod different, device plugin missing", "2", "1", "", utils.GetWorkerPodVersionLabelName, "", deleteAction),
 	)
 })
 
@@ -237,7 +237,7 @@ var _ = Describe("reconcileLabels", func() {
 			name:                     "moduleName",
 			namespace:                "moduleNamespace",
 			moduleVersionLabel:       "",
-			moduleLoaderVersionLabel: "1",
+			workerPodVersionLabel:    "1",
 			devicePluginVersionLabel: "1",
 		}
 
@@ -253,7 +253,7 @@ var _ = Describe("reconcileLabels", func() {
 			name:                     "moduleName",
 			namespace:                "moduleNamespace",
 			moduleVersionLabel:       "",
-			moduleLoaderVersionLabel: "1",
+			workerPodVersionLabel:    "1",
 			devicePluginVersionLabel: "1",
 		}
 		pod.SetLabels(map[string]string{constants.ModuleNameLabel: "moduleName", constants.DaemonSetRole: constants.DevicePluginRoleLabelValue})
@@ -265,36 +265,19 @@ var _ = Describe("reconcileLabels", func() {
 		Expect(len(res.labelsToAdd)).To(Equal(0))
 	})
 
-	It("add label scenario with module loader pod not present", func() {
+	It("add label scenario", func() {
 		moduleLabels := &modulesVersionLabels{
 			name:                     "moduleName",
 			namespace:                "moduleNamespace",
 			moduleVersionLabel:       "1",
-			moduleLoaderVersionLabel: "",
+			workerPodVersionLabel:    "",
 			devicePluginVersionLabel: "",
 		}
 
 		res := helper.reconcileLabels(map[string]*modulesVersionLabels{"key": moduleLabels}, []v1.Pod{pod})
 
 		Expect(res.requeue).To(BeFalse())
-		Expect(res.labelsToAdd).To(Equal(map[string]string{utils.GetModuleLoaderVersionLabelName("moduleNamespace", "moduleName"): "1"}))
-		Expect(len(res.labelsToDelete)).To(Equal(0))
-	})
-
-	It("add label scenario with module loader pod still present", func() {
-		moduleLabels := &modulesVersionLabels{
-			name:                     "moduleName",
-			namespace:                "moduleNamespace",
-			moduleVersionLabel:       "1",
-			moduleLoaderVersionLabel: "",
-			devicePluginVersionLabel: "",
-		}
-		pod.SetLabels(map[string]string{constants.ModuleNameLabel: "moduleName", constants.DaemonSetRole: constants.ModuleLoaderRoleLabelValue})
-
-		res := helper.reconcileLabels(map[string]*modulesVersionLabels{"key": moduleLabels}, []v1.Pod{pod})
-
-		Expect(res.requeue).To(BeTrue())
-		Expect(len(res.labelsToAdd)).To(Equal(0))
+		Expect(res.labelsToAdd).To(Equal(map[string]string{utils.GetWorkerPodVersionLabelName("moduleNamespace", "moduleName"): "1"}))
 		Expect(len(res.labelsToDelete)).To(Equal(0))
 	})
 
@@ -303,7 +286,7 @@ var _ = Describe("reconcileLabels", func() {
 			name:                     "moduleName",
 			namespace:                "moduleNamespace",
 			moduleVersionLabel:       "1",
-			moduleLoaderVersionLabel: "1",
+			workerPodVersionLabel:    "1",
 			devicePluginVersionLabel: "1",
 		}
 		pod := v1.Pod{}

--- a/internal/utils/kmmlabels.go
+++ b/internal/utils/kmmlabels.go
@@ -11,8 +11,8 @@ func GetModuleVersionLabelName(namespace, name string) string {
 	return fmt.Sprintf("%s.%s.%s", constants.ModuleVersionLabelPrefix, namespace, name)
 }
 
-func GetModuleLoaderVersionLabelName(namespace, name string) string {
-	return fmt.Sprintf("%s.%s.%s", constants.ModuleLoaderVersionLabelPrefix, namespace, name)
+func GetWorkerPodVersionLabelName(namespace, name string) string {
+	return fmt.Sprintf("%s.%s.%s", constants.WorkerPodVersionLabelPrefix, namespace, name)
 }
 
 func GetDevicePluginVersionLabelName(namespace, name string) string {
@@ -28,15 +28,15 @@ func GetNamespaceNameFromVersionLabel(label string) (string, string, error) {
 }
 
 func IsVersionLabel(label string) bool {
-	return IsModuleVersionLabel(label) || IsModuleLoaderVersionLabel(label) || IsDevicePluginVersionLabel(label)
+	return IsModuleVersionLabel(label) || IsWorkerPodVersionLabel(label) || IsDevicePluginVersionLabel(label)
 }
 
 func IsModuleVersionLabel(label string) bool {
 	return strings.HasPrefix(label, constants.ModuleVersionLabelPrefix)
 }
 
-func IsModuleLoaderVersionLabel(label string) bool {
-	return strings.HasPrefix(label, constants.ModuleLoaderVersionLabelPrefix)
+func IsWorkerPodVersionLabel(label string) bool {
+	return strings.HasPrefix(label, constants.WorkerPodVersionLabelPrefix)
 }
 
 func IsDevicePluginVersionLabel(label string) bool {
@@ -46,7 +46,7 @@ func IsDevicePluginVersionLabel(label string) bool {
 func GetNodesVersionLabels(nodeLabels map[string]string) map[string]string {
 	versionLabels := map[string]string{}
 	for label, labelValue := range nodeLabels {
-		if strings.HasPrefix(label, constants.ModuleLoaderVersionLabelPrefix) ||
+		if strings.HasPrefix(label, constants.WorkerPodVersionLabelPrefix) ||
 			strings.HasPrefix(label, constants.DevicePluginVersionLabelPrefix) ||
 			strings.HasPrefix(label, constants.ModuleVersionLabelPrefix) {
 			versionLabels[label] = labelValue
@@ -55,11 +55,11 @@ func GetNodesVersionLabels(nodeLabels map[string]string) map[string]string {
 	return versionLabels
 }
 
-func GetNodesModuleLoaderVersionLabel(nodeLabels map[string]string, namespace, name string) (string, bool) {
+func GetNodeWorkerPodVersionLabel(nodeLabels map[string]string, namespace, name string) (string, bool) {
 	if nodeLabels == nil {
 		return "", false
 	}
-	labelValue, ok := nodeLabels[GetModuleLoaderVersionLabelName(namespace, name)]
+	labelValue, ok := nodeLabels[GetWorkerPodVersionLabelName(namespace, name)]
 	if !ok {
 		return "", false
 	}

--- a/internal/utils/kmmlabels_test.go
+++ b/internal/utils/kmmlabels_test.go
@@ -12,10 +12,10 @@ var _ = Describe("GetModuleVersionLabelName", func() {
 	})
 })
 
-var _ = Describe("GetModuleLoaderVersionLabelName", func() {
+var _ = Describe("GetWorkerPodVersionLabelName", func() {
 	It("should work as expected", func() {
-		res := GetModuleLoaderVersionLabelName("some-namespace", "some-name")
-		Expect(res).To(Equal("beta.kmm.node.kubernetes.io/version-module-loader.some-namespace.some-name"))
+		res := GetWorkerPodVersionLabelName("some-namespace", "some-name")
+		Expect(res).To(Equal("beta.kmm.node.kubernetes.io/version-worker-pod.some-namespace.some-name"))
 	})
 })
 
@@ -39,7 +39,7 @@ var _ = Describe("GetNamespaceNameFromVersionLabel", func() {
 			Expect(namespace).To(Equal(expectedNamespace))
 			Expect(name).To(Equal(expectedName))
 		},
-		Entry("moduleLoader label", "beta.kmm.node.kubernetes.io/version-module-loader.some-namespace.some-name", "some-namespace", "some-name", false),
+		Entry("workerPod label", "beta.kmm.node.kubernetes.io/version-worker-pod.some-namespace.some-name", "some-namespace", "some-name", false),
 		Entry("devicePlugin label", "beta.kmm.node.kubernetes.io/version-device-plugin.some-namespace.some-name", "some-namespace", "some-name", false),
 		Entry("module label", "kmm.node.kubernetes.io/version-module.some-namespace.some-name", "some-namespace", "some-name", false),
 		Entry("with error", "version-module-some-namespace-some-name", "some-namespace", "some-name", true),


### PR DESCRIPTION
Main points:
1) Renaming the ordered upgrade internal label from module-loader to
   worker-pod
2) simplifying labels reconciliation: no more need to check if
   module-loader pod exists, now we only need to check device-plugin
   pods
3) unit tests adaptation