### PR TITLE
Fix support bundle collection

### DIFF
--- a/internal/build/ocpbuild/maker_test.go
+++ b/internal/build/ocpbuild/maker_test.go
@@ -115,11 +115,7 @@ var _ = Describe("Maker_MakeBuildTemplate", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: moduleName + "-build-",
 				Namespace:    namespace,
-				Labels: map[string]string{
-					constants.ModuleNameLabel:     moduleName,
-					constants.TargetKernelTarget:  targetKernel,
-					"kmm.openshift.io/build.type": BuildType,
-				},
+				Labels:       ocpbuildutils.GetOCPBuildLabels(&mld, BuildType),
 				OwnerReferences: []metav1.OwnerReference{
 					{
 						APIVersion:         "kmm.sigs.x-k8s.io/v1beta1",

--- a/internal/controllers/nmc_reconciler.go
+++ b/internal/controllers/nmc_reconciler.go
@@ -969,7 +969,12 @@ func (p *podManagerImpl) baseWorkerPod(
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: item.Namespace,
 			Name:      workerPodName(nodeName, item.Name),
-			Labels:    map[string]string{constants.ModuleNameLabel: item.Name},
+			Labels: map[string]string{
+				"app.kubernetes.io/name":      "kmm",
+				"app.kubernetes.io/component": "worker",
+				"app.kubernetes.io/part-of":   "kmm",
+				constants.ModuleNameLabel:     item.Name,
+			},
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{

--- a/internal/controllers/nmc_reconciler_test.go
+++ b/internal/controllers/nmc_reconciler_test.go
@@ -1454,12 +1454,16 @@ softdep b pre: c
 			Name:      workerPodName(nmcName, moduleName),
 			Namespace: namespace,
 			Labels: map[string]string{
-				actionLabelKey:            string(action),
-				constants.ModuleNameLabel: moduleName,
+				"app.kubernetes.io/component": "worker",
+				"app.kubernetes.io/name":      "kmm",
+				"app.kubernetes.io/part-of":   "kmm",
+				actionLabelKey:                string(action),
+				constants.ModuleNameLabel:     moduleName,
 			},
 			Annotations: map[string]string{
 				configAnnotationKey: configAnnotationValue,
-				modulesOrderKey:     modulesOrderValue},
+				modulesOrderKey:     modulesOrderValue,
+			},
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{

--- a/internal/utils/ocpbuild/utils.go
+++ b/internal/utils/ocpbuild/utils.go
@@ -17,7 +17,13 @@ func GetOCPBuildAnnotations(hash uint64) map[string]string {
 }
 
 func GetOCPBuildLabels(mld *api.ModuleLoaderData, buildType string) map[string]string {
-	return moduleKernelLabels(mld.Name, mld.KernelVersion, buildType)
+	labels := moduleKernelLabels(mld.Name, mld.KernelVersion, buildType)
+
+	labels["app.kubernetes.io/name"] = "kmm"
+	labels["app.kubernetes.io/component"] = buildType
+	labels["app.kubernetes.io/part-of"] = "kmm"
+
+	return labels
 }
 
 func moduleKernelLabels(moduleName, kernelVersion, buildType string) map[string]string {

--- a/internal/utils/ocpbuild/utils_test.go
+++ b/internal/utils/ocpbuild/utils_test.go
@@ -4,8 +4,40 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	buildv1 "github.com/openshift/api/build/v1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+var _ = Describe("GetOCPBuildLabels", func() {
+	const (
+		kernelVersion = "some-kernel-version"
+		moduleName    = "some-module"
+		buildType     = "some-build-type"
+	)
+
+	It("should work as expected", func() {
+		mld := &api.ModuleLoaderData{
+			KernelVersion: kernelVersion,
+			Name:          moduleName,
+		}
+
+		expected := map[string]string{
+			constants.ModuleNameLabel:     moduleName,
+			constants.BuildTypeLabel:      buildType,
+			constants.TargetKernelTarget:  kernelVersion,
+			"app.kubernetes.io/name":      "kmm",
+			"app.kubernetes.io/component": buildType,
+			"app.kubernetes.io/part-of":   "kmm",
+		}
+
+		Expect(
+			GetOCPBuildLabels(mld, buildType),
+		).To(
+			Equal(expected),
+		)
+	})
+})
 
 var _ = Describe("IsBuildChanged", func() {
 	b0 := &buildv1.Build{


### PR DESCRIPTION
Add common labels to worker, build and signing pods so that their logs are collected in the support bundle.

Fixes #818 

/cc @yevgeny-shnaidman 