### PR TITLE
[release-1.1] MGMT-16007: Disable HTTP/2 for webhooks

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -17,11 +17,13 @@ limitations under the License.
 package main
 
 import (
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"os"
 	"strconv"
 
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/http"
 	ocpbuildutils "github.com/rh-ecosystem-edge/kernel-module-management/internal/utils/ocpbuild"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -78,9 +80,13 @@ func main() {
 
 	setupLogger := logger.WithName("setup")
 
-	var configFile string
+	var (
+		configFile         string
+		enableWehbookHTTP2 bool
+	)
 
 	flag.StringVar(&configFile, "config", "", "The path to the configuration file.")
+	flag.BoolVar(&enableWehbookHTTP2, "enable-webhook-http2", false, "Enable HTTP/2 in the webhook server")
 
 	klog.InitFlags(flag.CommandLine)
 
@@ -103,6 +109,11 @@ func main() {
 	setupLogger.Info("Creating manager", "git commit", commit)
 
 	options := ctrl.Options{Scheme: scheme}
+
+	if !enableWehbookHTTP2 {
+		setupLogger.Info("Disabling HTTP/2 in the webhook server")
+		options.TLSOpts = []func(config *tls.Config){http.DisableHTTP2}
+	}
 
 	options, err = options.AndFrom(ctrl.ConfigFile().AtPath(configFile))
 	if err != nil {

--- a/internal/http/http.go
+++ b/internal/http/http.go
@@ -1,0 +1,7 @@
+package http
+
+import "crypto/tls"
+
+func DisableHTTP2(c *tls.Config) {
+	c.NextProtos = []string{"http/1.1"}
+}

--- a/internal/http/http_test.go
+++ b/internal/http/http_test.go
@@ -1,0 +1,18 @@
+package http
+
+import (
+	"crypto/tls"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("DisableHTTP2", func() {
+	It("should only contain HTTP/1.1", func() {
+		cfg := &tls.Config{}
+
+		DisableHTTP2(cfg)
+
+		Expect(cfg.NextProtos).To(Equal([]string{"http/1.1"}))
+	})
+})


### PR DESCRIPTION
Disable HTTP/2 by default for the webooks server, which is the only KMM server affected by CVE-2023-44487.

/cc @yevgeny-shnaidman 