### PR TITLE
MGMT-16007: Disable HTTP/2 for webhooks

### DIFF
--- a/bundle/manifests/kmm-operator-manager-config_v1_configmap.yaml
+++ b/bundle/manifests/kmm-operator-manager-config_v1_configmap.yaml
@@ -3,10 +3,12 @@ data:
   controller_manager_config.yaml: |
     healthProbeBindAddress: :8081
     metricsBindAddress: 127.0.0.1:8080
-    webhookPort: 9443
     leaderElection:
       enabled: true
       resourceID: kmm.sigs.x-k8s.io
+    webhook:
+      disableHTTP2: true  # CVE-2023-44487
+      port: 9443
     worker:
       runAsUser: 0
       seLinuxType: spc_t

--- a/cmd/manager-hub/main.go
+++ b/cmd/manager-hub/main.go
@@ -104,7 +104,7 @@ func main() {
 		cmd.FatalError(setupLogger, err, "could not parse the configuration file", "path", configFile)
 	}
 
-	options := cfg.ManagerOptions()
+	options := cfg.ManagerOptions(setupLogger)
 	options.Scheme = scheme
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), *options)

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -111,7 +111,7 @@ func main() {
 		cmd.FatalError(setupLogger, err, "could not parse the configuration file", "path", configFile)
 	}
 
-	options := cfg.ManagerOptions()
+	options := cfg.ManagerOptions(setupLogger)
 	options.Scheme = scheme
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), *options)

--- a/config/manager/controller_manager_config.yaml
+++ b/config/manager/controller_manager_config.yaml
@@ -1,9 +1,11 @@
 healthProbeBindAddress: :8081
 metricsBindAddress: 127.0.0.1:8080
-webhookPort: 9443
 leaderElection:
   enabled: true
   resourceID: kmm.sigs.x-k8s.io
+webhook:
+  disableHTTP2: true  # CVE-2023-44487
+  port: 9443
 worker:
   runAsUser: 0
   seLinuxType: spc_t

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 var _ = Describe("ParseFile", func() {
@@ -20,7 +21,10 @@ var _ = Describe("ParseFile", func() {
 				Enabled:    true,
 				ResourceID: "some-resource-id",
 			},
-			WebhookPort: 9443,
+			Webhook: Webhook{
+				DisableHTTP2: true,
+				Port:         9443,
+			},
 			Worker: Worker{
 				RunAsUser:            pointer.Int64(1234),
 				SELinuxType:          "mySELinuxType",
@@ -34,4 +38,51 @@ var _ = Describe("ParseFile", func() {
 			Equal(expected),
 		)
 	})
+})
+
+var _ = Describe("Config_ManagerOptions", func() {
+	DescribeTable(
+		"should work as expected",
+		func(disableHTTP2 bool) {
+			const (
+				healthProbeBindAddress   = ":8081"
+				metricsBindAddress       = "127.0.0.1:8080"
+				leaderElectionEnabled    = true
+				leaderElectionResourceID = "some-resource-id"
+				webhookPort              = 1234
+			)
+
+			cfg := Config{
+				HealthProbeBindAddress: healthProbeBindAddress,
+				MetricsBindAddress:     metricsBindAddress,
+				LeaderElection: LeaderElection{
+					Enabled:    leaderElectionEnabled,
+					ResourceID: leaderElectionResourceID,
+				},
+				Webhook: Webhook{
+					DisableHTTP2: disableHTTP2,
+					Port:         webhookPort,
+				},
+				Worker: Worker{},
+			}
+
+			opts := cfg.ManagerOptions(GinkgoLogr)
+
+			Expect(opts.HealthProbeBindAddress).To(Equal(healthProbeBindAddress))
+			Expect(opts.MetricsBindAddress).To(Equal(metricsBindAddress))
+			Expect(opts.LeaderElection).To(Equal(leaderElectionEnabled))
+			Expect(opts.LeaderElectionID).To(Equal(leaderElectionResourceID))
+
+			expectedTLSOptsLen := 0
+
+			if disableHTTP2 {
+				expectedTLSOptsLen = 1
+			}
+
+			Expect(opts.WebhookServer.(*webhook.DefaultServer).Options.TLSOpts).To(HaveLen(expectedTLSOptsLen))
+			Expect(opts.WebhookServer.(*webhook.DefaultServer).Options.Port).To(Equal(webhookPort))
+		},
+		Entry("HTTP/2 disabled", false),
+		Entry("HTTP/2 enabled", true),
+	)
 })

--- a/internal/config/testdata/config.yaml
+++ b/internal/config/testdata/config.yaml
@@ -1,6 +1,8 @@
 healthProbeBindAddress: :8081
 metricsBindAddress: 127.0.0.1:8080
-webhookPort: 9443
+webhook:
+  disableHTTP2: true
+  port: 9443
 leaderElection:
   enabled: true
   resourceID: some-resource-id

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -1,0 +1,7 @@
+package http
+
+import "crypto/tls"
+
+func DisableHTTP2(c *tls.Config) {
+	c.NextProtos = []string{"http/1.1"}
+}

--- a/internal/http/http_test.go
+++ b/internal/http/http_test.go
@@ -1,0 +1,18 @@
+package http
+
+import (
+	"crypto/tls"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("DisableHTTP2", func() {
+	It("should only contain HTTP/1.1", func() {
+		cfg := &tls.Config{}
+
+		DisableHTTP2(cfg)
+
+		Expect(cfg.NextProtos).To(Equal([]string{"http/1.1"}))
+	})
+})


### PR DESCRIPTION
Disable HTTP/2 by default for the webooks server, which is the only KMM server affected by CVE-2023-44487.

/cc @bthurber @yevgeny-shnaidman 