### PR TITLE
Use KMM's service account in its namespace

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -187,6 +187,7 @@ func main() {
 		nmcHelper,
 		filterAPI,
 		authFactory,
+		operatorNamespace,
 		scheme,
 	)
 	if err = mnc.SetupWithManager(mgr); err != nil {


### PR DESCRIPTION
When a Module created in the operator's namespace does not specify a service account name in its moduleLoader's section, use KMM's powerful service account from the bundle.

/cc @enriquebelarte @yevgeny-shnaidman 