### PR TITLE
Fixing Module with device-plugin finalization deadlock (#590)

### DIFF
--- a/internal/controllers/mock_module_reconciler.go
+++ b/internal/controllers/mock_module_reconciler.go
@@ -119,17 +119,31 @@ func (mr *MockmoduleReconcilerHelperAPIMockRecorder) handleBuild(ctx, mld any) *
 }
 
 // handleDevicePlugin mocks base method.
-func (m *MockmoduleReconcilerHelperAPI) handleDevicePlugin(ctx context.Context, mod *v1beta1.Module, existingModuleDS []v1.DaemonSet) error {
+func (m *MockmoduleReconcilerHelperAPI) handleDevicePlugin(ctx context.Context, mod *v1beta1.Module, existingDevicePluginDS []v1.DaemonSet) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "handleDevicePlugin", ctx, mod, existingModuleDS)
+	ret := m.ctrl.Call(m, "handleDevicePlugin", ctx, mod, existingDevicePluginDS)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // handleDevicePlugin indicates an expected call of handleDevicePlugin.
-func (mr *MockmoduleReconcilerHelperAPIMockRecorder) handleDevicePlugin(ctx, mod, existingModuleDS any) *gomock.Call {
+func (mr *MockmoduleReconcilerHelperAPIMockRecorder) handleDevicePlugin(ctx, mod, existingDevicePluginDS any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleDevicePlugin", reflect.TypeOf((*MockmoduleReconcilerHelperAPI)(nil).handleDevicePlugin), ctx, mod, existingModuleDS)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleDevicePlugin", reflect.TypeOf((*MockmoduleReconcilerHelperAPI)(nil).handleDevicePlugin), ctx, mod, existingDevicePluginDS)
+}
+
+// handleModuleDeletion mocks base method.
+func (m *MockmoduleReconcilerHelperAPI) handleModuleDeletion(ctx context.Context, existingDevicePluginDS []v1.DaemonSet) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "handleModuleDeletion", ctx, existingDevicePluginDS)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// handleModuleDeletion indicates an expected call of handleModuleDeletion.
+func (mr *MockmoduleReconcilerHelperAPIMockRecorder) handleModuleDeletion(ctx, existingDevicePluginDS any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleModuleDeletion", reflect.TypeOf((*MockmoduleReconcilerHelperAPI)(nil).handleModuleDeletion), ctx, existingDevicePluginDS)
 }
 
 // handleSigning mocks base method.

--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -109,6 +109,16 @@ func (r *ModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return res, fmt.Errorf("failed to get the requested %s KMMO CR: %w", req.NamespacedName, err)
 	}
 
+	existingDevicePluginDS, err := r.daemonAPI.GetModuleDaemonSets(ctx, mod.Name, mod.Namespace)
+	if err != nil {
+		return res, fmt.Errorf("could not get DaemonSets for module %s, namespace %s: %v", mod.Name, mod.Namespace, err)
+	}
+
+	if mod.GetDeletionTimestamp() != nil {
+		err = r.reconHelperAPI.handleModuleDeletion(ctx, existingDevicePluginDS)
+		return ctrl.Result{}, err
+	}
+
 	r.reconHelperAPI.setKMMOMetrics(ctx)
 
 	targetedNodes, err := r.reconHelperAPI.getNodesListBySelector(ctx, mod)
