### PR TITLE
Adjusting pod-node reconciler to v2 (#578)

### DIFF
--- a/internal/controllers/pod_node_module_reconciler.go
+++ b/internal/controllers/pod_node_module_reconciler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/daemonset"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/filter"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	v1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -54,8 +55,7 @@ func (pnmr *PodNodeModuleReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		return ctrl.Result{}, fmt.Errorf("pod %s has no %q label", podNamespacedName, constants.ModuleNameLabel)
 	}
 
-	labelName := pnmr.daemonAPI.GetNodeLabelFromPod(&pod, moduleName, false)
-	deprecatedLabelName := pnmr.daemonAPI.GetNodeLabelFromPod(&pod, moduleName, true)
+	labelName := utils.GetDevicePluginNodeLabel(pod.Namespace, moduleName)
 
 	logger = logger.WithValues(
 		"node name", nodeName,
@@ -92,9 +92,9 @@ func (pnmr *PodNodeModuleReconciler) Reconcile(ctx context.Context, req ctrl.Req
 				}
 			}
 			if !foundRunningPod {
-				if err := pnmr.deleteLabel(ctx, nodeName, labelName, deprecatedLabelName); err != nil {
-					return ctrl.Result{}, fmt.Errorf("could not unlabel node %s with label {%q, %q}: %v",
-						nodeName, labelName, deprecatedLabelName, err)
+				if err := pnmr.deleteLabel(ctx, nodeName, labelName); err != nil {
+					return ctrl.Result{}, fmt.Errorf("could not unlabel node %s with label %s: %v",
+						nodeName, labelName, err)
 				}
 			}
 		}
@@ -116,8 +116,8 @@ func (pnmr *PodNodeModuleReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 	logger.Info("Labeling node")
 
-	if err := pnmr.addLabel(ctx, nodeName, labelName, deprecatedLabelName); err != nil {
-		return ctrl.Result{}, fmt.Errorf("could not label node %s with {%q, %q}: %v", nodeName, labelName, deprecatedLabelName, err)
+	if err := pnmr.addLabel(ctx, nodeName, labelName); err != nil {
+		return ctrl.Result{}, fmt.Errorf("could not label node %s with %s: %v", nodeName, labelName, err)
 	}
 
 	return ctrl.Result{}, nil
@@ -133,6 +133,16 @@ func (pnmr *PodNodeModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
+	isDaemonSetPod := predicate.NewPredicateFuncs(func(o client.Object) bool {
+		ownerReferences := o.GetOwnerReferences()
+		for _, ownerReference := range ownerReferences {
+			if ownerReference.Kind == "DaemonSet" {
+				return true
+			}
+		}
+		return false
+	})
+
 	p := predicate.And(
 		predicate.Or(
 			filter.PodReadinessChangedPredicate(
@@ -141,6 +151,7 @@ func (pnmr *PodNodeModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			filter.DeletingPredicate(),
 		),
 		filter.HasLabel(constants.ModuleNameLabel),
+		isDaemonSetPod,
 	)
 
 	return ctrl.
@@ -151,7 +162,7 @@ func (pnmr *PodNodeModuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(pnmr)
 }
 
-func (pnmr *PodNodeModuleReconciler) addLabel(ctx context.Context, nodeName string, labelNames ...string) error {
+func (pnmr *PodNodeModuleReconciler) addLabel(ctx context.Context, nodeName string, labelName string) error {
 	node := v1.Node{}
 
 	if err := pnmr.client.Get(ctx, types.NamespacedName{Name: nodeName}, &node); err != nil {
@@ -161,12 +172,10 @@ func (pnmr *PodNodeModuleReconciler) addLabel(ctx context.Context, nodeName stri
 	nodeCopy := node.DeepCopy()
 
 	if node.Labels == nil {
-		node.Labels = make(map[string]string, len(labelNames))
+		node.Labels = make(map[string]string)
 	}
 
-	for _, ln := range labelNames {
-		node.Labels[ln] = ""
-	}
+	node.Labels[labelName] = ""
 
 	return pnmr.client.Patch(ctx, &node, client.MergeFrom(nodeCopy))
 }
@@ -179,7 +188,7 @@ func (pnmr *PodNodeModuleReconciler) deleteFinalizer(ctx context.Context, pod *v
 	return pnmr.client.Patch(ctx, pod, client.MergeFrom(podCopy))
 }
 
-func (pnmr *PodNodeModuleReconciler) deleteLabel(ctx context.Context, nodeName string, labelNames ...string) error {
+func (pnmr *PodNodeModuleReconciler) deleteLabel(ctx context.Context, nodeName string, labelName string) error {
 	node := v1.Node{}
 
 	if err := pnmr.client.Get(ctx, types.NamespacedName{Name: nodeName}, &node); err != nil {
@@ -188,9 +197,7 @@ func (pnmr *PodNodeModuleReconciler) deleteLabel(ctx context.Context, nodeName s
 
 	nodeCopy := node.DeepCopy()
 
-	for _, ln := range labelNames {
-		delete(node.Labels, ln)
-	}
+	delete(node.Labels, labelName)
 
 	return pnmr.client.Patch(ctx, &node, client.MergeFrom(nodeCopy))
 }

--- a/internal/controllers/pod_node_module_reconciler_test.go
+++ b/internal/controllers/pod_node_module_reconciler_test.go
@@ -9,6 +9,7 @@ import (
 	mock_client "github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/daemonset"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	"go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -20,12 +21,10 @@ import (
 var _ = Describe("PodNodeModuleReconciler", func() {
 	Describe("Reconcile", func() {
 		const (
-			moduleName          = "module-name"
-			nodeName            = "node-name"
-			podName             = "pod-name"
-			podNamespace        = "pod-namespace"
-			nodeLabel           = "some node label"
-			deprecatedNodeLabel = "some deprecated node label"
+			moduleName   = "module-name"
+			nodeName     = "node-name"
+			podName      = "pod-name"
+			podNamespace = "pod-namespace"
 		)
 
 		var (
@@ -67,8 +66,6 @@ var _ = Describe("PodNodeModuleReconciler", func() {
 						pod.Name = podName
 					},
 				),
-				mockDC.EXPECT().GetNodeLabelFromPod(gomock.Any(), moduleName, false).Return(nodeLabel),
-				mockDC.EXPECT().GetNodeLabelFromPod(gomock.Any(), moduleName, true).Return(deprecatedNodeLabel),
 				kubeClient.EXPECT().List(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("some error")),
 			)
 
@@ -90,14 +87,13 @@ var _ = Describe("PodNodeModuleReconciler", func() {
 						pod.SetLabels(map[string]string{constants.ModuleNameLabel: moduleName})
 						pod.Spec.NodeName = nodeName
 						pod.Name = podName
+						pod.Namespace = podNamespace
 					},
 				),
-				mockDC.EXPECT().GetNodeLabelFromPod(gomock.Any(), moduleName, false).Return(nodeLabel),
-				mockDC.EXPECT().GetNodeLabelFromPod(gomock.Any(), moduleName, true).Return(deprecatedNodeLabel),
 				kubeClient.EXPECT().List(ctx, gomock.Any(), labelSelector, fieldSelector).Return(nil),
 				kubeClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Do(
 					func(_ interface{}, _ interface{}, node *v1.Node, _ ...client.GetOption) {
-						node.SetLabels(map[string]string{nodeLabel: "", deprecatedNodeLabel: ""})
+						node.SetLabels(map[string]string{utils.GetDevicePluginNodeLabel(podNamespace, moduleName): ""})
 					},
 				),
 				kubeClient.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Do(
@@ -119,15 +115,14 @@ var _ = Describe("PodNodeModuleReconciler", func() {
 				fieldSelector = client.MatchingFields{"spec.nodeName": nodeName}
 			)
 
-			gomock.InOrder(kubeClient.EXPECT().Get(ctx, req.NamespacedName, gomock.Any()).Do(
-				func(_ interface{}, _ interface{}, pod *v1.Pod, _ ...client.GetOption) {
-					pod.SetLabels(map[string]string{constants.ModuleNameLabel: moduleName})
-					pod.Spec.NodeName = nodeName
-					pod.Name = podName
-				},
-			),
-				mockDC.EXPECT().GetNodeLabelFromPod(gomock.Any(), moduleName, false).Return(nodeLabel),
-				mockDC.EXPECT().GetNodeLabelFromPod(gomock.Any(), moduleName, true).Return(deprecatedNodeLabel),
+			gomock.InOrder(
+				kubeClient.EXPECT().Get(ctx, req.NamespacedName, gomock.Any()).Do(
+					func(_ interface{}, _ interface{}, pod *v1.Pod, _ ...client.GetOption) {
+						pod.SetLabels(map[string]string{constants.ModuleNameLabel: moduleName})
+						pod.Spec.NodeName = nodeName
+						pod.Name = podName
+					},
+				),
 				kubeClient.EXPECT().List(ctx, gomock.Any(), labelSelector, fieldSelector).Do(
 					func(_ interface{}, modulePodsList *v1.PodList, _ ...client.ListOption) {
 						modulePodsList.Items = []v1.Pod{
@@ -158,16 +153,15 @@ var _ = Describe("PodNodeModuleReconciler", func() {
 		}
 
 		It("should NOT label or unlabel when the Pod has no .spec.nodeName", func() {
-			gomock.InOrder(kubeClient.EXPECT().Get(ctx, req.NamespacedName, gomock.Any()).Do(
-				func(_ interface{}, _ interface{}, pod *v1.Pod, _ ...client.GetOption) {
-					pod.SetLabels(map[string]string{constants.ModuleNameLabel: moduleName})
-					pod.Finalizers = []string{constants.NodeLabelerFinalizer}
-					pod.DeletionTimestamp = &now
-					pod.Name = podName
-				},
-			),
-				mockDC.EXPECT().GetNodeLabelFromPod(gomock.Any(), moduleName, false).Return(nodeLabel),
-				mockDC.EXPECT().GetNodeLabelFromPod(gomock.Any(), moduleName, true).Return(deprecatedNodeLabel),
+			gomock.InOrder(
+				kubeClient.EXPECT().Get(ctx, req.NamespacedName, gomock.Any()).Do(
+					func(_ interface{}, _ interface{}, pod *v1.Pod, _ ...client.GetOption) {
+						pod.SetLabels(map[string]string{constants.ModuleNameLabel: moduleName})
+						pod.Finalizers = []string{constants.NodeLabelerFinalizer}
+						pod.DeletionTimestamp = &now
+						pod.Name = podName
+					},
+				),
 				kubeClient.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&v1.Pod{}), gomock.Any()).Do(patchRemoveFinalizerFunc),
 			)
 
@@ -181,6 +175,7 @@ var _ = Describe("PodNodeModuleReconciler", func() {
 				kubeClient.EXPECT().Get(ctx, req.NamespacedName, gomock.Any()).Do(
 					func(_ interface{}, _ interface{}, pod *v1.Pod, _ ...client.GetOption) {
 						pod.Name = podName
+						pod.Namespace = podNamespace
 						pod.SetLabels(map[string]string{constants.ModuleNameLabel: moduleName})
 						pod.Spec.NodeName = nodeName
 						pod.Status = v1.PodStatus{
@@ -193,8 +188,6 @@ var _ = Describe("PodNodeModuleReconciler", func() {
 						}
 					},
 				),
-				mockDC.EXPECT().GetNodeLabelFromPod(gomock.Any(), moduleName, false).Return(nodeLabel),
-				mockDC.EXPECT().GetNodeLabelFromPod(gomock.Any(), moduleName, true).Return(deprecatedNodeLabel),
 				kubeClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil),
 				kubeClient.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Do(
 					func(_ interface{}, node *v1.Node, p client.Patch, _ ...client.GetOption) {
@@ -202,8 +195,7 @@ var _ = Describe("PodNodeModuleReconciler", func() {
 						data, err := p.Data(node)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(data).To(ContainSubstring("labels"))
-						Expect(data).To(ContainSubstring(nodeLabel))
-						Expect(data).To(ContainSubstring(deprecatedNodeLabel))
+						Expect(data).To(ContainSubstring(utils.GetDevicePluginNodeLabel(podNamespace, moduleName)))
 					},
 				),
 			)
@@ -229,14 +221,8 @@ var _ = Describe("PodNodeModuleReconciler", func() {
 						pod.Name = podName
 					},
 				),
-				mockDC.EXPECT().GetNodeLabelFromPod(gomock.Any(), moduleName, false).Return(nodeLabel),
-				mockDC.EXPECT().GetNodeLabelFromPod(gomock.Any(), moduleName, true).Return(deprecatedNodeLabel),
 				kubeClient.EXPECT().List(ctx, gomock.Any(), labelSelector, fieldSelector).Return(nil),
-				kubeClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Do(
-					func(_ interface{}, _ interface{}, node *v1.Node, _ ...client.GetOption) {
-						node.SetLabels(map[string]string{nodeLabel: "", deprecatedNodeLabel: ""})
-					},
-				),
+				kubeClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil),
 				kubeClient.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(nil),
 				kubeClient.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Do(patchRemoveFinalizerFunc),
 			)

--- a/internal/daemonset/daemonset_test.go
+++ b/internal/daemonset/daemonset_test.go
@@ -261,7 +261,7 @@ var _ = Describe("SetDevicePluginAsDesired", func() {
 						},
 						ImagePullSecrets: []v1.LocalObjectReference{repoSecret},
 						NodeSelector: map[string]string{
-							getDriverContainerNodeLabel(mod.Namespace, mod.Name, true): "",
+							utils.GetKernelModuleReadyNodeLabel(mod.Namespace, mod.Name): "",
 						},
 						PriorityClassName:  "system-node-critical",
 						ServiceAccountName: serviceAccountName,
@@ -471,28 +471,5 @@ var _ = Describe("OverrideLabels", func() {
 		).To(
 			Equal(map[string]string{"a": "z", "c": "d"}),
 		)
-	})
-})
-
-var _ = Describe("GetNodeLabelFromPod", func() {
-
-	const namespace = "some-namespace"
-	var dc DaemonSetCreator
-
-	BeforeEach(func() {
-		dc = NewCreator(clnt, kernelLabel, scheme)
-	})
-
-	It("should return a device plugin label", func() {
-		pod := v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels:    map[string]string{constants.ModuleNameLabel: moduleName},
-				Namespace: namespace,
-			},
-		}
-		res := dc.GetNodeLabelFromPod(&pod, "module-name", false)
-		Expect(res).To(Equal(getDevicePluginNodeLabel(namespace, "module-name", false)))
-		res = dc.GetNodeLabelFromPod(&pod, "module-name", true)
-		Expect(res).To(Equal(getDevicePluginNodeLabel(namespace, "module-name", true)))
 	})
 })

--- a/internal/daemonset/mock_daemonset.go
+++ b/internal/daemonset/mock_daemonset.go
@@ -15,7 +15,6 @@ import (
 	v1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	gomock "go.uber.org/mock/gomock"
 	v1 "k8s.io/api/apps/v1"
-	v10 "k8s.io/api/core/v1"
 )
 
 // MockDaemonSetCreator is a mock of DaemonSetCreator interface.
@@ -69,20 +68,6 @@ func (m *MockDaemonSetCreator) GetModuleDaemonSets(ctx context.Context, name, na
 func (mr *MockDaemonSetCreatorMockRecorder) GetModuleDaemonSets(ctx, name, namespace any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleDaemonSets", reflect.TypeOf((*MockDaemonSetCreator)(nil).GetModuleDaemonSets), ctx, name, namespace)
-}
-
-// GetNodeLabelFromPod mocks base method.
-func (m *MockDaemonSetCreator) GetNodeLabelFromPod(pod *v10.Pod, moduleName string, useDeprecatedLabel bool) string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNodeLabelFromPod", pod, moduleName, useDeprecatedLabel)
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// GetNodeLabelFromPod indicates an expected call of GetNodeLabelFromPod.
-func (mr *MockDaemonSetCreatorMockRecorder) GetNodeLabelFromPod(pod, moduleName, useDeprecatedLabel any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodeLabelFromPod", reflect.TypeOf((*MockDaemonSetCreator)(nil).GetNodeLabelFromPod), pod, moduleName, useDeprecatedLabel)
 }
 
 // SetDevicePluginAsDesired mocks base method.

--- a/internal/utils/kmmlabels.go
+++ b/internal/utils/kmmlabels.go
@@ -73,6 +73,10 @@ func GetKernelModuleReadyNodeLabel(namespace, moduleName string) string {
 	return fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.ready", namespace, moduleName)
 }
 
+func GetDevicePluginNodeLabel(namespace, moduleName string) string {
+	return fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.device-plugin-ready", namespace, moduleName)
+}
+
 func IsKernelModuleReadyNodeLabel(label string) bool {
 	return reKernelModuleReadyLabel.MatchString(label)
 }


### PR DESCRIPTION
pod-node-reconciler must now handle only device-plugin pod in order not to interfere with the NMC reconciler, which handles node labeling based on worker pod