### PR TITLE
CVE-2023-44487 http/2 workaround

### DIFF
--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -255,8 +255,9 @@ spec:
                 - --secure-listen-address=0.0.0.0:8443
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
+                - --http2-disable
                 - --v=0
-                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.13
+                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.14
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -392,8 +392,9 @@ spec:
                 - --secure-listen-address=0.0.0.0:8443
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
+                - --http2-disable
                 - --v=0
-                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.13
+                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.14
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443


### PR DESCRIPTION
CVE-2023-44487  is an issue with handling multiplexed streams in the HTTP/2 protocol. This PR works around it in the kube-proxy by just disabling http2 entirely to match with the downstream/release csv