### PR TITLE
MGMT-16723: Add read-only OCP global pull secret to worker pods

### DIFF
--- a/internal/controllers/nmc_reconciler_test.go
+++ b/internal/controllers/nmc_reconciler_test.go
@@ -1662,6 +1662,7 @@ func getBaseWorkerPod(subcommand string, action WorkerAction, owner ctrlclient.O
 		volNameModulesOrder   = "modules-order"
 	)
 
+	hostPathFile := v1.HostPathFile
 	hostPathDirectory := v1.HostPathDirectory
 	hostPathDirectoryOrCreate := v1.HostPathDirectoryOrCreate
 
@@ -1745,6 +1746,11 @@ softdep b pre: c
 							Name:      trustedCAVolumeName,
 							ReadOnly:  true,
 							MountPath: "/etc/pki/tls/certs",
+						},
+						{
+							Name:      globalPullSecretName,
+							ReadOnly:  true,
+							MountPath: filepath.Join(worker.PullSecretsDir, globalPullSecretName),
 						},
 						{
 							Name:      volNameModulesOrder,
@@ -1832,6 +1838,15 @@ softdep b pre: c
 					},
 				},
 				{
+					Name: globalPullSecretName,
+					VolumeSource: v1.VolumeSource{
+						HostPath: &v1.HostPathVolumeSource{
+							Path: worker.GlobalPullSecretPath,
+							Type: &hostPathFile,
+						},
+					},
+				},
+				{
 					Name: volNameModulesOrder,
 					VolumeSource: v1.VolumeSource{
 						DownwardAPI: &v1.DownwardAPIVolumeSource{
@@ -1868,7 +1883,6 @@ softdep b pre: c
 			},
 		}
 		pod.Spec.Volumes = append(pod.Spec.Volumes, fwVol)
-
 	}
 
 	Expect(

--- a/internal/worker/constants.go
+++ b/internal/worker/constants.go
@@ -7,5 +7,6 @@ const (
 	FirmwareClassPathLocation = "/sys/module/firmware_class/parameters/path"
 	ImagesDir                 = "/var/run/kmm/images"
 	PullSecretsDir            = "/var/run/kmm/pull-secrets"
+	GlobalPullSecretPath      = "/var/lib/kubelet/config.json"
 	FirmwareMountPath         = "/var/lib/firmware"
 )


### PR DESCRIPTION
This PR adds the OpenShift global pull secret to the worker pods as a read-only [hostPath](https://kubernetes.io/docs/concepts/storage/volumes/#hostpath) volume mount. The OpenShift global pull secret can be found under the host's `/var/lib/kubelet/config.json` path and is configured by the MachineConfigOperator as the [default global auth file of cri-o](https://github.com/openshift/machine-config-operator/blob/master/templates/master/01-master-container-runtime/_base/files/crio.yaml#L59).

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/992