### PR TITLE
CVE-2023-44487 workaround

### DIFF
--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -254,8 +254,9 @@ spec:
                 - --secure-listen-address=0.0.0.0:8443
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
+                - --http2-disable
                 - --v=0
-                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.13
+                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.14
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -391,8 +391,9 @@ spec:
                 - --secure-listen-address=0.0.0.0:8443
                 - --upstream=http://127.0.0.1:8080/
                 - --logtostderr=true
+                - --http2-disable
                 - --v=0
-                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.13
+                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy:v4.14
                 name: kube-rbac-proxy
                 ports:
                 - containerPort: 8443

--- a/config/manager-base/kustomization.yaml
+++ b/config/manager-base/kustomization.yaml
@@ -14,7 +14,7 @@ patches:
 images:
 - name: gcr.io/kubebuilder/kube-rbac-proxy
   newName: registry.redhat.io/openshift4/ose-kube-rbac-proxy
-  newTag: v4.13
+  newTag: v4.14
 - name: must-gather
   newName: quay.io/edge-infrastructure/kernel-module-management-must-gather
   newTag: latest

--- a/config/manager-base/manager_auth_proxy_patch.yaml
+++ b/config/manager-base/manager_auth_proxy_patch.yaml
@@ -15,6 +15,7 @@ spec:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"
         - "--logtostderr=true"
+        - "--http2-disable"
         - "--v=0"
         ports:
         - containerPort: 8443


### PR DESCRIPTION
CVE-2023-44487 is an issue with handling multiplexed streams in the HTTP/2 protocol. 
This PR works around it in the kube-proxy by just disabling http2 entirely to match with the downstream/release csv.

(It is only relevant for the release-2.0 branch because it is superseded by #888 in main)