### PR TITLE
Add message to different kmm-ci modules

### DIFF
--- a/ci/kmm-kmod/kmm_ci_a.c
+++ b/ci/kmm-kmod/kmm_ci_a.c
@@ -8,12 +8,12 @@ MODULE_DESCRIPTION("A simple kernel module for KMM CI");
 MODULE_VERSION("0.01");
 
 static int __init kmm_ci_init(void) {
-    printk(KERN_INFO "Hello, World!\n");
+    printk(KERN_INFO "Hello, World!. Loaded kmm-ci-a.\n");
     return 0;
 }
 
 static void __exit kmm_ci_exit(void) {
-    printk(KERN_INFO "Goodbye, World!\n");
+    printk(KERN_INFO "Goodbye, World!. Unloaded kmm-ci-a\n");
 }
 
 module_init(kmm_ci_init);

--- a/ci/kmm-kmod/kmm_ci_b.c
+++ b/ci/kmm-kmod/kmm_ci_b.c
@@ -1,1 +1,20 @@
-kmm_ci_a.c
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/kernel.h>
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Quentin Barrand");
+MODULE_DESCRIPTION("A simple kernel module for KMM CI");
+MODULE_VERSION("0.01");
+
+static int __init kmm_ci_init(void) {
+    printk(KERN_INFO "Hello, World!. Loaded kmm-ci-b.\n");
+    return 0;
+}
+
+static void __exit kmm_ci_exit(void) {
+    printk(KERN_INFO "Goodbye, World!. Unloaded kmm-ci-b\n");
+}
+
+module_init(kmm_ci_init);
+module_exit(kmm_ci_exit);


### PR DESCRIPTION
Make `kmm-ci-a` and `kmm-ci-b` print different messages in dmesg for easier debugging.