### PR TITLE
Handling of kmm  module ready label (kernel module is loaded) (#575)

### DIFF
--- a/Dockerfile.kmm-operator-build
+++ b/Dockerfile.kmm-operator-build
@@ -7,7 +7,7 @@ ENV GOOS=linux
 ENV GOARCH=amd64
 
 RUN yum install -y podman docker
-RUN go install github.com/golang/mock/mockgen@v1.7.0-rc.1
+RUN go install go.uber.org/mock/mockgen@v0.3.0
 RUN curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /tmp/kubectl
 RUN install -o root -g root -m 0755 /tmp/kubectl /usr/local/bin/kubectl
 COPY --from=quay.io/openshift/origin-cli:latest /usr/bin/oc /usr/bin

--- a/internal/controllers/mock_nmc_reconciler.go
+++ b/internal/controllers/mock_nmc_reconciler.go
@@ -111,6 +111,20 @@ func (mr *MocknmcReconcilerHelperMockRecorder) SyncStatus(ctx, nmc any) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncStatus", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).SyncStatus), ctx, nmc)
 }
 
+// UpdateNodeLabels mocks base method.
+func (m *MocknmcReconcilerHelper) UpdateNodeLabels(ctx context.Context, nmc *v1beta1.NodeModulesConfig) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateNodeLabels", ctx, nmc)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateNodeLabels indicates an expected call of UpdateNodeLabels.
+func (mr *MocknmcReconcilerHelperMockRecorder) UpdateNodeLabels(ctx, nmc any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNodeLabels", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).UpdateNodeLabels), ctx, nmc)
+}
+
 // MockpodManager is a mock of podManager interface.
 type MockpodManager struct {
 	ctrl     *gomock.Controller

--- a/internal/controllers/nmc_reconciler.go
+++ b/internal/controllers/nmc_reconciler.go
@@ -157,6 +157,10 @@ func (r *NMCReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 		return reconcile.Result{}, fmt.Errorf("could not garbage collect in-use labels for NMC %s: %v", req.NamespacedName, err)
 	}
 
+	if err := r.helper.UpdateNodeLabels(ctx, &nmcObj); err != nil {
+		return reconcile.Result{}, fmt.Errorf("could not update node's labels for NMC %s: %v", req.NamespacedName, err)
+	}
+
 	return ctrl.Result{}, nil
 }
 
