### PR TITLE
Bundle: fix the CA type label for the Service CA

### DIFF
--- a/bundle-hub/manifests/kmm-operator-hub-service-ca_v1_configmap.yaml
+++ b/bundle-hub/manifests/kmm-operator-hub-service-ca_v1_configmap.yaml
@@ -3,10 +3,10 @@ data: {}
 kind: ConfigMap
 metadata:
   annotations:
-    kmm.openshift.io/ca.type: service
     service.beta.openshift.io/inject-cabundle: "true"
   labels:
     app.kubernetes.io/component: kmm-hub
     app.kubernetes.io/name: kmm-hub
     app.kubernetes.io/part-of: kmm
+    kmm.openshift.io/ca.type: service
   name: kmm-operator-hub-service-ca

--- a/bundle/manifests/kmm-operator-service-ca_v1_configmap.yaml
+++ b/bundle/manifests/kmm-operator-service-ca_v1_configmap.yaml
@@ -3,10 +3,10 @@ data: {}
 kind: ConfigMap
 metadata:
   annotations:
-    kmm.openshift.io/ca.type: service
     service.beta.openshift.io/inject-cabundle: "true"
   labels:
     app.kubernetes.io/component: kmm
     app.kubernetes.io/name: kmm
     app.kubernetes.io/part-of: kmm
+    kmm.openshift.io/ca.type: service
   name: kmm-operator-service-ca

--- a/config/manager-base/configmap-service-ca.yaml
+++ b/config/manager-base/configmap-service-ca.yaml
@@ -2,8 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   annotations:
-    kmm.openshift.io/ca.type: service
     service.beta.openshift.io/inject-cabundle: "true"
+  labels:
+    kmm.openshift.io/ca.type: service
   name: service-ca
   namespace: system
 data: {}


### PR DESCRIPTION
The Service CA ConfigMap has the service type as an annotation instead of a label, which made KMM unable to find it when the Module was created in the openshift-kmm namespace.

/cc @yevgeny-shnaidman @enriquebelarte 