### PR TITLE
Changing the flow of SyncStatus to accomodate Delete Pod errors (#566)

### DIFF
--- a/internal/controllers/nmc_reconciler_test.go
+++ b/internal/controllers/nmc_reconciler_test.go
@@ -600,10 +600,10 @@ var _ = Describe("nmcReconcilerHelperImpl_SyncStatus", func() {
 
 		gomock.InOrder(
 			pm.EXPECT().ListWorkerPodsOnNode(ctx, nmcName).Return(pods, nil),
-			pm.EXPECT().DeletePod(ctx, &podWithStatus),
-			pm.EXPECT().DeletePod(ctx, &podWithoutStatus),
 			kubeClient.EXPECT().Status().Return(sw),
 			sw.EXPECT().Patch(ctx, nmc, gomock.Any()),
+			pm.EXPECT().DeletePod(ctx, &podWithStatus),
+			pm.EXPECT().DeletePod(ctx, &podWithoutStatus),
 		)
 
 		Expect(
@@ -697,9 +697,9 @@ var _ = Describe("nmcReconcilerHelperImpl_SyncStatus", func() {
 
 		gomock.InOrder(
 			pm.EXPECT().ListWorkerPodsOnNode(ctx, nmcName).Return([]v1.Pod{pod}, nil),
-			pm.EXPECT().DeletePod(ctx, &pod),
 			kubeClient.EXPECT().Status().Return(sw),
 			sw.EXPECT().Patch(ctx, nmc, gomock.Any()),
+			pm.EXPECT().DeletePod(ctx, &pod),
 		)
 
 		Expect(
@@ -771,9 +771,9 @@ var _ = Describe("nmcReconcilerHelperImpl_SyncStatus", func() {
 
 		gomock.InOrder(
 			pm.EXPECT().ListWorkerPodsOnNode(ctx, nmcName).Return([]v1.Pod{pod}, nil),
-			pm.EXPECT().DeletePod(ctx, &pod),
 			kubeClient.EXPECT().Status().Return(sw),
 			sw.EXPECT().Patch(ctx, nmc, gomock.Any()),
+			pm.EXPECT().DeletePod(ctx, &pod),
 		)
 
 		Expect(
@@ -795,6 +795,50 @@ var _ = Describe("nmcReconcilerHelperImpl_SyncStatus", func() {
 		}
 
 		Expect(nmc.Status.Modules[0]).To(BeComparableTo(expectedStatus))
+	})
+
+	It("pod should not be deleted if NMC patch failed", func() {
+		const (
+			modName      = "module"
+			modNamespace = "namespace"
+		)
+
+		nmc := &kmmv1beta1.NodeModulesConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: nmcName},
+			Status: kmmv1beta1.NodeModulesConfigStatus{
+				Modules: []kmmv1beta1.NodeModuleStatus{
+					{
+						ModuleItem: kmmv1beta1.ModuleItem{
+							Name:      modName,
+							Namespace: modNamespace,
+						},
+					},
+				},
+			},
+		}
+
+		pod := v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: modNamespace,
+				Labels: map[string]string{
+					actionLabelKey:            WorkerActionUnload,
+					constants.ModuleNameLabel: modName,
+				},
+			},
+			Status: v1.PodStatus{Phase: v1.PodSucceeded},
+		}
+
+		gomock.InOrder(
+			pm.EXPECT().ListWorkerPodsOnNode(ctx, nmcName).Return([]v1.Pod{pod}, nil),
+			kubeClient.EXPECT().Status().Return(sw),
+			sw.EXPECT().Patch(ctx, nmc, gomock.Any()).Return(fmt.Errorf("some error")),
+		)
+
+		Expect(
+			wh.SyncStatus(ctx, nmc),
+		).To(
+			HaveOccurred(),
+		)
 	})
 })
 


### PR DESCRIPTION
Currently, in DeletePod is eexcuted per each Pod, and then NMC status is patched once for the the Modules. In case NMC status patch has failed, but the Pod was already deleted, we cannot reconcile NMC status in the next reconciliatio loop, since we don't know what do have the Pod. Since the status will contain InProgress=True, the module will never be reconciled.
In the new flow, all the Pods are deleted only after NMC was successfully patched. In case Pod deletion failed, the reconcile loop will try again, without progressing to NMC spec/status reconciliation. It will also allow for manual intervantion, in case Pod is stuck on some weird error