@@ -224,6 +228,7 @@ type nmcReconcilerHelper interface {
 	ProcessUnconfiguredModuleStatus(ctx context.Context, nmc *kmmv1beta1.NodeModulesConfig, status *kmmv1beta1.NodeModuleStatus) error
 	RemoveOrphanFinalizers(ctx context.Context, nodeName string) error
 	SyncStatus(ctx context.Context, nmc *kmmv1beta1.NodeModulesConfig) error
+	UpdateNodeLabels(ctx context.Context, nmc *kmmv1beta1.NodeModulesConfig) error
 }
 
 type nmcReconcilerHelperImpl struct {
@@ -523,6 +528,58 @@ func (h *nmcReconcilerHelperImpl) SyncStatus(ctx context.Context, nmcObj *kmmv1b
 	}
 
 	return errs.ErrorOrNil()
+}
+
+func (h *nmcReconcilerHelperImpl) UpdateNodeLabels(ctx context.Context, nmc *kmmv1beta1.NodeModulesConfig) error {
+	node := v1.Node{}
+	if err := h.client.Get(ctx, types.NamespacedName{Name: nmc.Name}, &node); err != nil {
+		return fmt.Errorf("could not get node %s: %v", nmc.Name, err)
+	}
+
+	// get all the kernel module ready labels of the node
+	nodeModuleReadyLabels := sets.New[string]()
+	for label := range node.GetLabels() {
+		if utils.IsKernelModuleReadyNodeLabel(label) {
+			nodeModuleReadyLabels.Insert(label)
+		}
+	}
+
+	// get spec labels and their config
+	specLabels := make(map[string]kmmv1beta1.ModuleConfig)
+	for _, module := range nmc.Spec.Modules {
+		label := utils.GetKernelModuleReadyNodeLabel(module.Namespace, module.Name)
+		specLabels[label] = module.Config
+	}
+
+	// get status labels and their config
+	statusLabels := make(map[string]kmmv1beta1.ModuleConfig)
+	for _, module := range nmc.Status.Modules {
+		label := utils.GetKernelModuleReadyNodeLabel(module.Namespace, module.Name)
+		statusLabels[label] = kmmv1beta1.ModuleConfig{}
+		if module.Config != nil {
+			statusLabels[label] = *module.Config
+		}
+	}
+
+	patchFrom := client.MergeFrom(node.DeepCopy())
+	// label in node but not in spec or status - should be removed
+	for label := range nodeModuleReadyLabels {
+		_, inSpec := specLabels[label]
+		_, inStatus := statusLabels[label]
+		if !inSpec && !inStatus {
+			labels.RemoveLabel(&node, label)
+		}
+	}
+
+	// label in spec and status and config equal - should be added
+	for label, specConfig := range specLabels {
+		statusConfig, ok := statusLabels[label]
+		if ok && reflect.DeepEqual(specConfig, statusConfig) {
+			labels.SetLabel(&node, label, "")
+		}
+	}
+
+	return h.client.Patch(ctx, &node, patchFrom)
 }
 
 const (

--- a/internal/controllers/nmc_reconciler_test.go
+++ b/internal/controllers/nmc_reconciler_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/nmc"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/ocp/ca"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/worker"
 	"go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
@@ -150,6 +151,7 @@ var _ = Describe("NodeModulesConfigReconciler_Reconcile", func() {
 			wh.EXPECT().ProcessModuleSpec(contextWithValueMatch, nmc, &spec1, nil),
 			wh.EXPECT().ProcessUnconfiguredModuleStatus(contextWithValueMatch, nmc, &status2),
 			wh.EXPECT().GarbageCollectInUseLabels(ctx, nmc),
+			wh.EXPECT().UpdateNodeLabels(ctx, nmc),
 		)
 
 		Expect(
@@ -916,7 +918,115 @@ var _ = Describe("nmcReconcilerHelperImpl_RemoveOrphanFinalizers", func() {
 })
 
 const (
-	moduleName         = "my-module"
+	moduleName      = "my-module"
+	moduleNamespace = "my-module-namespace"
+)
+
+var _ = Describe("nmcReconcilerHelperImpl_UpdateNodeLabels", func() {
+	var (
+		ctx          = context.TODO()
+		client       *testclient.MockClient
+		expectedNode v1.Node
+		nmc          kmmv1beta1.NodeModulesConfig
+		wh           nmcReconcilerHelper
+	)
+
+	BeforeEach(func() {
+		ctrl := gomock.NewController(GinkgoT())
+		client = testclient.NewMockClient(ctrl)
+		expectedNode = v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "node name",
+				Labels: map[string]string{},
+			},
+		}
+		nmc = kmmv1beta1.NodeModulesConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "nmcName"},
+		}
+		wh = newWorkerHelper(client, nil)
+	})
+
+	moduleConfig := kmmv1beta1.ModuleConfig{
+		KernelVersion:        "some version",
+		ContainerImage:       "some image",
+		InTreeModuleToRemove: "some kernel module",
+	}
+
+	It("failed to get node", func() {
+		client.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
+
+		err := wh.UpdateNodeLabels(ctx, &nmc)
+		Expect(err).To(HaveOccurred())
+	})
+
+	DescribeTable("nodes labels scenarios", func(nodeLabelPresent, specPresent, statusPresent, statusConfigPresent, configsEqual, resultLabelPresent bool) {
+		nodeLabels := make(map[string]string)
+		if nodeLabelPresent {
+			nodeLabels[utils.GetKernelModuleReadyNodeLabel(moduleNamespace, moduleName)] = ""
+		}
+		if specPresent {
+			nmc.Spec.Modules = []kmmv1beta1.NodeModuleSpec{
+				{
+					ModuleItem: kmmv1beta1.ModuleItem{
+						Name:      moduleName,
+						Namespace: moduleNamespace,
+					},
+					Config: moduleConfig,
+				},
+			}
+		}
+		if statusPresent {
+			nmc.Status.Modules = []kmmv1beta1.NodeModuleStatus{
+				{
+					ModuleItem: kmmv1beta1.ModuleItem{
+						Name:      moduleName,
+						Namespace: moduleNamespace,
+					},
+				},
+			}
+			if statusConfigPresent {
+				statusConfig := moduleConfig
+				if !configsEqual {
+					statusConfig.ContainerImage = "some other container image"
+				}
+				nmc.Status.Modules[0].Config = &statusConfig
+			}
+		}
+
+		if resultLabelPresent {
+			resultLabels := map[string]string{utils.GetKernelModuleReadyNodeLabel(moduleNamespace, moduleName): ""}
+			expectedNode.SetLabels(resultLabels)
+		}
+
+		gomock.InOrder(
+			client.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ interface{}, _ interface{}, node *v1.Node, _ ...ctrlclient.GetOption) error {
+					node.SetName("node name")
+					node.SetLabels(nodeLabels)
+					return nil
+				},
+			),
+			client.EXPECT().Patch(ctx, &expectedNode, gomock.Any()).Return(nil),
+		)
+
+		err := wh.UpdateNodeLabels(ctx, &nmc)
+		Expect(err).NotTo(HaveOccurred())
+
+	},
+		Entry("node label present, spec missing, status missing", true, false, false, false, false, false),
+		Entry("node label present, spec present, status missing", true, true, false, false, false, true),
+		Entry("node label present, spec present, status present, status config missing", true, true, true, false, false, true),
+		Entry("node label present, spec present, status present, status config present, configs not equal", true, true, true, true, false, true),
+		Entry("node label present, spec present, status present, status config present, configs equal", true, true, true, true, true, true),
+		Entry("node label missing, spec missing, status missing", false, false, false, false, false, false),
+		Entry("node label missing, spec present, status missing", false, true, false, false, false, false),
+		Entry("node label missing, spec present, status present, status config missing", false, true, true, false, false, false),
+		Entry("node label missing, spec present, status present, status config present, configs not equal", false, true, true, true, false, false),
+		Entry("node label missing, spec present, status present, status config present, configs equal", false, true, true, true, true, true),
+	)
+})
+
+const (
 	serviceAccountName = "some-sa"
 	workerImage        = "worker-image"
 )

