### PR TITLE
Record more fields into the NMC status

### DIFF
--- a/internal/controllers/nmc_reconciler.go
+++ b/internal/controllers/nmc_reconciler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/labels"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/nmc"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/ocp/ca"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/worker"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -440,6 +441,16 @@ func (h *nmcReconcilerHelperImpl) SyncStatus(ctx context.Context, nmcObj *kmmv1b
 			}
 		}
 
+		if irsName, err := getImageRepoSecretName(&p); err != nil {
+			logger.Info(
+				utils.WarnString("Error while looking for the imageRepoSecret volume"),
+				"error",
+				err,
+			)
+		} else if irsName != "" {
+			status.ImageRepoSecret = &v1.LocalObjectReference{Name: irsName}
+		}
+
 		status.ServiceAccountName = p.Spec.ServiceAccountName
 
 		updateModuleStatus := false
@@ -516,10 +527,11 @@ func (h *nmcReconcilerHelperImpl) SyncStatus(ctx context.Context, nmcObj *kmmv1b
 
 const (
 	configFileName = "config.yaml"
-	configFullPath = volMountPoingConfig + "/" + configFileName
+	configFullPath = volMountPointConfig + "/" + configFileName
 
-	volNameConfig       = "config"
-	volMountPoingConfig = "/etc/kmm-worker"
+	volNameConfig          = "config"
+	volNameImageRepoSecret = "image-repo-secret"
+	volMountPointConfig    = "/etc/kmm-worker"
 )
 
 //go:generate mockgen -source=nmc_reconciler.go -package=controllers -destination=mock_nmc_reconciler.go podManager
@@ -571,12 +583,13 @@ func (p *podManagerImpl) CreateLoaderPod(ctx context.Context, nmc client.Object,
 		return fmt.Errorf("could not set worker config: %v", err)
 	}
 
-	labels.SetLabel(pod, actionLabelKey, WorkerActionLoad)
 	if nms.Config.Modprobe.ModulesLoadingOrder != nil {
 		if err = setWorkerSofdepConfig(pod, nms.Config.Modprobe.ModulesLoadingOrder); err != nil {
 			return fmt.Errorf("could not set software dependency for mulitple modules: %v", err)
 		}
 	}
+
+	labels.SetLabel(pod, actionLabelKey, WorkerActionLoad)
 
 	pod.Spec.RestartPolicy = v1.RestartPolicyNever
 
@@ -597,12 +610,13 @@ func (p *podManagerImpl) CreateUnloaderPod(ctx context.Context, nmc client.Objec
 		return fmt.Errorf("could not set worker config: %v", err)
 	}
 
-	labels.SetLabel(pod, actionLabelKey, WorkerActionUnload)
 	if nms.Config.Modprobe.ModulesLoadingOrder != nil {
 		if err = setWorkerSofdepConfig(pod, nms.Config.Modprobe.ModulesLoadingOrder); err != nil {
 			return fmt.Errorf("could not set software dependency for mulitple modules: %v", err)
 		}
 	}
+
+	labels.SetLabel(pod, actionLabelKey, WorkerActionUnload)
 
 	return p.client.Create(ctx, pod)
 }