@@ -119,11 +129,6 @@ func (r *ModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	mldMappings, nodesWithMapping, err := r.reconHelperAPI.getRelevantKernelMappingsAndNodes(ctx, mod, targetedNodes)
 	if err != nil {
 		return res, fmt.Errorf("could get kernel mappings and nodes for modules %s: %w", mod.Name, err)
-	}
-
-	existingModuleDS, err := r.daemonAPI.GetModuleDaemonSets(ctx, mod.Name, mod.Namespace)
-	if err != nil {
-		return res, fmt.Errorf("could not get DaemonSets for module %s, namespace %s: %v", mod.Name, mod.Namespace, err)
 	}
 
 	for kernelVersion, mld := range mldMappings {
@@ -151,18 +156,18 @@ func (r *ModuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	logger.Info("Handle device plugin")
-	err = r.reconHelperAPI.handleDevicePlugin(ctx, mod, existingModuleDS)
+	err = r.reconHelperAPI.handleDevicePlugin(ctx, mod, existingDevicePluginDS)
 	if err != nil {
 		return res, fmt.Errorf("could handle device plugin: %w", err)
 	}
 
 	logger.Info("Run garbage collection")
-	err = r.reconHelperAPI.garbageCollect(ctx, mod, mldMappings, existingModuleDS)
+	err = r.reconHelperAPI.garbageCollect(ctx, mod, mldMappings, existingDevicePluginDS)
 	if err != nil {
 		return res, fmt.Errorf("failed to run garbage collection: %v", err)
 	}
 
-	err = r.statusUpdaterAPI.ModuleUpdateStatus(ctx, mod, nodesWithMapping, targetedNodes, existingModuleDS)
+	err = r.statusUpdaterAPI.ModuleUpdateStatus(ctx, mod, nodesWithMapping, targetedNodes, existingDevicePluginDS)
 	if err != nil {
 		return res, fmt.Errorf("failed to update status of the module: %w", err)
 	}
@@ -181,8 +186,9 @@ type moduleReconcilerHelperAPI interface {
 	getRelevantKernelMappingsAndNodes(ctx context.Context, mod *kmmv1beta1.Module, targetedNodes []v1.Node) (map[string]*api.ModuleLoaderData, []v1.Node, error)
 	handleBuild(ctx context.Context, mld *api.ModuleLoaderData) (bool, error)
 	handleSigning(ctx context.Context, mld *api.ModuleLoaderData) (bool, error)
-	handleDevicePlugin(ctx context.Context, mod *kmmv1beta1.Module, existingModuleDS []appsv1.DaemonSet) error
+	handleDevicePlugin(ctx context.Context, mod *kmmv1beta1.Module, existingDevicePluginDS []appsv1.DaemonSet) error
 	garbageCollect(ctx context.Context, mod *kmmv1beta1.Module, mldMappings map[string]*api.ModuleLoaderData, existingDS []appsv1.DaemonSet) error
+	handleModuleDeletion(ctx context.Context, existingDevicePluginDS []appsv1.DaemonSet) error
 }
 
 type moduleReconcilerHelper struct {
@@ -338,13 +344,13 @@ func (mrh *moduleReconcilerHelper) handleSigning(ctx context.Context, mld *api.M
 	return completedSuccessfully, nil
 }
 
-func (mrh *moduleReconcilerHelper) handleDevicePlugin(ctx context.Context, mod *kmmv1beta1.Module, existingModuleDS []appsv1.DaemonSet) error {
+func (mrh *moduleReconcilerHelper) handleDevicePlugin(ctx context.Context, mod *kmmv1beta1.Module, existingDevicePluginDS []appsv1.DaemonSet) error {
 	if mod.Spec.DevicePlugin == nil {
 		return nil
 	}
 
 	logger := log.FromContext(ctx)
-	ds := getExistingDS(existingModuleDS, mod.Namespace, mod.Name, mod.Spec.ModuleLoader.Container.Version)
+	ds := getExistingDS(existingDevicePluginDS, mod.Namespace, mod.Name, mod.Spec.ModuleLoader.Container.Version)
 	if ds == nil {
 		logger.Info("creating new device plugin DS", "version", mod.Spec.ModuleLoader.Container.Version)
 		ds = &appsv1.DaemonSet{
@@ -391,6 +397,17 @@ func (mrh *moduleReconcilerHelper) garbageCollect(ctx context.Context,
 
 	logger.Info("Garbage-collected Sign objects", "names", deleted)
 
+	return nil
+}
+
+func (mrh *moduleReconcilerHelper) handleModuleDeletion(ctx context.Context, existingDevicePluginDS []appsv1.DaemonSet) error {
+	// delete all the Device Plugin Daemonset, in order to allow worker pods to delete kernel modules
+	for _, ds := range existingDevicePluginDS {
+		err := mrh.client.Delete(ctx, &ds)
+		if err != nil {
+			return fmt.Errorf("failed to delete device-plugin Daemonset %s/%s: %v", ds.Namespace, ds.Name, err)
+		}
+	}
 	return nil
 }
 

--- a/internal/controllers/module_reconciler_test.go
+++ b/internal/controllers/module_reconciler_test.go
@@ -75,7 +75,7 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	DescribeTable("check error flows", func(getModuleError, getNodesError, getMappingsError, getDSError, handleBuildError,
+	DescribeTable("check error flows", func(getModuleError, getDSError, getNodesError, getMappingsError, handleBuildError,
 		handleSignError, handlePluginError, gcError bool) {
 		mod := kmmv1beta1.Module{}
 		selectNodesList := []v1.Node{v1.Node{}}
@@ -88,6 +88,11 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			goto executeTestFunction
 		}
 		mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(&mod, nil)
+		if getDSError {
+			mockDC.EXPECT().GetModuleDaemonSets(ctx, mod.Name, mod.Namespace).Return(nil, returnedError)
+			goto executeTestFunction
+		}
+		mockDC.EXPECT().GetModuleDaemonSets(ctx, mod.Name, mod.Namespace).Return(moduleDS, nil)
 		mockReconHelper.EXPECT().setKMMOMetrics(ctx)
 		if getNodesError {
 			mockReconHelper.EXPECT().getNodesListBySelector(ctx, &mod).Return(nil, returnedError)
@@ -99,11 +104,6 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 			goto executeTestFunction
 		}
 		mockReconHelper.EXPECT().getRelevantKernelMappingsAndNodes(ctx, &mod, selectNodesList).Return(mappings, kernelNodesList, nil)
-		if getDSError {
-			mockDC.EXPECT().GetModuleDaemonSets(ctx, mod.Name, mod.Namespace).Return(nil, returnedError)
-			goto executeTestFunction
-		}
-		mockDC.EXPECT().GetModuleDaemonSets(ctx, mod.Name, mod.Namespace).Return(moduleDS, nil)
 		if handleBuildError {
 			mockReconHelper.EXPECT().handleBuild(ctx, mappings["kernelVersion"]).Return(false, returnedError)
 			goto executeTestFunction
@@ -134,13 +134,12 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 
 	},
 		Entry("getRequestedModule failed", true, false, false, false, false, false, false, false),
-		Entry("getNodesListBySelector failed", false, true, false, false, false, false, false, false),
-		Entry("getRelevantKernelMappingsAndNodes failed", false, false, true, false, false, false, false, false),
-		Entry("ModuleDaemonSetsByKernelVersion failed", false, false, false, true, false, false, false, false),
-		Entry("handleBuild failed ", false, false, false, false, true, false, false, false),
-		Entry("handleSig failedn", false, false, false, false, false, true, false, false),
-		Entry("handleDriverContainer failed", false, false, false, false, false, false, false, false),
-		Entry("handleDevicePlugin failed", false, false, false, false, false, false, true, false),
+		Entry("getModuleDaemonSets failed", false, true, false, false, false, false, false, false),
+		Entry("getNodesListBySelector failed", false, false, true, false, false, false, false, false),
+		Entry("getRelevantKernelMappingsAndNodes failed", false, false, false, true, false, false, false, false),
+		Entry("handleBuild failed ", false, false, false, false, false, true, false, false),
+		Entry("handleSig failed", false, false, false, false, false, false, true, false),
+		Entry("handleDevicePlugin failed", false, false, false, false, false, false, false, true),
 		Entry("garbageCollect failed", false, false, false, false, false, false, false, true),
 		Entry("moduleUpdateStatus failed", false, false, false, false, false, false, false, false),
 	)
@@ -153,10 +152,10 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		moduleDS := []appsv1.DaemonSet{appsv1.DaemonSet{}}
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(&mod, nil),
+			mockDC.EXPECT().GetModuleDaemonSets(ctx, mod.Name, mod.Namespace).Return(moduleDS, nil),
 			mockReconHelper.EXPECT().setKMMOMetrics(ctx),
 			mockReconHelper.EXPECT().getNodesListBySelector(ctx, &mod).Return(selectNodesList, nil),
 			mockReconHelper.EXPECT().getRelevantKernelMappingsAndNodes(ctx, &mod, selectNodesList).Return(mappings, kernelNodesList, nil),
-			mockDC.EXPECT().GetModuleDaemonSets(ctx, mod.Name, mod.Namespace).Return(moduleDS, nil),
 			mockReconHelper.EXPECT().handleBuild(ctx, mappings["kernelVersion"]).Return(false, nil),
 			mockReconHelper.EXPECT().handleDevicePlugin(ctx, &mod, moduleDS).Return(nil),
 			mockReconHelper.EXPECT().garbageCollect(ctx, &mod, mappings, moduleDS).Return(nil),
@@ -178,10 +177,10 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		moduleDS := []appsv1.DaemonSet{appsv1.DaemonSet{}}
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(&mod, nil),
+			mockDC.EXPECT().GetModuleDaemonSets(ctx, mod.Name, mod.Namespace).Return(moduleDS, nil),
 			mockReconHelper.EXPECT().setKMMOMetrics(ctx),
 			mockReconHelper.EXPECT().getNodesListBySelector(ctx, &mod).Return(selectNodesList, nil),
 			mockReconHelper.EXPECT().getRelevantKernelMappingsAndNodes(ctx, &mod, selectNodesList).Return(mappings, kernelNodesList, nil),
-			mockDC.EXPECT().GetModuleDaemonSets(ctx, mod.Name, mod.Namespace).Return(moduleDS, nil),
 			mockReconHelper.EXPECT().handleBuild(ctx, mappings["kernelVersion"]).Return(true, nil),
 			mockReconHelper.EXPECT().handleSigning(ctx, mappings["kernelVersion"]).Return(false, nil),
 			mockReconHelper.EXPECT().handleDevicePlugin(ctx, &mod, moduleDS).Return(nil),
@@ -203,10 +202,10 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		moduleDS := []appsv1.DaemonSet{appsv1.DaemonSet{}}
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(&mod, nil),
+			mockDC.EXPECT().GetModuleDaemonSets(ctx, mod.Name, mod.Namespace).Return(moduleDS, nil),
 			mockReconHelper.EXPECT().setKMMOMetrics(ctx),
 			mockReconHelper.EXPECT().getNodesListBySelector(ctx, &mod).Return(selectNodesList, nil),
 			mockReconHelper.EXPECT().getRelevantKernelMappingsAndNodes(ctx, &mod, selectNodesList).Return(mappings, kernelNodesList, nil),
-			mockDC.EXPECT().GetModuleDaemonSets(ctx, mod.Name, mod.Namespace).Return(moduleDS, nil),
 			mockReconHelper.EXPECT().handleBuild(ctx, mappings["kernelVersion"]).Return(true, nil),
 			mockReconHelper.EXPECT().handleSigning(ctx, mappings["kernelVersion"]).Return(true, nil),
 			mockReconHelper.EXPECT().handleDevicePlugin(ctx, &mod, moduleDS).Return(nil),
@@ -219,6 +218,35 @@ var _ = Describe("ModuleReconciler_Reconcile", func() {
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).NotTo(HaveOccurred())
 	})
+
+	It("module deletion flow", func() {
+		mod := kmmv1beta1.Module{}
+		mod.SetDeletionTimestamp(&metav1.Time{})
+		moduleDS := []appsv1.DaemonSet{appsv1.DaemonSet{}}
+
+		By("good flow")
+		gomock.InOrder(
+			mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(&mod, nil),
+			mockDC.EXPECT().GetModuleDaemonSets(ctx, mod.Name, mod.Namespace).Return(moduleDS, nil),
+			mockReconHelper.EXPECT().handleModuleDeletion(ctx, moduleDS).Return(nil),
+		)
+
+		res, err := mr.Reconcile(ctx, req)
+		Expect(res).To(Equal(reconcile.Result{}))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("error flow")
+		gomock.InOrder(
+			mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(&mod, nil),
+			mockDC.EXPECT().GetModuleDaemonSets(ctx, mod.Name, mod.Namespace).Return(moduleDS, nil),
+			mockReconHelper.EXPECT().handleModuleDeletion(ctx, moduleDS).Return(fmt.Errorf("some error")),
+		)
+
+		res, err = mr.Reconcile(ctx, req)
+		Expect(res).To(Equal(reconcile.Result{}))
+		Expect(err).To(HaveOccurred())
+	})
+
 })
 
 var _ = Describe("ModuleReconciler_getNodesListBySelector", func() {
@@ -683,6 +711,37 @@ var _ = Describe("ModuleReconciler_garbageCollect", func() {
 		Entry("sign GC failed", false, false),
 	)
 
+})
+
+var _ = Describe("ModuleReconciler_handleModuleDeletion", func() {
+	var (
+		ctrl *gomock.Controller
+		clnt *client.MockClient
+		mhr  moduleReconcilerHelperAPI
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		mhr = newModuleReconcilerHelper(clnt, nil, nil, nil, nil, nil, "")
+	})
+
+	existingDS := []appsv1.DaemonSet{appsv1.DaemonSet{}}
+	ctx := context.Background()
+
+	It("good flow", func() {
+		clnt.EXPECT().Delete(ctx, &existingDS[0]).Return(nil)
+
+		err := mhr.handleModuleDeletion(ctx, existingDS)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("error flow", func() {
+		clnt.EXPECT().Delete(ctx, &existingDS[0]).Return(fmt.Errorf("some error"))
+
+		err := mhr.handleModuleDeletion(ctx, existingDS)
+		Expect(err).To(HaveOccurred())
+	})
 })
 
 var _ = Describe("ModuleReconciler_setKMMOMetrics", func() {


### PR DESCRIPTION
Currently, when the module is deleted, the finalization function is called. This function basically waits till all the kernel modules has been unloaded, and only then removes the finalizer from Module. In case device-plugin is deployed, its Daemonset won't be deleted (since Module is not deleted due to finalizer), and the kernel modules cannot be unloaded due to device plugin running
Solution: in case of Module being deleted, handle device-plugin deletion in the module-reconciler specifically, and not wait for it to be deleted based on ownerReference