### PR TITLE
[release-2.0] Allow the controller to delete `NodeModulesConfigs`

### DIFF
--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -220,6 +220,7 @@ spec:
           - nodemodulesconfigs
           verbs:
           - create
+          - delete
           - get
           - list
           - patch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -130,6 +130,7 @@ rules:
   - nodemodulesconfigs
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/internal/controllers/module_nmc_reconciler.go
+++ b/internal/controllers/module_nmc_reconciler.go
@@ -34,7 +34,7 @@ import (
 )
 
 //+kubebuilder:rbac:groups="core",resources=nodes,verbs=get;watch
-//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=nodemodulesconfigs,verbs=get;list;watch;patch;create
+//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=nodemodulesconfigs,verbs=get;list;watch;patch;create;delete
 //+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modules/finalizers,verbs=update
 
 const (


### PR DESCRIPTION
Make the OwnerReferencesPermissionEnforcement admission plugin happy.

---

This is a cherry-pick of a855c08a.

/cc @yevgeny-shnaidman 