### PR TITLE
Docs: remove an incorrect line from upstream

### DIFF
--- a/docs/mkdocs/documentation/hub_spoke.md
+++ b/docs/mkdocs/documentation/hub_spoke.md
@@ -60,8 +60,6 @@ The command below installs the bleeding edge version of KMM-Hub.
 oc apply -k https://github.com/rh-ecosystem-edge/kernel-module-management/config/default-hub
 ```
 
-This installs the operator in the `kmm-operator-system` namespace.
-
 ### The `ManagedClusterModule` CRD
 
 The `ManagedClusterModule` CRD is used to configure the deployment of kernel modules on Spoke clusters.


### PR DESCRIPTION
That line slipped in during the cherry-pick.

/cc @yevgeny-shnaidman 