--- a/internal/utils/kmmlabels.go
+++ b/internal/utils/kmmlabels.go
@@ -2,10 +2,13 @@ package utils
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 )
+
+var reKernelModuleReadyLabel = regexp.MustCompile(`^kmm\.node\.kubernetes\.io/[a-zA-Z0-9-]+\.[a-zA-Z0-9-]+\.ready$`)
 
 func GetModuleVersionLabelName(namespace, name string) string {
 	return fmt.Sprintf("%s.%s.%s", constants.ModuleVersionLabelPrefix, namespace, name)
@@ -64,4 +67,12 @@ func GetNodeWorkerPodVersionLabel(nodeLabels map[string]string, namespace, name 
 		return "", false
 	}
 	return labelValue, true
+}
+
+func GetKernelModuleReadyNodeLabel(namespace, moduleName string) string {
+	return fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.ready", namespace, moduleName)
+}
+
+func IsKernelModuleReadyNodeLabel(label string) bool {
+	return reKernelModuleReadyLabel.MatchString(label)
 }


### PR DESCRIPTION
This PR adds the ability to add/remove
kmm.node.kubernetes.io/%s.%s.ready label to the node. This is done based on the current labels on the node, and the comparison between NMC module's spec and status. State machine for adding/removing:
1) if spec config and status config are not equal - node's label should
   stay as is (either present or missing)
2) if both spec and status are missing - node's label should be removed 3) if spec config and status config are equal - node's label should be
   set