@@ -789,7 +803,7 @@ func (p *podManagerImpl) baseWorkerPod(
 	volumeMounts := []v1.VolumeMount{
 		{
 			Name:      volNameConfig,
-			MountPath: volMountPoingConfig,
+			MountPath: volMountPointConfig,
 			ReadOnly:  true,
 		},
 		{
@@ -908,6 +922,22 @@ func setWorkerSofdepConfig(pod *v1.Pod, modulesLoadingOrder []string) error {
 	return nil
 }
 
+func getImageRepoSecretName(pod *v1.Pod) (string, error) {
+	for _, v := range pod.Spec.Volumes {
+		if v.Name == volNameImageRepoSecret {
+			svs := v.VolumeSource.Secret
+
+			if svs == nil {
+				return "", fmt.Errorf("volume %s is not of type secret", volNameImageRepoSecret)
+			}
+
+			return svs.SecretName, nil
+		}
+	}
+
+	return "", nil
+}
+
 func getModulesOrderAnnotationValue(modulesNames []string) string {
 	var softDepData strings.Builder
 	for i := 0; i < len(modulesNames)-1; i++ {
@@ -938,10 +968,25 @@ type pullSecretHelperImpl struct {
 func (p *pullSecretHelperImpl) VolumesAndVolumeMounts(ctx context.Context, item *kmmv1beta1.ModuleItem) ([]v1.Volume, []v1.VolumeMount, error) {
 	logger := ctrl.LoggerFrom(ctx)
 
-	var pullSecretNames []string
+	secretNames := sets.New[string]()
+
+	type pullSecret struct {
+		secretName string
+		volumeName string
+		optional   bool
+	}
+
+	pullSecrets := make([]pullSecret, 0)
 
 	if irs := item.ImageRepoSecret; irs != nil {
-		pullSecretNames = append(pullSecretNames, irs.Name)
+		secretNames.Insert(irs.Name)
+
+		ps := pullSecret{
+			secretName: irs.Name,
+			volumeName: volNameImageRepoSecret,
+		}
+
+		pullSecrets = append(pullSecrets, ps)
 	}
 
 	if san := item.ServiceAccountName; san != "" {
@@ -955,22 +1000,32 @@ func (p *pullSecretHelperImpl) VolumesAndVolumeMounts(ctx context.Context, item 
 		}
 
 		for _, s := range sa.ImagePullSecrets {
-			pullSecretNames = append(pullSecretNames, s.Name)
+			if secretNames.Has(s.Name) {
+				continue
+			}
+
+			secretNames.Insert(s.Name)
+
+			ps := pullSecret{
+				secretName: s.Name,
+				volumeName: "pull-secret-" + s.Name,
+				optional:   true, // to match the node's container runtime behaviour
+			}
+
+			pullSecrets = append(pullSecrets, ps)
 		}
 	}
 
-	volumes := make([]v1.Volume, 0, len(pullSecretNames))
-	volumeMounts := make([]v1.VolumeMount, 0, len(pullSecretNames))
+	volumes := make([]v1.Volume, 0, len(pullSecrets))
+	volumeMounts := make([]v1.VolumeMount, 0, len(pullSecrets))
 
-	for _, s := range pullSecretNames {
-		volumeName := "pull-secret-" + s
-
+	for _, s := range pullSecrets {
 		v := v1.Volume{
-			Name: volumeName,
+			Name: s.volumeName,
 			VolumeSource: v1.VolumeSource{
 				Secret: &v1.SecretVolumeSource{
-					SecretName: s,
-					Optional:   pointer.Bool(true),
+					SecretName: s.secretName,
+					Optional:   pointer.Bool(s.optional),
 				},
 			},
 		}
@@ -978,9 +1033,9 @@ func (p *pullSecretHelperImpl) VolumesAndVolumeMounts(ctx context.Context, item 
 		volumes = append(volumes, v)
 
 		vm := v1.VolumeMount{
-			Name:      volumeName,
+			Name:      s.volumeName,
 			ReadOnly:  true,
-			MountPath: filepath.Join(worker.PullSecretsDir, s),
+			MountPath: filepath.Join(worker.PullSecretsDir, s.secretName),
 		}
 
 		volumeMounts = append(volumeMounts, vm)

--- a/internal/controllers/nmc_reconciler_test.go
+++ b/internal/controllers/nmc_reconciler_test.go
@@ -713,8 +713,10 @@ var _ = Describe("nmcReconcilerHelperImpl_SyncStatus", func() {
 
 	It("should add the status if a loader pod was successful", func() {
 		const (
-			modName      = "module"
-			modNamespace = "namespace"
+			irsName            = "some-secret"
+			modName            = "module"
+			modNamespace       = "namespace"
+			serviceAccountName = "some-sa"
 		)
 
 		nmc := &kmmv1beta1.NodeModulesConfig{
@@ -748,6 +750,17 @@ var _ = Describe("nmcReconcilerHelperImpl_SyncStatus", func() {
 				Labels: map[string]string{
 					actionLabelKey:            WorkerActionLoad,
 					constants.ModuleNameLabel: modName,
+				},
+			},
+			Spec: v1.PodSpec{
+				ServiceAccountName: serviceAccountName,
+				Volumes: []v1.Volume{
+					{
+						Name: volNameImageRepoSecret,
+						VolumeSource: v1.VolumeSource{
+							Secret: &v1.SecretVolumeSource{SecretName: irsName},
+						},
+					},
 				},
 			},
 			Status: v1.PodStatus{
@@ -786,8 +799,10 @@ var _ = Describe("nmcReconcilerHelperImpl_SyncStatus", func() {
 
 		expectedStatus := kmmv1beta1.NodeModuleStatus{
 			ModuleItem: kmmv1beta1.ModuleItem{
-				Name:      modName,
-				Namespace: modNamespace,
+				ImageRepoSecret:    &v1.LocalObjectReference{Name: irsName},
+				Name:               modName,
+				Namespace:          modNamespace,
+				ServiceAccountName: serviceAccountName,
 			},
 			Config:             &cfg,
 			LastTransitionTime: &now,
@@ -934,7 +949,10 @@ var _ = Describe("podManagerImpl_CreateLoaderPod", func() {
 			ObjectMeta: metav1.ObjectMeta{Name: nmcName},
 		}
 
+		const irsName = "some-secret"
+
 		mi := kmmv1beta1.ModuleItem{
+			ImageRepoSecret:    &v1.LocalObjectReference{Name: irsName},
 			Name:               moduleName,
 			Namespace:          namespace,
 			ServiceAccountName: serviceAccountName,
@@ -1341,17 +1359,18 @@ var _ = Describe("pullSecretHelperImpl_VolumesAndVolumeMounts", func() {
 			Do(func(_ context.Context, _ types.NamespacedName, sa *v1.ServiceAccount, _ ...ctrlclient.GetOption) {
 				sa.ImagePullSecrets = []v1.LocalObjectReference{
 					{Name: "pull-secret-1"},
+					{Name: "pull-secret-1"}, // intentional duplicate, should not be in the volume list
 					{Name: "pull-secret-2"},
 				}
 			})
 
 		vols := []v1.Volume{
 			{
-				Name: "pull-secret-pull-secret-0",
+				Name: volNameImageRepoSecret,
 				VolumeSource: v1.VolumeSource{
 					Secret: &v1.SecretVolumeSource{
 						SecretName: "pull-secret-0",
-						Optional:   pointer.Bool(true),
+						Optional:   pointer.Bool(false),
 					},
 				},
 			},
@@ -1377,7 +1396,7 @@ var _ = Describe("pullSecretHelperImpl_VolumesAndVolumeMounts", func() {
 
 		volMounts := []v1.VolumeMount{
 			{
-				Name:      "pull-secret-pull-secret-0",
+				Name:      volNameImageRepoSecret,
 				ReadOnly:  true,
 				MountPath: filepath.Join(worker.PullSecretsDir, "pull-secret-0"),
 			},


### PR DESCRIPTION
Record the service account name as well as the imageRepoSecret used in a successful loader Pod into the NMC status.
The service account name is stored as part of the PodSpec. For the imageRepoSecret name, add that volume under a well-known name that can be looked up by `SyncStatus()`.

Fixes #783

/cc @yevgeny-shnaidman 