### PR TITLE
re-fixing DevicePlugin upgrade from v1.1 to v2

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -8,7 +8,6 @@ const (
 	TargetKernelTarget           = "kmm.node.kubernetes.io/target-kernel"
 	KernelLabel                  = "kmm.node.kubernetes.io/kernel-version.full"
 	BuildTypeLabel               = "kmm.openshift.io/build.type"
-	DaemonSetRole                = "kmm.node.kubernetes.io/role"
 
 	WorkerPodVersionLabelPrefix    = "beta.kmm.node.kubernetes.io/version-worker-pod"
 	DevicePluginVersionLabelPrefix = "beta.kmm.node.kubernetes.io/version-device-plugin"
@@ -22,8 +21,6 @@ const (
 	DockerfileCMKey                = "dockerfile"
 	PublicSignDataKey              = "cert"
 	PrivateSignDataKey             = "key"
-
-	ModuleLoaderRoleLabelValue = "module-loader"
 
 	OperatorNamespaceEnvVar = "OPERATOR_NAMESPACE"
 )

--- a/internal/controllers/device_plugin_reconciler.go
+++ b/internal/controllers/device_plugin_reconciler.go
@@ -176,7 +176,7 @@ func (dprh *devicePluginReconcilerHelper) getModuleDevicePluginDaemonSets(ctx co
 	devicePluginsList := make([]appsv1.DaemonSet, 0, len(dsList.Items))
 	// remove the older version module loader daemonsets
 	for _, ds := range dsList.Items {
-		if ds.GetLabels()[constants.DaemonSetRole] != constants.ModuleLoaderRoleLabelValue {
+		if _, ok := ds.GetLabels()[constants.KernelLabel]; !ok {
 			devicePluginsList = append(devicePluginsList, ds)
 		}
 	}

--- a/internal/controllers/device_plugin_reconciler_test.go
+++ b/internal/controllers/device_plugin_reconciler_test.go
@@ -904,7 +904,7 @@ var _ = Describe("DevicePluginReconciler_getModuleDevicePluginDaemonSets", func(
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					constants.ModuleNameLabel: "some name",
-					constants.DaemonSetRole:   constants.ModuleLoaderRoleLabelValue,
+					constants.KernelLabel:     "some kernel",
 				},
 			},
 		}
@@ -912,7 +912,6 @@ var _ = Describe("DevicePluginReconciler_getModuleDevicePluginDaemonSets", func(
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					constants.ModuleNameLabel: "some name",
-					constants.DaemonSetRole:   "some role",
 				},
 			},
 		}


### PR DESCRIPTION
Unlike upstream, in downstream version ModuleLoader daemonset differs from DevicePlugin by present of the kernel version label, and not by role label.
This PR changes the identification of DevicePlugins during gathering all device plugin DS by checkig the absence of the kernel version label