### PR TITLE
Add default GitStream permissions

### DIFF
--- a/.github/workflows/gitstream.yml
+++ b/.github/workflows/gitstream.yml
@@ -18,6 +18,9 @@ jobs:
 
     permissions:
       actions: write
+      contents: write
+      issues: write
+      pull-requests: write
 
     steps:
       # gcompat: glibc compatibility layer on alpine for Go


### PR DESCRIPTION
When one custom scope is defined, all default permissions are removed. This PR sets all the permissions GitStream needs to work correctly.

/cc @ybettan  