### PR TITLE
OCPBUGS-18405: Bump memory limit to 384Mi

### DIFF
--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -231,7 +231,7 @@ spec:
                 resources:
                   limits:
                     cpu: 500m
-                    memory: 128Mi
+                    memory: 384Mi
                   requests:
                     cpu: 10m
                     memory: 64Mi

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -368,7 +368,7 @@ spec:
                 resources:
                   limits:
                     cpu: 500m
-                    memory: 128Mi
+                    memory: 384Mi
                   requests:
                     cpu: 10m
                     memory: 64Mi

--- a/config/manager-base/manager.yaml
+++ b/config/manager-base/manager.yaml
@@ -70,7 +70,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 128Mi
+            memory: 384Mi
           requests:
             cpu: 10m
             memory: 64Mi


### PR DESCRIPTION
/cc @yevgeny-shnaidman 