### PR TITLE
Fixing DevicePlugin upgrade from v1.x to v2.x (#679)

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -8,6 +8,7 @@ const (
 	TargetKernelTarget           = "kmm.node.kubernetes.io/target-kernel"
 	KernelLabel                  = "kmm.node.kubernetes.io/kernel-version.full"
 	BuildTypeLabel               = "kmm.openshift.io/build.type"
+	DaemonSetRole                = "kmm.node.kubernetes.io/role"
 
 	WorkerPodVersionLabelPrefix    = "beta.kmm.node.kubernetes.io/version-worker-pod"
 	DevicePluginVersionLabelPrefix = "beta.kmm.node.kubernetes.io/version-device-plugin"
@@ -21,6 +22,8 @@ const (
 	DockerfileCMKey                = "dockerfile"
 	PublicSignDataKey              = "cert"
 	PrivateSignDataKey             = "key"
+
+	ModuleLoaderRoleLabelValue = "module-loader"
 
 	OperatorNamespaceEnvVar = "OPERATOR_NAMESPACE"
 )

--- a/internal/controllers/device_plugin_reconciler.go
+++ b/internal/controllers/device_plugin_reconciler.go
@@ -172,7 +172,16 @@ func (dprh *devicePluginReconcilerHelper) getModuleDevicePluginDaemonSets(ctx co
 	if err := dprh.client.List(ctx, &dsList, opts...); err != nil {
 		return nil, fmt.Errorf("could not list DaemonSets: %v", err)
 	}
-	return dsList.Items, nil
+
+	devicePluginsList := make([]appsv1.DaemonSet, 0, len(dsList.Items))
+	// remove the older version module loader daemonsets
+	for _, ds := range dsList.Items {
+		if ds.GetLabels()[constants.DaemonSetRole] != constants.ModuleLoaderRoleLabelValue {
+			devicePluginsList = append(devicePluginsList, ds)
+		}
+	}
+
+	return devicePluginsList, nil
 }
 
 func (dprh *devicePluginReconcilerHelper) handleDevicePlugin(ctx context.Context, mod *kmmv1beta1.Module, existingDevicePluginDS []appsv1.DaemonSet) error {

--- a/internal/controllers/device_plugin_reconciler_test.go
+++ b/internal/controllers/device_plugin_reconciler_test.go
@@ -865,3 +865,67 @@ var _ = Describe("DevicePluginReconciler_getExistingDS", func() {
 		Expect(res).To(Equal(&ds))
 	})
 })
+
+var _ = Describe("DevicePluginReconciler_getModuleDevicePluginDaemonSets", func() {
+	var (
+		ctrl *gomock.Controller
+		clnt *client.MockClient
+		dprh devicePluginReconcilerHelper
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		dprh = devicePluginReconcilerHelper{
+			client: clnt,
+		}
+	})
+
+	ctx := context.Background()
+
+	It("list failed", func() {
+		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
+
+		dsList, err := dprh.getModuleDevicePluginDaemonSets(ctx, "name", "namespace")
+
+		Expect(err).ToNot(BeNil())
+		Expect(dsList).To(BeNil())
+	})
+
+	It("good flow, return only device plugin DSs, either v2 or v1", func() {
+		ds1 := appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					constants.ModuleNameLabel: "some name",
+				},
+			},
+		}
+		ds2 := appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					constants.ModuleNameLabel: "some name",
+					constants.DaemonSetRole:   constants.ModuleLoaderRoleLabelValue,
+				},
+			},
+		}
+		ds3 := appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					constants.ModuleNameLabel: "some name",
+					constants.DaemonSetRole:   "some role",
+				},
+			},
+		}
+		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ interface{}, list *appsv1.DaemonSetList, _ ...interface{}) error {
+				list.Items = []appsv1.DaemonSet{ds1, ds2, ds3}
+				return nil
+			},
+		)
+
+		dsList, err := dprh.getModuleDevicePluginDaemonSets(ctx, "name", "namespace")
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dsList).To(Equal([]appsv1.DaemonSet{ds1, ds3}))
+	})
+})


### PR DESCRIPTION
In v1.x we had 2 type of Daemonsets: DevicePlugin and ModuleLoader, which could be distingished by the DaemonsetRole label In v2.x, there only 1 type of daemonset, DevicePlugin, so the DaemonsetRole labels was removed.
During DevicePlugin reconciliation, reconcile get all the device plugin Ds based only on module name label, which means that in case there is a v1.1 ModuleLoader DS running it will also be chosen. Once reconciler tries to reconcile ModuleLoader DS, it will fail
This PR, updates the function that chooses the DevicePlugin DS, by removing old ModuleLoader Ds based on Role label