### PR TITLE
MGMT-16272: Allow the controller to delete NodeModulesConfigs

### DIFF
--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -32,7 +32,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-11-16T10:48:49Z"
+    createdAt: "2023-11-22T16:41:19Z"
     operatorframework.io/suggested-namespace: openshift-kmm-hub
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -48,7 +48,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-11-16T10:48:48Z"
+    createdAt: "2023-11-22T16:41:17Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -221,6 +221,7 @@ spec:
           - nodemodulesconfigs
           verbs:
           - create
+          - delete
           - get
           - list
           - patch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -130,6 +130,7 @@ rules:
   - nodemodulesconfigs
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/internal/controllers/module_nmc_reconciler.go
+++ b/internal/controllers/module_nmc_reconciler.go
@@ -33,7 +33,7 @@ import (
 )
 
 //+kubebuilder:rbac:groups="core",resources=nodes,verbs=get;watch
-//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=nodemodulesconfigs,verbs=get;list;watch;patch;create
+//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=nodemodulesconfigs,verbs=get;list;watch;patch;create;delete
 //+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modules/finalizers,verbs=update
 
 const (


### PR DESCRIPTION
Make the `OwnerReferencesPermissionEnforcement` admission plugin happy.

/cc @yevgeny-shnaidman 