### PR TITLE
Update docs to v2.0.1

### DIFF
--- a/config/manager/controller_config.yaml
+++ b/config/manager/controller_config.yaml
@@ -1,5 +1,4 @@
 healthProbeBindAddress: :8081
-metricsBindAddress: 127.0.0.1:8080
 leaderElection:
   enabled: true
   resourceID: kmm.sigs.x-k8s.io

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
   - index.md
   - Documentation:
       - documentation/install.md
+      - documentation/configure.md
       - documentation/deploy_kmod.md
       - documentation/kmod_image.md
       - Binary firmwares: documentation/firmwares.md
@@ -42,3 +43,8 @@ markdown_extensions:
 theme:
   name: readthedocs
   custom_dir: overrides/
+  highlightjs: true
+  hljs_languages:
+    - dockerfile
+    - shell
+    - yaml

--- a/docs/mkdocs/documentation/configure.md
+++ b/docs/mkdocs/documentation/configure.md
@@ -1,0 +1,92 @@
+# Configuring
+
+KMM should be configured out of the box with sensible defaults.
+The operator configuration is set in the `kmm-operator-manager-config` `ConfigMap` in the operator namespace.
+To modify any setting, edit the `ConfigMap` data and restart the controller with the following command:
+
+```shell
+kubectl rollout restart -n "$namespace" deployment/kmm-operator-controller
+```
+
+The value of `$namespace` depends on your [installation method](install.md).
+
+## Reference
+
+#### `healthProbeBindAddress`
+
+Defines the address on which the operator should listen for kubelet health probes.  
+Recommended value: `:8081`.
+
+#### `leaderElection.enabled`
+
+Determines whether [leader election](https://kubernetes.io/docs/concepts/architecture/leases/) is used to ensure that
+only one replica of the KMM operator is running at any time.  
+Recommended value: `true`.
+
+#### `leaderElection.resourceID`
+
+Determines the name of the resource that leader election will use for holding the leader lock.  
+Recommended value: `kmm.sigs.x-k8s.io`.
+
+#### `metrics.bindAddress`
+
+Determines the bind address for the metrics server.
+It will be defaulted to `:8080` if unspecified.
+Set this to "0" to disable the metrics server.  
+Recommended value: `0.0.0.0:8443`.
+
+#### `metrics.disableHTTP2`
+
+If `true`, disables HTTP/2 for the metrics server, as a mitigation for
+[CVE-2023-44487](https://access.redhat.com/security/cve/cve-2023-44487).  
+Recommended value: `true`.
+
+#### `metrics.enableAuthnAuthz`
+
+Determines if metrics should be authenticated (via `TokenReviews`) and authorized (via `SubjectAccessReviews`) with the
+kube-apiserver.  
+For the authentication and authorization the controller needs a ClusterRole with the following rules:
+
+  - `apiGroups: authentication.k8s.io, resources: tokenreviews, verbs: create`
+  - `apiGroups: authorization.k8s.io, resources: subjectaccessreviews, verbs: create`
+
+To scrape metrics e.g. via Prometheus the client needs a `ClusterRole` with the following rule:
+
+  - `nonResourceURLs: "/metrics", verbs: get`
+
+Recommended value: `true`.
+
+#### `metrics.secureServing`
+
+Determines whether the metrics should be served over HTTPS instead of HTTP.  
+Recommended value: `true`.
+
+#### `webhook.disableHTTP2`
+
+If `true`, disables HTTP/2 for the webhook server, as a mitigation for
+[CVE-2023-44487](https://access.redhat.com/security/cve/cve-2023-44487).  
+Recommended value: `true`.
+
+#### `webhook.port`
+
+Defines the port on which the operator should be listening for webhook requests.  
+Recommended value: `9443`.
+
+#### `worker.runAsUser`
+
+Determines the value of the `runAsUser` field of the worker container's
+[SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).  
+Recommended value: `9443`.
+
+#### `worker.seLinuxType`
+
+Determines the value of the `seLinuxOptions.type` field of the worker container's
+[SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).  
+Recommended value: `spc_t`.
+
+#### `worker.setFirmwareClassPath`
+
+If set, the value of this field will be written by the worker into the `/sys/module/firmware_class/parameters/path` file
+on the node.
+This sets the [kernel's firmware search path](firmwares.md#setting-the-kernels-firmware-search-path).  
+Recommended value: `/var/lib/firmware` if you need to set that value through the worker app; otherwise, unset.

--- a/docs/mkdocs/documentation/deploy_kmod.md
+++ b/docs/mkdocs/documentation/deploy_kmod.md
@@ -228,6 +228,22 @@ The following variables will be substituted:
 | `MOD_NAME`            | The `Module`'s name                    | `my-mod`                      |
 | `MOD_NAMESPACE`       | The `Module`'s namespace               | `my-namespace`                |
 
+### Unloading the kernel module
+
+To unload a module loaded with KMM from nodes, simply delete the corresponding `Module` resource.
+KMM will then create worker Pods where required to run `modprobe -r` and unload the kernel module from nodes.
+
+!!! warning
+    To create unloading worker Pods, KMM needs all the resources it used when loading the kernel module.
+    This includes the `ServiceAccount` that are referenced in the `Module` as well as any RBAC you may have defined to
+    allow privileged KMM worker Pods to run.
+    It also includes any pull secret referenced in `.spec.imageRepoSecret`.  
+    To avoid situations where KMM is unable to unload the kernel module from nodes:  
+
+      - do not delete those resources while the `Module` resource is still present in the cluster in any state,
+        including `Terminating`;
+      - do not delete any namespace containing at least a `Module` resource.
+
 ## Security and permissions
 
 Loading kernel modules is a highly sensitive operation.

--- a/docs/mkdocs/documentation/firmwares.md
+++ b/docs/mkdocs/documentation/firmwares.md
@@ -49,3 +49,11 @@ spec:
   selector:
     node-role.kubernetes.io/worker: ""
 ```
+
+## Setting the kernel's firmware search path
+
+The Linux kernel accepts the `firmware_class.path` parameter as a
+[search path for firmwares](https://www.kernel.org/doc/html/latest/driver-api/firmware/fw_search_path.html).
+Since version 2.0.0, KMM workers can set that value on nodes by writing to sysfs, before attempting to load kmods.  
+To enable that feature, set `worker.setFirmwareClassPath` to `/var/lib/firmware` in the
+[operator configuration](configure.md#workersetfirmwareclasspath).  

--- a/docs/mkdocs/documentation/hub_spoke.md
+++ b/docs/mkdocs/documentation/hub_spoke.md
@@ -60,6 +60,8 @@ The command below installs the bleeding edge version of KMM-Hub.
 oc apply -k https://github.com/rh-ecosystem-edge/kernel-module-management/config/default-hub
 ```
 
+This installs the operator in the `kmm-operator-system` namespace.
+
 ### The `ManagedClusterModule` CRD
 
 The `ManagedClusterModule` CRD is used to configure the deployment of kernel modules on Spoke clusters.


### PR DESCRIPTION
Add a reference page for the operator configuration. Mention that OperatorHub.io installation methods install in the `operators` namespace.

/cc @yevgeny-shnaidman 