### PR TITLE
adapting Device Plugin status report in Module to v.2 (#606)

### DIFF
--- a/internal/controllers/device_plugin_reconciler.go
+++ b/internal/controllers/device_plugin_reconciler.go
@@ -85,9 +85,6 @@ func (r *DevicePluginReconciler) SetupWithManager(mgr ctrl.Manager) error {
 //+kubebuilder:rbac:groups="core",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups="core",resources=serviceaccounts,verbs=get;list;watch
 
-// Reconcile lists all nodes and looks for kernels that match its mappings.
-// For each mapping that matches at least one node in the cluster, it creates a DaemonSet running the container image
-// on the nodes with a compatible kernel.
 func (r *DevicePluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	res := ctrl.Result{}
 
@@ -285,7 +282,47 @@ func (dprh *devicePluginReconcilerHelper) getRequestedModule(ctx context.Context
 func (dprh *devicePluginReconcilerHelper) moduleUpdateDevicePluginStatus(ctx context.Context,
 	mod *kmmv1beta1.Module,
 	existingDevicePluginDS []appsv1.DaemonSet) error {
-	return nil
+
+	// get the number of nodes targeted by selector (which also relevant for device plugin)
+	numTargetedNodes, err := dprh.getNumTargetedNodes(ctx, mod.Spec.Selector)
+	if err != nil {
+		return fmt.Errorf("failed to determine the number of nodes that should be targeted by Module's %s/%s selector: %v", mod.Namespace, mod.Name, err)
+	}
+
+	// number of available consists of sum of available pods for both (in case of ordered upgrade)
+	// device plugin DaemonSets
+	numAvailable := int32(0)
+	for _, ds := range existingDevicePluginDS {
+		numAvailable += ds.Status.NumberAvailable
+	}
+
+	unmodifiedMod := mod.DeepCopy()
+
+	mod.Status.DevicePlugin.NodesMatchingSelectorNumber = int32(numTargetedNodes)
+	mod.Status.DevicePlugin.DesiredNumber = int32(numTargetedNodes)
+	mod.Status.DevicePlugin.AvailableNumber = numAvailable
+
+	return dprh.client.Status().Patch(ctx, mod, client.MergeFrom(unmodifiedMod))
+}
+
+func (dprh *devicePluginReconcilerHelper) getNumTargetedNodes(ctx context.Context, selectorLabels map[string]string) (int, error) {
+	logger := log.FromContext(ctx)
+	logger.V(1).Info("Listing nodes", "selector", selectorLabels)
+
+	selectedNodes := v1.NodeList{}
+	opt := client.MatchingLabels(selectorLabels)
+	if err := dprh.client.List(ctx, &selectedNodes, opt); err != nil {
+		return 0, fmt.Errorf("could not list nodes: %v", err)
+	}
+
+	numNodes := 0
+
+	for _, node := range selectedNodes.Items {
+		if utils.IsNodeSchedulable(&node) {
+			numNodes += 1
+		}
+	}
+	return numNodes, nil
 }
 
 //go:generate mockgen -source=device_plugin_reconciler.go -package=controllers -destination=mock_device_plugin_reconciler.go daemonSetCreator

--- a/internal/controllers/device_plugin_reconciler_test.go
+++ b/internal/controllers/device_plugin_reconciler_test.go
@@ -493,6 +493,65 @@ var _ = Describe("DevicePluginReconciler_setKMMOMetrics", func() {
 	)
 })
 
+var _ = Describe("DevicePluginReconciler_moduleUpdateDevicePluginStatus", func() {
+	var (
+		ctrl         *gomock.Controller
+		clnt         *client.MockClient
+		statusWriter *client.MockStatusWriter
+		dprh         devicePluginReconcilerHelperAPI
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		statusWriter = client.NewMockStatusWriter(ctrl)
+		dprh = newDevicePluginReconcilerHelper(clnt, nil, nil, "")
+	})
+
+	ctx := context.Background()
+
+	DescribeTable("device-plugin status update",
+		func(numTargetedNodes int, numAvailableInDaemonSets []int, nodesMatchingNumber, availableNumber int) {
+			mod := kmmv1beta1.Module{}
+			expectedMod := mod.DeepCopy()
+			expectedMod.Status.DevicePlugin.NodesMatchingSelectorNumber = int32(nodesMatchingNumber)
+			expectedMod.Status.DevicePlugin.DesiredNumber = int32(nodesMatchingNumber)
+			expectedMod.Status.DevicePlugin.AvailableNumber = int32(availableNumber)
+
+			nodesList := []v1.Node{}
+			for i := 0; i < numTargetedNodes; i++ {
+				nodesList = append(nodesList, v1.Node{})
+			}
+			daemonSetsList := []appsv1.DaemonSet{}
+			for _, numAvailable := range numAvailableInDaemonSets {
+				ds := appsv1.DaemonSet{
+					Status: appsv1.DaemonSetStatus{
+						NumberAvailable: int32(numAvailable),
+					},
+				}
+				daemonSetsList = append(daemonSetsList, ds)
+			}
+
+			clnt.EXPECT().List(context.Background(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ interface{}, list *v1.NodeList, _ ...interface{}) error {
+					list.Items = nodesList
+					return nil
+				},
+			)
+			clnt.EXPECT().Status().Return(statusWriter)
+			statusWriter.EXPECT().Patch(ctx, expectedMod, gomock.Any())
+
+			err := dprh.moduleUpdateDevicePluginStatus(ctx, &mod, daemonSetsList)
+			Expect(err).NotTo(HaveOccurred())
+		},
+		Entry("0 target node, 0 ds", 0, nil, 0, 0),
+		Entry("0 target node, 1 ds", 0, []int{1}, 0, 1),
+		Entry("0 target node, 2 ds", 0, []int{3, 6}, 0, 9),
+		Entry("3 target node, 0 ds", 3, nil, 3, 0),
+		Entry("2 target node, 3 ds", 2, []int{3, 6, 8}, 2, 17),
+	)
+})
+
 var _ = Describe("DevicePluginReconciler_setDevicePluginAsDesired", func() {
 	const (
 		devicePluginImage = "device-plugin-image"

--- a/internal/controllers/mock_module_nmc_reconciler.go
+++ b/internal/controllers/mock_module_nmc_reconciler.go
@@ -145,16 +145,16 @@ func (mr *MockmoduleNMCReconcilerHelperAPIMockRecorder) prepareSchedulingData(ct
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "prepareSchedulingData", reflect.TypeOf((*MockmoduleNMCReconcilerHelperAPI)(nil).prepareSchedulingData), ctx, mod, targetedNodes, currentNMCs)
 }
 
-// setFinalizer mocks base method.
-func (m *MockmoduleNMCReconcilerHelperAPI) setFinalizer(ctx context.Context, mod *v1beta1.Module) error {
+// setFinalizerAndStatus mocks base method.
+func (m *MockmoduleNMCReconcilerHelperAPI) setFinalizerAndStatus(ctx context.Context, mod *v1beta1.Module) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "setFinalizer", ctx, mod)
+	ret := m.ctrl.Call(m, "setFinalizerAndStatus", ctx, mod)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// setFinalizer indicates an expected call of setFinalizer.
-func (mr *MockmoduleNMCReconcilerHelperAPIMockRecorder) setFinalizer(ctx, mod any) *gomock.Call {
+// setFinalizerAndStatus indicates an expected call of setFinalizerAndStatus.
+func (mr *MockmoduleNMCReconcilerHelperAPIMockRecorder) setFinalizerAndStatus(ctx, mod any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "setFinalizer", reflect.TypeOf((*MockmoduleNMCReconcilerHelperAPI)(nil).setFinalizer), ctx, mod)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "setFinalizerAndStatus", reflect.TypeOf((*MockmoduleNMCReconcilerHelperAPI)(nil).setFinalizerAndStatus), ctx, mod)
 }

--- a/internal/controllers/module_nmc_reconciler.go
+++ b/internal/controllers/module_nmc_reconciler.go
@@ -89,7 +89,7 @@ func (mnr *ModuleNMCReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return ctrl.Result{}, nil
 	}
 
-	err = mnr.reconHelper.setFinalizer(ctx, mod)
+	err = mnr.reconHelper.setFinalizerAndStatus(ctx, mod)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to set finalizer on %s Module: %v", req.NamespacedName, err)
 	}
@@ -149,7 +149,7 @@ func (mnr *ModuleNMCReconciler) SetupWithManager(mgr ctrl.Manager) error {
 //go:generate mockgen -source=module_nmc_reconciler.go -package=controllers -destination=mock_module_nmc_reconciler.go moduleNMCReconcilerHelperAPI
 
 type moduleNMCReconcilerHelperAPI interface {
-	setFinalizer(ctx context.Context, mod *kmmv1beta1.Module) error
+	setFinalizerAndStatus(ctx context.Context, mod *kmmv1beta1.Module) error
 	finalizeModule(ctx context.Context, mod *kmmv1beta1.Module) error
 	getRequestedModule(ctx context.Context, namespacedName types.NamespacedName) (*kmmv1beta1.Module, error)
 	getNodesListBySelector(ctx context.Context, mod *kmmv1beta1.Module) ([]v1.Node, error)
@@ -184,7 +184,7 @@ func newModuleNMCReconcilerHelper(client client.Client,
 	}
 }
 
-func (mnrh *moduleNMCReconcilerHelper) setFinalizer(ctx context.Context, mod *kmmv1beta1.Module) error {
+func (mnrh *moduleNMCReconcilerHelper) setFinalizerAndStatus(ctx context.Context, mod *kmmv1beta1.Module) error {
 	if controllerutil.ContainsFinalizer(mod, constants.ModuleFinalizer) {
 		return nil
 	}
@@ -194,7 +194,16 @@ func (mnrh *moduleNMCReconcilerHelper) setFinalizer(ctx context.Context, mod *km
 
 	modCopy := mod.DeepCopy()
 	controllerutil.AddFinalizer(mod, constants.ModuleFinalizer)
-	return mnrh.client.Patch(ctx, mod, client.MergeFrom(modCopy))
+	err := mnrh.client.Patch(ctx, mod, client.MergeFrom(modCopy))
+	if err != nil {
+		return fmt.Errorf("failed to set finalizer for module %s/%s: %v", mod.Namespace, mod.Name, err)
+	}
+
+	//mod.Status.ModuleLoader.NodesMatchingSelectorNumber = 0
+	//mod.Status.ModuleLoader.DesiredNumber = 0
+	//mod.Status.ModuleLoader.AvailableNumber = 0
+
+	return mnrh.client.Status().Update(ctx, mod)
 }
 
 func (mnrh *moduleNMCReconcilerHelper) getRequestedModule(ctx context.Context, namespacedName types.NamespacedName) (*kmmv1beta1.Module, error) {

--- a/internal/controllers/module_nmc_reconciler_test.go
+++ b/internal/controllers/module_nmc_reconciler_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Reconcile", func() {
 	})
 
 	DescribeTable("check error flows", func(getModuleError,
-		setFinalizerError,
+		setFinalizerAndStatusError,
 		getNodesError,
 		getNMCsMapError,
 		prepareSchedulingError,
@@ -104,11 +104,11 @@ var _ = Describe("Reconcile", func() {
 			goto executeTestFunction
 		}
 		mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(&mod, nil)
-		if setFinalizerError {
-			mockReconHelper.EXPECT().setFinalizer(ctx, &mod).Return(returnedError)
+		if setFinalizerAndStatusError {
+			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, &mod).Return(returnedError)
 			goto executeTestFunction
 		}
-		mockReconHelper.EXPECT().setFinalizer(ctx, &mod).Return(nil)
+		mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, &mod).Return(nil)
 		if getNodesError {
 			mockReconHelper.EXPECT().getNodesListBySelector(ctx, &mod).Return(nil, returnedError)
 			goto executeTestFunction
@@ -138,7 +138,7 @@ var _ = Describe("Reconcile", func() {
 
 	},
 		Entry("getRequestedModule failed", true, false, false, false, false, false),
-		Entry("setFinalizer failed", false, true, false, false, false, false),
+		Entry("setFinalizerAndStatus failed", false, true, false, false, false, false),
 		Entry("getNodesListBySelector failed", false, false, true, false, false, false),
 		Entry("getNMCsByModuleMap failed", false, false, false, true, false, false),
 		Entry("prepareSchedulingData failed", false, false, false, false, true, false),
@@ -150,7 +150,7 @@ var _ = Describe("Reconcile", func() {
 		nmcMLDConfigs := map[string]schedulingData{nodeName: enableSchedulingData}
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(&mod, nil),
-			mockReconHelper.EXPECT().setFinalizer(ctx, &mod).Return(nil),
+			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, &mod).Return(nil),
 			mockReconHelper.EXPECT().getNodesListBySelector(ctx, &mod).Return(targetedNodes, nil),
 			mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, &mod).Return(currentNMCs, nil),
 			mockReconHelper.EXPECT().prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs).Return(nmcMLDConfigs, nil),
@@ -167,7 +167,7 @@ var _ = Describe("Reconcile", func() {
 		nmcMLDConfigs := map[string]schedulingData{nodeName: disableSchedulingData}
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(&mod, nil),
-			mockReconHelper.EXPECT().setFinalizer(ctx, &mod).Return(nil),
+			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, &mod).Return(nil),
 			mockReconHelper.EXPECT().getNodesListBySelector(ctx, &mod).Return(targetedNodes, nil),
 			mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, &mod).Return(currentNMCs, nil),
 			mockReconHelper.EXPECT().prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs).Return(nmcMLDConfigs, nil),
@@ -223,40 +223,57 @@ var _ = Describe("getRequestedModule", func() {
 
 })
 
-var _ = Describe("setFinalizer", func() {
+var _ = Describe("setFinalizerAndStatus", func() {
 	var (
-		ctrl *gomock.Controller
-		clnt *client.MockClient
-		mnrh moduleNMCReconcilerHelperAPI
-		mod  kmmv1beta1.Module
+		ctrl         *gomock.Controller
+		clnt         *client.MockClient
+		statusWriter *client.MockStatusWriter
+		mnrh         moduleNMCReconcilerHelperAPI
+		mod          kmmv1beta1.Module
+		expectedMod  *kmmv1beta1.Module
 	)
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
+		statusWriter = client.NewMockStatusWriter(ctrl)
 		mnrh = newModuleNMCReconcilerHelper(clnt, nil, nil, nil, nil, scheme)
 		mod = kmmv1beta1.Module{}
+		expectedMod = mod.DeepCopy()
 	})
 
 	ctx := context.Background()
 
 	It("finalizer is already set", func() {
 		controllerutil.AddFinalizer(&mod, constants.ModuleFinalizer)
-		err := mnrh.setFinalizer(ctx, &mod)
+		err := mnrh.setFinalizerAndStatus(ctx, &mod)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("finalizer is not set", func() {
+		controllerutil.AddFinalizer(expectedMod, constants.ModuleFinalizer)
 		clnt.EXPECT().Patch(ctx, &mod, gomock.Any()).Return(nil)
+		clnt.EXPECT().Status().Return(statusWriter)
+		statusWriter.EXPECT().Update(ctx, expectedMod).Return(nil)
 
-		err := mnrh.setFinalizer(ctx, &mod)
+		err := mnrh.setFinalizerAndStatus(ctx, &mod)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("finalizer is not set, failed to patch the Module", func() {
 		clnt.EXPECT().Patch(ctx, &mod, gomock.Any()).Return(fmt.Errorf("some error"))
 
-		err := mnrh.setFinalizer(ctx, &mod)
+		err := mnrh.setFinalizerAndStatus(ctx, &mod)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("finalizer is not set, failed to update Module's status", func() {
+		controllerutil.AddFinalizer(expectedMod, constants.ModuleFinalizer)
+		clnt.EXPECT().Patch(ctx, &mod, gomock.Any()).Return(nil)
+		clnt.EXPECT().Status().Return(statusWriter)
+		statusWriter.EXPECT().Update(ctx, expectedMod).Return(fmt.Errorf("some error"))
+
+		err := mnrh.setFinalizerAndStatus(ctx, &mod)
 		Expect(err).To(HaveOccurred())
 	})
 })


### PR DESCRIPTION
This commits adds implementation of reporting device plugin status into the Module's status.
The following fields are reported:
1) number of targeted nodes ( based on selector field) 2) number of desired podsto be run
3) current number of the pods actually running