### PR TITLE
Move to the new ObjectReconciler interface

### DIFF
--- a/internal/controllers/build_sign_reconciler.go
+++ b/internal/controllers/build_sign_reconciler.go
@@ -31,13 +31,12 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	ocpbuildutils "github.com/rh-ecosystem-edge/kernel-module-management/internal/utils/ocpbuild"
 	v1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 const BuildSignReconcilerName = "BuildSignReconciler"
@@ -72,20 +71,10 @@ func NewBuildSignReconciler(
 // Reconcile lists all nodes and looks for kernels that match its mappings.
 // For each mapping that matches at least one node in the cluster, it creates a DaemonSet running the container image
 // on the nodes with a compatible kernel.
-func (r *BuildSignReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *BuildSignReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.Module) (ctrl.Result, error) {
 	res := ctrl.Result{}
 
 	logger := log.FromContext(ctx)
-
-	mod, err := r.reconHelperAPI.getRequestedModule(ctx, req.NamespacedName)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			logger.Info("Module deleted")
-			return ctrl.Result{}, nil
-		}
-
-		return res, fmt.Errorf("failed to get the requested %s KMMO CR: %w", req.NamespacedName, err)
-	}
 
 	targetedNodes, err := r.reconHelperAPI.getNodesListBySelector(ctx, mod)
 	if err != nil {
@@ -134,7 +123,6 @@ func (r *BuildSignReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 //go:generate mockgen -source=build_sign_reconciler.go -package=controllers -destination=mock_build_sign_reconciler.go buildSignReconcilerHelperAPI
 
 type buildSignReconcilerHelperAPI interface {
-	getRequestedModule(ctx context.Context, namespacedName types.NamespacedName) (*kmmv1beta1.Module, error)
 	getNodesListBySelector(ctx context.Context, mod *kmmv1beta1.Module) ([]v1.Node, error)
 	getRelevantKernelMappings(ctx context.Context, mod *kmmv1beta1.Module, targetedNodes []v1.Node) (map[string]*api.ModuleLoaderData, error)
 	handleBuild(ctx context.Context, mld *api.ModuleLoaderData) (bool, error)
@@ -306,15 +294,6 @@ func (bsrh *buildSignReconcilerHelper) garbageCollect(ctx context.Context,
 	return nil
 }
 
-func (bsrh *buildSignReconcilerHelper) getRequestedModule(ctx context.Context, namespacedName types.NamespacedName) (*kmmv1beta1.Module, error) {
-	mod := kmmv1beta1.Module{}
-
-	if err := bsrh.client.Get(ctx, namespacedName, &mod); err != nil {
-		return nil, fmt.Errorf("failed to get the kmmo module %s: %w", namespacedName, err)
-	}
-	return &mod, nil
-}
-
 // SetupWithManager sets up the controller with the Manager.
 func (r *BuildSignReconciler) SetupWithManager(mgr ctrl.Manager, kernelLabel string) error {
 	return ctrl.NewControllerManagedBy(mgr).
@@ -328,5 +307,7 @@ func (r *BuildSignReconciler) SetupWithManager(mgr ctrl.Manager, kernelLabel str
 			),
 		).
 		Named(BuildSignReconcilerName).
-		Complete(r)
+		Complete(
+			reconcile.AsReconciler[*kmmv1beta1.Module](mgr.GetClient(), r),
+		)
 }

--- a/internal/controllers/build_sign_reconciler_test.go
+++ b/internal/controllers/build_sign_reconciler_test.go
@@ -15,17 +15,17 @@ import (
 	ocpbuildutils "github.com/rh-ecosystem-edge/kernel-module-management/internal/utils/ocpbuild"
 	"go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var _ = Describe("BuildSignReconciler_Reconcile", func() {
+	const moduleName = "test-module"
+
 	var (
 		ctrl            *gomock.Controller
 		mockReconHelper *MockbuildSignReconcilerHelperAPI
+		mod             *kmmv1beta1.Module
 		bsr             *BuildSignReconciler
 	)
 
@@ -33,41 +33,24 @@ var _ = Describe("BuildSignReconciler_Reconcile", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockReconHelper = NewMockbuildSignReconcilerHelperAPI(ctrl)
 
+		mod = &kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: moduleName},
+		}
+
 		bsr = &BuildSignReconciler{
 			reconHelperAPI: mockReconHelper,
 		}
 	})
 
-	const moduleName = "test-module"
-
-	nsn := types.NamespacedName{
-		Name:      moduleName,
-		Namespace: namespace,
-	}
-
-	req := reconcile.Request{NamespacedName: nsn}
-
 	ctx := context.Background()
 
-	It("should return ok if module has been deleted", func() {
-		mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(nil, apierrors.NewNotFound(schema.GroupResource{}, "whatever"))
-
-		res, err := bsr.Reconcile(ctx, req)
-
-		Expect(res).To(Equal(reconcile.Result{}))
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	DescribeTable("check error flows", func(getModuleError, getNodesError, getMappingsError, handleBuildError, handleSignError bool) {
-		mod := kmmv1beta1.Module{}
+	DescribeTable("check error flows", func(getNodesError, getMappingsError, handleBuildError, handleSignError bool) {
+		mod := kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: moduleName},
+		}
 		selectNodesList := []v1.Node{v1.Node{}}
 		mappings := map[string]*api.ModuleLoaderData{"kernelVersion": &api.ModuleLoaderData{}}
 		returnedError := fmt.Errorf("some error")
-		if getModuleError {
-			mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(nil, returnedError)
-			goto executeTestFunction
-		}
-		mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(&mod, nil)
 		if getNodesError {
 			mockReconHelper.EXPECT().getNodesListBySelector(ctx, &mod).Return(nil, returnedError)
 			goto executeTestFunction
@@ -91,72 +74,63 @@ var _ = Describe("BuildSignReconciler_Reconcile", func() {
 		mockReconHelper.EXPECT().garbageCollect(ctx, &mod, mappings).Return(returnedError)
 
 	executeTestFunction:
-		res, err := bsr.Reconcile(ctx, req)
+		res, err := bsr.Reconcile(ctx, &mod)
 
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).To(HaveOccurred())
-
 	},
-		Entry("getRequestedModule failed", true, false, false, false, false),
-		Entry("getNodesListBySelector failed", false, true, false, false, false),
-		Entry("getRelevantKernelMappingsAndNodes failed", false, false, true, false, false),
-		Entry("handleBuild failed ", false, false, false, true, false),
-		Entry("handleSign failed", false, false, false, false, true),
-		Entry("garbageCollect failed", false, false, false, false, false),
+		Entry("getNodesListBySelector failed", true, false, false, false),
+		Entry("getRelevantKernelMappingsAndNodes failed", false, true, false, false),
+		Entry("handleBuild failed ", false, false, true, false),
+		Entry("handleSign failed", false, false, false, true),
+		Entry("garbageCollect failed", false, false, false, false),
 	)
 
 	It("Build has not completed successfully", func() {
-		mod := kmmv1beta1.Module{}
 		selectNodesList := []v1.Node{v1.Node{}}
 		mappings := map[string]*api.ModuleLoaderData{"kernelVersion": &api.ModuleLoaderData{}}
 		gomock.InOrder(
-			mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(&mod, nil),
-			mockReconHelper.EXPECT().getNodesListBySelector(ctx, &mod).Return(selectNodesList, nil),
-			mockReconHelper.EXPECT().getRelevantKernelMappings(ctx, &mod, selectNodesList).Return(mappings, nil),
+			mockReconHelper.EXPECT().getNodesListBySelector(ctx, mod).Return(selectNodesList, nil),
+			mockReconHelper.EXPECT().getRelevantKernelMappings(ctx, mod, selectNodesList).Return(mappings, nil),
 			mockReconHelper.EXPECT().handleBuild(ctx, mappings["kernelVersion"]).Return(false, nil),
-			mockReconHelper.EXPECT().garbageCollect(ctx, &mod, mappings).Return(nil),
+			mockReconHelper.EXPECT().garbageCollect(ctx, mod, mappings).Return(nil),
 		)
 
-		res, err := bsr.Reconcile(ctx, req)
+		res, err := bsr.Reconcile(ctx, mod)
 
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).NotTo(HaveOccurred())
-
 	})
 
 	It("Signing has not completed successfully", func() {
-		mod := kmmv1beta1.Module{}
 		selectNodesList := []v1.Node{v1.Node{}}
 		mappings := map[string]*api.ModuleLoaderData{"kernelVersion": &api.ModuleLoaderData{}}
 		gomock.InOrder(
-			mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(&mod, nil),
-			mockReconHelper.EXPECT().getNodesListBySelector(ctx, &mod).Return(selectNodesList, nil),
-			mockReconHelper.EXPECT().getRelevantKernelMappings(ctx, &mod, selectNodesList).Return(mappings, nil),
+			mockReconHelper.EXPECT().getNodesListBySelector(ctx, mod).Return(selectNodesList, nil),
+			mockReconHelper.EXPECT().getRelevantKernelMappings(ctx, mod, selectNodesList).Return(mappings, nil),
 			mockReconHelper.EXPECT().handleBuild(ctx, mappings["kernelVersion"]).Return(true, nil),
 			mockReconHelper.EXPECT().handleSigning(ctx, mappings["kernelVersion"]).Return(false, nil),
-			mockReconHelper.EXPECT().garbageCollect(ctx, &mod, mappings).Return(nil),
+			mockReconHelper.EXPECT().garbageCollect(ctx, mod, mappings).Return(nil),
 		)
 
-		res, err := bsr.Reconcile(ctx, req)
+		res, err := bsr.Reconcile(ctx, mod)
 
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("Good flow", func() {
-		mod := kmmv1beta1.Module{}
 		selectNodesList := []v1.Node{v1.Node{}}
 		mappings := map[string]*api.ModuleLoaderData{"kernelVersion": &api.ModuleLoaderData{}}
 		gomock.InOrder(
-			mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(&mod, nil),
-			mockReconHelper.EXPECT().getNodesListBySelector(ctx, &mod).Return(selectNodesList, nil),
-			mockReconHelper.EXPECT().getRelevantKernelMappings(ctx, &mod, selectNodesList).Return(mappings, nil),
+			mockReconHelper.EXPECT().getNodesListBySelector(ctx, mod).Return(selectNodesList, nil),
+			mockReconHelper.EXPECT().getRelevantKernelMappings(ctx, mod, selectNodesList).Return(mappings, nil),
 			mockReconHelper.EXPECT().handleBuild(ctx, mappings["kernelVersion"]).Return(true, nil),
 			mockReconHelper.EXPECT().handleSigning(ctx, mappings["kernelVersion"]).Return(true, nil),
-			mockReconHelper.EXPECT().garbageCollect(ctx, &mod, mappings).Return(nil),
+			mockReconHelper.EXPECT().garbageCollect(ctx, mod, mappings).Return(nil),
 		)
 
-		res, err := bsr.Reconcile(ctx, req)
+		res, err := bsr.Reconcile(ctx, mod)
 
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/controllers/device_plugin_pod_reconciler.go
+++ b/internal/controllers/device_plugin_pod_reconciler.go
@@ -8,11 +8,11 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/filter"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	v1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubectl/pkg/util/podutils"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -31,26 +31,14 @@ func NewDevicePluginPodReconciler(client client.Client) *DevicePluginPodReconcil
 	return &DevicePluginPodReconciler{client: client}
 }
 
-func (dppr *DevicePluginPodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (dppr *DevicePluginPodReconciler) Reconcile(ctx context.Context, pod *v1.Pod) (ctrl.Result, error) {
 	logger := ctrl.LoggerFrom(ctx)
-
-	pod := v1.Pod{}
-	podNamespacedName := req.NamespacedName
-
-	if err := dppr.client.Get(ctx, podNamespacedName, &pod); err != nil {
-		if k8serrors.IsNotFound(err) {
-			logger.Info("Pod not found")
-			return ctrl.Result{}, nil
-		}
-
-		return ctrl.Result{}, fmt.Errorf("could not get pod %s: %v", podNamespacedName, err)
-	}
 
 	nodeName := pod.Spec.NodeName
 
 	moduleName, ok := pod.Labels[constants.ModuleNameLabel]
 	if !ok {
-		return ctrl.Result{}, fmt.Errorf("pod %s has no %q label", podNamespacedName, constants.ModuleNameLabel)
+		return ctrl.Result{}, fmt.Errorf("pod %s/%s has no %q label", pod.Namespace, pod.Name, constants.ModuleNameLabel)
 	}
 
 	labelName := utils.GetDevicePluginNodeLabel(pod.Namespace, moduleName)
@@ -67,7 +55,7 @@ func (dppr *DevicePluginPodReconciler) Reconcile(ctx context.Context, req ctrl.R
 	// at the beginning. IsodReady condition should still be checked, in case pod state
 	// has changed not due to Daemonset termination, but due to internal state of Daemonset on
 	// cluster
-	if !podutils.IsPodReady(&pod) || !pod.DeletionTimestamp.IsZero() {
+	if !podutils.IsPodReady(pod) || !pod.DeletionTimestamp.IsZero() {
 		// If the pod was created very recently but immediately deleted, its .spec.nodeName may still be empty.
 		// In that case, no need to try and unlabel the node; because .spec.nodeName is empty, it was never labeled in
 		// the first place.
@@ -104,7 +92,7 @@ func (dppr *DevicePluginPodReconciler) Reconcile(ctx context.Context, req ctrl.R
 			// the specified Pod has already been deleted. By ignoring NotFound errors we ensure
 			// that no additional, unnecessary reconciliation request will be queued (since a
 			// reconciliation result with a non-nil error will be requeued).
-			if err := dppr.deleteFinalizer(ctx, &pod); client.IgnoreNotFound(err) != nil {
+			if err := dppr.deleteFinalizer(ctx, pod); client.IgnoreNotFound(err) != nil {
 				return ctrl.Result{}, fmt.Errorf("could not delete the pod finalizer: %v", err)
 			}
 		}
@@ -157,7 +145,9 @@ func (dppr *DevicePluginPodReconciler) SetupWithManager(mgr ctrl.Manager) error 
 		Named(DevicePluginPodReconcilerName).
 		For(&v1.Pod{}).
 		WithEventFilter(p).
-		Complete(dppr)
+		Complete(
+			reconcile.AsReconciler[*v1.Pod](dppr.client, dppr),
+		)
 }
 
 func (dppr *DevicePluginPodReconciler) addLabel(ctx context.Context, nodeName string, labelName string) error {

--- a/internal/controllers/device_plugin_reconciler.go
+++ b/internal/controllers/device_plugin_reconciler.go
@@ -29,28 +29,25 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 const (
 	DevicePluginReconcilerName     = "DevicePluginReconciler"
 	kubeletDevicePluginsVolumeName = "kubelet-device-plugins"
 	kubeletDevicePluginsPath       = "/var/lib/kubelet/device-plugins"
-	nodeVarLibFirmwarePath         = "/var/lib/firmware"
 )
 
 // ModuleReconciler reconciles a Module object
 type DevicePluginReconciler struct {
-	client.Client
-
+	client         client.Client
 	filter         *filter.Filter
 	reconHelperAPI devicePluginReconcilerHelperAPI
 }
@@ -64,6 +61,7 @@ func NewDevicePluginReconciler(
 ) *DevicePluginReconciler {
 	reconHelperAPI := newDevicePluginReconcilerHelper(client, metricsAPI, scheme, operatorNamespace)
 	return &DevicePluginReconciler{
+		client:         client,
 		reconHelperAPI: reconHelperAPI,
 		filter:         filter,
 	}
@@ -75,7 +73,9 @@ func (r *DevicePluginReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&kmmv1beta1.Module{}).
 		Owns(&appsv1.DaemonSet{}).
 		Named(DevicePluginReconcilerName).
-		Complete(r)
+		Complete(
+			reconcile.AsReconciler[*kmmv1beta1.Module](r.client, r),
+		)
 }
 
 //+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modules,verbs=get;list;watch;
@@ -85,20 +85,10 @@ func (r *DevicePluginReconciler) SetupWithManager(mgr ctrl.Manager) error {
 //+kubebuilder:rbac:groups="core",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups="core",resources=serviceaccounts,verbs=get;list;watch
 
-func (r *DevicePluginReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *DevicePluginReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.Module) (ctrl.Result, error) {
 	res := ctrl.Result{}
 
 	logger := log.FromContext(ctx)
-
-	mod, err := r.reconHelperAPI.getRequestedModule(ctx, req.NamespacedName)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			logger.Info("Module deleted")
-			return ctrl.Result{}, nil
-		}
-
-		return res, fmt.Errorf("failed to get the requested %s KMMO CR: %w", req.NamespacedName, err)
-	}
 
 	existingDevicePluginDS, err := r.reconHelperAPI.getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace)
 	if err != nil {
@@ -136,7 +126,6 @@ func (r *DevicePluginReconciler) Reconcile(ctx context.Context, req ctrl.Request
 //go:generate mockgen -source=device_plugin_reconciler.go -package=controllers -destination=mock_device_plugin_reconciler.go devicePluginReconcilerHelperAPI
 
 type devicePluginReconcilerHelperAPI interface {
-	getRequestedModule(ctx context.Context, namespacedName types.NamespacedName) (*kmmv1beta1.Module, error)
 	setKMMOMetrics(ctx context.Context)
 	handleDevicePlugin(ctx context.Context, mod *kmmv1beta1.Module, existingDevicePluginDS []appsv1.DaemonSet) error
 	garbageCollect(ctx context.Context, mod *kmmv1beta1.Module, existingDS []appsv1.DaemonSet) error
@@ -277,15 +266,6 @@ func (dprh *devicePluginReconcilerHelper) setKMMOMetrics(ctx context.Context) {
 	dprh.metricsAPI.SetKMMInClusterBuildNum(numModulesWithBuild)
 	dprh.metricsAPI.SetKMMInClusterSignNum(numModulesWithSign)
 	dprh.metricsAPI.SetKMMDevicePluginNum(numModulesWithDevicePlugin)
-}
-
-func (dprh *devicePluginReconcilerHelper) getRequestedModule(ctx context.Context, namespacedName types.NamespacedName) (*kmmv1beta1.Module, error) {
-	mod := kmmv1beta1.Module{}
-
-	if err := dprh.client.Get(ctx, namespacedName, &mod); err != nil {
-		return nil, fmt.Errorf("failed to get the kmmo module %s: %w", namespacedName, err)
-	}
-	return &mod, nil
 }
 
 func (dprh *devicePluginReconcilerHelper) moduleUpdateDevicePluginStatus(ctx context.Context,

--- a/internal/controllers/device_plugin_reconciler_test.go
+++ b/internal/controllers/device_plugin_reconciler_test.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -30,6 +29,7 @@ var _ = Describe("DevicePluginReconciler_Reconcile", func() {
 	var (
 		ctrl            *gomock.Controller
 		mockReconHelper *MockdevicePluginReconcilerHelperAPI
+		mod             *kmmv1beta1.Module
 		dpr             *DevicePluginReconciler
 	)
 
@@ -37,40 +37,20 @@ var _ = Describe("DevicePluginReconciler_Reconcile", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockReconHelper = NewMockdevicePluginReconcilerHelperAPI(ctrl)
 
+		mod = &kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: moduleName},
+		}
+
 		dpr = &DevicePluginReconciler{
 			reconHelperAPI: mockReconHelper,
 		}
 	})
 
-	const moduleName = "test-module"
-
-	nsn := types.NamespacedName{
-		Name:      moduleName,
-		Namespace: namespace,
-	}
-
-	req := reconcile.Request{NamespacedName: nsn}
-
 	ctx := context.Background()
 
-	It("should return ok if module has been deleted", func() {
-		mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(nil, apierrors.NewNotFound(schema.GroupResource{}, "whatever"))
-
-		res, err := dpr.Reconcile(ctx, req)
-
-		Expect(res).To(Equal(reconcile.Result{}))
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	DescribeTable("check error flows", func(getModuleError, getDSError, handlePluginError, gcError bool) {
-		mod := kmmv1beta1.Module{}
+	DescribeTable("check error flows", func(getDSError, handlePluginError, gcError bool) {
 		devicePluginDS := []appsv1.DaemonSet{appsv1.DaemonSet{}}
 		returnedError := fmt.Errorf("some error")
-		if getModuleError {
-			mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(nil, returnedError)
-			goto executeTestFunction
-		}
-		mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(&mod, nil)
 		if getDSError {
 			mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(nil, returnedError)
 			goto executeTestFunction
@@ -78,118 +58,71 @@ var _ = Describe("DevicePluginReconciler_Reconcile", func() {
 		mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(devicePluginDS, nil)
 		mockReconHelper.EXPECT().setKMMOMetrics(ctx)
 		if handlePluginError {
-			mockReconHelper.EXPECT().handleDevicePlugin(ctx, &mod, devicePluginDS).Return(returnedError)
+			mockReconHelper.EXPECT().handleDevicePlugin(ctx, mod, devicePluginDS).Return(returnedError)
 			goto executeTestFunction
 		}
-		mockReconHelper.EXPECT().handleDevicePlugin(ctx, &mod, devicePluginDS).Return(nil)
+		mockReconHelper.EXPECT().handleDevicePlugin(ctx, mod, devicePluginDS).Return(nil)
 		if gcError {
-			mockReconHelper.EXPECT().garbageCollect(ctx, &mod, devicePluginDS).Return(returnedError)
+			mockReconHelper.EXPECT().garbageCollect(ctx, mod, devicePluginDS).Return(returnedError)
 			goto executeTestFunction
 		}
-		mockReconHelper.EXPECT().garbageCollect(ctx, &mod, devicePluginDS).Return(nil)
-		mockReconHelper.EXPECT().moduleUpdateDevicePluginStatus(ctx, &mod, devicePluginDS).Return(returnedError)
+		mockReconHelper.EXPECT().garbageCollect(ctx, mod, devicePluginDS).Return(nil)
+		mockReconHelper.EXPECT().moduleUpdateDevicePluginStatus(ctx, mod, devicePluginDS).Return(returnedError)
 
 	executeTestFunction:
-		res, err := dpr.Reconcile(ctx, req)
+		res, err := dpr.Reconcile(ctx, mod)
 
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).To(HaveOccurred())
 
 	},
-		Entry("getRequestedModule failed", true, false, false, false),
-		Entry("getDevicePluginDaemonSets failed", false, true, false, false),
-		Entry("handleDevicePlugin failed", false, false, true, false),
-		Entry("garbageCollect failed", false, false, false, true),
-		Entry("devicePluginUpdateStatus failed", false, false, false, false),
+		Entry("getDevicePluginDaemonSets failed", true, false, false),
+		Entry("handleDevicePlugin failed", false, true, false),
+		Entry("garbageCollect failed", false, false, true),
+		Entry("devicePluginUpdateStatus failed", false, false, false),
 	)
 
 	It("Good flow", func() {
-		mod := kmmv1beta1.Module{}
 		devicePluginDS := []appsv1.DaemonSet{appsv1.DaemonSet{}}
 		gomock.InOrder(
-			mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(&mod, nil),
 			mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(devicePluginDS, nil),
 			mockReconHelper.EXPECT().setKMMOMetrics(ctx),
-			mockReconHelper.EXPECT().handleDevicePlugin(ctx, &mod, devicePluginDS).Return(nil),
-			mockReconHelper.EXPECT().garbageCollect(ctx, &mod, devicePluginDS).Return(nil),
-			mockReconHelper.EXPECT().moduleUpdateDevicePluginStatus(ctx, &mod, devicePluginDS).Return(nil),
+			mockReconHelper.EXPECT().handleDevicePlugin(ctx, mod, devicePluginDS).Return(nil),
+			mockReconHelper.EXPECT().garbageCollect(ctx, mod, devicePluginDS).Return(nil),
+			mockReconHelper.EXPECT().moduleUpdateDevicePluginStatus(ctx, mod, devicePluginDS).Return(nil),
 		)
 
-		res, err := dpr.Reconcile(ctx, req)
+		res, err := dpr.Reconcile(ctx, mod)
 
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("module deletion flow", func() {
-		mod := kmmv1beta1.Module{}
 		mod.SetDeletionTimestamp(&metav1.Time{})
 		devicePluginDS := []appsv1.DaemonSet{appsv1.DaemonSet{}}
 
 		By("good flow")
 		gomock.InOrder(
-			mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(&mod, nil),
 			mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(devicePluginDS, nil),
 			mockReconHelper.EXPECT().handleModuleDeletion(ctx, devicePluginDS).Return(nil),
 		)
 
-		res, err := dpr.Reconcile(ctx, req)
+		res, err := dpr.Reconcile(ctx, mod)
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).NotTo(HaveOccurred())
 
 		By("error flow")
 		gomock.InOrder(
-			mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(&mod, nil),
 			mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(devicePluginDS, nil),
 			mockReconHelper.EXPECT().handleModuleDeletion(ctx, devicePluginDS).Return(fmt.Errorf("some error")),
 		)
 
-		res, err = dpr.Reconcile(ctx, req)
+		res, err = dpr.Reconcile(ctx, mod)
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).To(HaveOccurred())
 	})
 
-})
-
-var _ = Describe("DevicePluginReconciler_getRequestedModule", func() {
-	var (
-		ctrl *gomock.Controller
-		clnt *client.MockClient
-		dprh devicePluginReconcilerHelperAPI
-	)
-
-	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		clnt = client.NewMockClient(ctrl)
-		dprh = newDevicePluginReconcilerHelper(clnt, nil, nil, "")
-	})
-
-	ctx := context.Background()
-	moduleName := "moduleName"
-	moduleNamespace := "moduleNamespace"
-	nsn := types.NamespacedName{Name: moduleName, Namespace: moduleNamespace}
-
-	It("good flow", func() {
-		clnt.EXPECT().Get(ctx, nsn, gomock.Any()).DoAndReturn(
-			func(_ interface{}, _ interface{}, module *kmmv1beta1.Module, _ ...ctrlclient.GetOption) error {
-				module.ObjectMeta = metav1.ObjectMeta{Name: moduleName, Namespace: moduleNamespace}
-				return nil
-			},
-		)
-
-		mod, err := dprh.getRequestedModule(ctx, nsn)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(mod.Name).To(Equal(moduleName))
-		Expect(mod.Namespace).To(Equal(moduleNamespace))
-	})
-
-	It("error flow", func() {
-
-		clnt.EXPECT().Get(ctx, nsn, gomock.Any()).Return(fmt.Errorf("some error"))
-		mod, err := dprh.getRequestedModule(ctx, nsn)
-		Expect(err).To(HaveOccurred())
-		Expect(mod).To(BeNil())
-	})
 })
 
 var _ = Describe("DevicePluginReconciler_handleDevicePlugin", func() {

--- a/internal/controllers/mock_build_sign_reconciler.go
+++ b/internal/controllers/mock_build_sign_reconciler.go
@@ -16,7 +16,6 @@ import (
 	api "github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	gomock "go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
-	types "k8s.io/apimachinery/pkg/types"
 )
 
 // MockbuildSignReconcilerHelperAPI is a mock of buildSignReconcilerHelperAPI interface.
@@ -84,21 +83,6 @@ func (m *MockbuildSignReconcilerHelperAPI) getRelevantKernelMappings(ctx context
 func (mr *MockbuildSignReconcilerHelperAPIMockRecorder) getRelevantKernelMappings(ctx, mod, targetedNodes any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getRelevantKernelMappings", reflect.TypeOf((*MockbuildSignReconcilerHelperAPI)(nil).getRelevantKernelMappings), ctx, mod, targetedNodes)
-}
-
-// getRequestedModule mocks base method.
-func (m *MockbuildSignReconcilerHelperAPI) getRequestedModule(ctx context.Context, namespacedName types.NamespacedName) (*v1beta1.Module, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "getRequestedModule", ctx, namespacedName)
-	ret0, _ := ret[0].(*v1beta1.Module)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// getRequestedModule indicates an expected call of getRequestedModule.
-func (mr *MockbuildSignReconcilerHelperAPIMockRecorder) getRequestedModule(ctx, namespacedName any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getRequestedModule", reflect.TypeOf((*MockbuildSignReconcilerHelperAPI)(nil).getRequestedModule), ctx, namespacedName)
 }
 
 // handleBuild mocks base method.

--- a/internal/controllers/mock_device_plugin_reconciler.go
+++ b/internal/controllers/mock_device_plugin_reconciler.go
@@ -15,7 +15,6 @@ import (
 	v1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	gomock "go.uber.org/mock/gomock"
 	v1 "k8s.io/api/apps/v1"
-	types "k8s.io/apimachinery/pkg/types"
 )
 
 // MockdevicePluginReconcilerHelperAPI is a mock of devicePluginReconcilerHelperAPI interface.
@@ -68,21 +67,6 @@ func (m *MockdevicePluginReconcilerHelperAPI) getModuleDevicePluginDaemonSets(ct
 func (mr *MockdevicePluginReconcilerHelperAPIMockRecorder) getModuleDevicePluginDaemonSets(ctx, name, namespace any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getModuleDevicePluginDaemonSets", reflect.TypeOf((*MockdevicePluginReconcilerHelperAPI)(nil).getModuleDevicePluginDaemonSets), ctx, name, namespace)
-}
-
-// getRequestedModule mocks base method.
-func (m *MockdevicePluginReconcilerHelperAPI) getRequestedModule(ctx context.Context, namespacedName types.NamespacedName) (*v1beta1.Module, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "getRequestedModule", ctx, namespacedName)
-	ret0, _ := ret[0].(*v1beta1.Module)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// getRequestedModule indicates an expected call of getRequestedModule.
-func (mr *MockdevicePluginReconcilerHelperAPIMockRecorder) getRequestedModule(ctx, namespacedName any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getRequestedModule", reflect.TypeOf((*MockdevicePluginReconcilerHelperAPI)(nil).getRequestedModule), ctx, namespacedName)
 }
 
 // handleDevicePlugin mocks base method.

--- a/internal/controllers/mock_module_nmc_reconciler.go
+++ b/internal/controllers/mock_module_nmc_reconciler.go
@@ -16,7 +16,6 @@ import (
 	api "github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	gomock "go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
-	types "k8s.io/apimachinery/pkg/types"
 	sets "k8s.io/apimachinery/pkg/util/sets"
 )
 
@@ -113,21 +112,6 @@ func (m *MockmoduleNMCReconcilerHelperAPI) getNodesListBySelector(ctx context.Co
 func (mr *MockmoduleNMCReconcilerHelperAPIMockRecorder) getNodesListBySelector(ctx, mod any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getNodesListBySelector", reflect.TypeOf((*MockmoduleNMCReconcilerHelperAPI)(nil).getNodesListBySelector), ctx, mod)
-}
-
-// getRequestedModule mocks base method.
-func (m *MockmoduleNMCReconcilerHelperAPI) getRequestedModule(ctx context.Context, namespacedName types.NamespacedName) (*v1beta1.Module, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "getRequestedModule", ctx, namespacedName)
-	ret0, _ := ret[0].(*v1beta1.Module)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// getRequestedModule indicates an expected call of getRequestedModule.
-func (mr *MockmoduleNMCReconcilerHelperAPIMockRecorder) getRequestedModule(ctx, namespacedName any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getRequestedModule", reflect.TypeOf((*MockmoduleNMCReconcilerHelperAPI)(nil).getRequestedModule), ctx, namespacedName)
 }
 
 // moduleUpdateWorkerPodsStatus mocks base method.

--- a/internal/controllers/module_nmc_reconciler.go
+++ b/internal/controllers/module_nmc_reconciler.go
@@ -19,7 +19,6 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/registry"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	v1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -30,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 //+kubebuilder:rbac:groups="core",resources=namespaces,verbs=get;list;patch;watch
@@ -80,39 +80,31 @@ func NewModuleNMCReconciler(client client.Client,
 	}
 }
 
-func (mnr *ModuleNMCReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (mnr *ModuleNMCReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.Module) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
-	logger.Info("Starting Module-NMS reconcilation", "module name and namespace", req.NamespacedName)
+	logger.Info("Starting Module-NMC reconciliation")
 
-	mod, err := mnr.reconHelper.getRequestedModule(ctx, req.NamespacedName)
-	if err != nil {
-		if k8serrors.IsNotFound(err) {
-			logger.Info("Module deleted, nothing to do")
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{}, fmt.Errorf("failed to get the requested %s Module: %v", req.NamespacedName, err)
-	}
 	if mod.GetDeletionTimestamp() != nil {
 		//Module is being deleted
-		if err = mnr.nsLabeler.tryRemovingLabel(ctx, mod.Namespace, mod.Name); err != nil {
+		if err := mnr.nsLabeler.tryRemovingLabel(ctx, mod.Namespace, mod.Name); err != nil {
 			return ctrl.Result{}, fmt.Errorf("error while trying to remove the label on namespace %s: %v", mod.Namespace, err)
 		}
 
-		err = mnr.reconHelper.finalizeModule(ctx, mod)
+		err := mnr.reconHelper.finalizeModule(ctx, mod)
 		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to finalize %s Module: %v", req.NamespacedName, err)
+			return ctrl.Result{}, fmt.Errorf("failed to finalize Module %s/%s: %v", mod.Namespace, mod.Name, err)
 		}
 		return ctrl.Result{}, nil
 	}
 
-	if err = mnr.nsLabeler.setLabel(ctx, mod.Namespace); err != nil {
+	if err := mnr.nsLabeler.setLabel(ctx, mod.Namespace); err != nil {
 		return ctrl.Result{}, fmt.Errorf("could not set label %q on namespace %s: %v", constants.NamespaceLabelKey, mod.Namespace, err)
 	}
 
-	err = mnr.reconHelper.setFinalizerAndStatus(ctx, mod)
+	err := mnr.reconHelper.setFinalizerAndStatus(ctx, mod)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to set finalizer on %s Module: %v", req.NamespacedName, err)
+		return ctrl.Result{}, fmt.Errorf("failed to set finalizer on Module %s/%s: %v", mod.Namespace, mod.Name, err)
 	}
 
 	// get nodes targeted by selector
@@ -123,7 +115,7 @@ func (mnr *ModuleNMCReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	currentNMCs, err := mnr.reconHelper.getNMCsByModuleSet(ctx, mod)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to get NMCs for %s Module: %v", req.NamespacedName, err)
+		return ctrl.Result{}, fmt.Errorf("failed to get NMCs for Module %s/%s: %v", mod.Namespace, mod.Name, err)
 	}
 
 	sdMap, prepareErrs := mnr.reconHelper.prepareSchedulingData(ctx, mod, targetedNodes, currentNMCs)
@@ -168,7 +160,9 @@ func (mnr *ModuleNMCReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(filter.ListModulesForNMC),
 		).
 		Named(ModuleNMCReconcilerName).
-		Complete(mnr)
+		Complete(
+			reconcile.AsReconciler[*kmmv1beta1.Module](mgr.GetClient(), mnr),
+		)
 }
 
 //go:generate mockgen -source=module_nmc_reconciler.go -package=controllers -destination=mock_module_nmc_reconciler.go moduleNMCReconcilerHelperAPI,namespaceLabeler
@@ -176,7 +170,6 @@ func (mnr *ModuleNMCReconciler) SetupWithManager(mgr ctrl.Manager) error {
 type moduleNMCReconcilerHelperAPI interface {
 	setFinalizerAndStatus(ctx context.Context, mod *kmmv1beta1.Module) error
 	finalizeModule(ctx context.Context, mod *kmmv1beta1.Module) error
-	getRequestedModule(ctx context.Context, namespacedName types.NamespacedName) (*kmmv1beta1.Module, error)
 	getNodesListBySelector(ctx context.Context, mod *kmmv1beta1.Module) ([]v1.Node, error)
 	getNMCsByModuleSet(ctx context.Context, mod *kmmv1beta1.Module) (sets.Set[string], error)
 	prepareSchedulingData(ctx context.Context, mod *kmmv1beta1.Module, targetedNodes []v1.Node, currentNMCs sets.Set[string]) (map[string]schedulingData, []error)
@@ -233,15 +226,6 @@ func (mnrh *moduleNMCReconcilerHelper) setFinalizerAndStatus(ctx context.Context
 	//mod.Status.ModuleLoader.AvailableNumber = 0
 
 	return mnrh.client.Status().Update(ctx, mod)
-}
-
-func (mnrh *moduleNMCReconcilerHelper) getRequestedModule(ctx context.Context, namespacedName types.NamespacedName) (*kmmv1beta1.Module, error) {
-	mod := kmmv1beta1.Module{}
-
-	if err := mnrh.client.Get(ctx, namespacedName, &mod); err != nil {
-		return nil, fmt.Errorf("failed to get Module %s: %w", namespacedName, err)
-	}
-	return &mod, nil
 }
 
 func (mnrh *moduleNMCReconcilerHelper) finalizeModule(ctx context.Context, mod *kmmv1beta1.Module) error {

--- a/internal/controllers/module_nmc_reconciler_test.go
+++ b/internal/controllers/module_nmc_reconciler_test.go
@@ -36,6 +36,7 @@ var _ = Describe("Reconcile", func() {
 		ctrl                *gomock.Controller
 		mockNamespaceHelper *MocknamespaceLabeler
 		mockReconHelper     *MockmoduleNMCReconcilerHelperAPI
+		mod                 *kmmv1beta1.Module
 		mnr                 *ModuleNMCReconciler
 	)
 
@@ -44,24 +45,19 @@ var _ = Describe("Reconcile", func() {
 		mockNamespaceHelper = NewMocknamespaceLabeler(ctrl)
 		mockReconHelper = NewMockmoduleNMCReconcilerHelperAPI(ctrl)
 
+		mod = &kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Name: moduleName, Namespace: namespace},
+		}
+
 		mnr = &ModuleNMCReconciler{
 			nsLabeler:   mockNamespaceHelper,
 			reconHelper: mockReconHelper,
 		}
 	})
 
-	const moduleName = "test-module"
 	const nodeName = "nodeName"
 
-	nsn := types.NamespacedName{
-		Name:      moduleName,
-		Namespace: namespace,
-	}
-
-	req := reconcile.Request{NamespacedName: nsn}
-
 	ctx := context.Background()
-	mod := kmmv1beta1.Module{}
 	node := v1.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: nodeName},
 	}
@@ -71,32 +67,21 @@ var _ = Describe("Reconcile", func() {
 	enableSchedulingData := schedulingData{action: actionAdd, mld: &mld, node: &node}
 	disableSchedulingData := schedulingData{action: actionDelete, mld: nil}
 
-	It("should return ok if module has been deleted", func() {
-		mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(nil, apierrors.NewNotFound(schema.GroupResource{}, "whatever"))
-
-		res, err := mnr.Reconcile(ctx, req)
-
-		Expect(res).To(Equal(reconcile.Result{}))
-		Expect(err).NotTo(HaveOccurred())
-	})
-
 	It("should run finalization and try removing namespace label when module is being deleted", func() {
-		mod := kmmv1beta1.Module{}
 		mod.SetDeletionTimestamp(&metav1.Time{})
+
 		gomock.InOrder(
-			mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(&mod, nil),
-			mockNamespaceHelper.EXPECT().tryRemovingLabel(ctx, mod.Namespace, mod.Namespace),
-			mockReconHelper.EXPECT().finalizeModule(ctx, &mod).Return(nil),
+			mockNamespaceHelper.EXPECT().tryRemovingLabel(ctx, namespace, moduleName),
+			mockReconHelper.EXPECT().finalizeModule(ctx, mod).Return(nil),
 		)
 
-		res, err := mnr.Reconcile(ctx, req)
+		res, err := mnr.Reconcile(ctx, mod)
 
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	type errorFlowTestCase struct {
-		getModuleError             bool
 		setFinalizerAndStatusError bool
 		getNodesError              bool
 		getNMCsMapError            bool
@@ -114,36 +99,31 @@ var _ = Describe("Reconcile", func() {
 			nmcMLDConfigs = map[string]schedulingData{"nodeName": enableSchedulingData}
 		}
 		returnedError := errors.New("some error")
-		if c.getModuleError {
-			mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(nil, returnedError)
-			goto executeTestFunction
-		}
-		mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(&mod, nil)
 		if c.setLabelError {
 			mockNamespaceHelper.EXPECT().setLabel(ctx, mod.Namespace).Return(returnedError)
 			goto executeTestFunction
 		}
 		mockNamespaceHelper.EXPECT().setLabel(ctx, mod.Namespace)
 		if c.setFinalizerAndStatusError {
-			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, &mod).Return(returnedError)
+			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, mod).Return(returnedError)
 			goto executeTestFunction
 		}
-		mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, &mod).Return(nil)
+		mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, mod).Return(nil)
 		if c.getNodesError {
-			mockReconHelper.EXPECT().getNodesListBySelector(ctx, &mod).Return(nil, returnedError)
+			mockReconHelper.EXPECT().getNodesListBySelector(ctx, mod).Return(nil, returnedError)
 			goto executeTestFunction
 		}
-		mockReconHelper.EXPECT().getNodesListBySelector(ctx, &mod).Return(targetedNodes, nil)
+		mockReconHelper.EXPECT().getNodesListBySelector(ctx, mod).Return(targetedNodes, nil)
 		if c.getNMCsMapError {
-			mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, &mod).Return(nil, returnedError)
+			mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, mod).Return(nil, returnedError)
 			goto executeTestFunction
 		}
-		mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, &mod).Return(currentNMCs, nil)
+		mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, mod).Return(currentNMCs, nil)
 		if c.prepareSchedulingError {
-			mockReconHelper.EXPECT().prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs).Return(nil, []error{returnedError})
+			mockReconHelper.EXPECT().prepareSchedulingData(ctx, mod, targetedNodes, currentNMCs).Return(nil, []error{returnedError})
 			goto moduleStatusUpdateFunction
 		}
-		mockReconHelper.EXPECT().prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs).Return(nmcMLDConfigs, []error{})
+		mockReconHelper.EXPECT().prepareSchedulingData(ctx, mod, targetedNodes, currentNMCs).Return(nmcMLDConfigs, []error{})
 		if c.disableEnableError {
 			if c.shouldBeOnNode {
 				mockReconHelper.EXPECT().enableModuleOnNode(ctx, &mld, &node).Return(returnedError)
@@ -160,19 +140,17 @@ var _ = Describe("Reconcile", func() {
 
 	moduleStatusUpdateFunction:
 		if c.moduleUpdateStatusErr {
-			mockReconHelper.EXPECT().moduleUpdateWorkerPodsStatus(ctx, &mod, targetedNodes).Return(returnedError)
+			mockReconHelper.EXPECT().moduleUpdateWorkerPodsStatus(ctx, mod, targetedNodes).Return(returnedError)
 		} else {
-			mockReconHelper.EXPECT().moduleUpdateWorkerPodsStatus(ctx, &mod, targetedNodes).Return(nil)
+			mockReconHelper.EXPECT().moduleUpdateWorkerPodsStatus(ctx, mod, targetedNodes).Return(nil)
 		}
 
 	executeTestFunction:
-		res, err := mnr.Reconcile(ctx, req)
+		res, err := mnr.Reconcile(ctx, mod)
 
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).To(HaveOccurred())
-
 	},
-		Entry("getRequestedModule failed", errorFlowTestCase{getModuleError: true}),
 		Entry("setFinalizerAndStatus failed", errorFlowTestCase{setFinalizerAndStatusError: true}),
 		Entry("getNodesListBySelector failed", errorFlowTestCase{getNodesError: true}),
 		Entry("getNMCsByModuleMap failed", errorFlowTestCase{getNMCsMapError: true}),
@@ -186,17 +164,16 @@ var _ = Describe("Reconcile", func() {
 	It("Good flow, should run on node", func() {
 		nmcMLDConfigs := map[string]schedulingData{nodeName: enableSchedulingData}
 		gomock.InOrder(
-			mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(&mod, nil),
 			mockNamespaceHelper.EXPECT().setLabel(ctx, mod.Namespace),
-			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, &mod).Return(nil),
-			mockReconHelper.EXPECT().getNodesListBySelector(ctx, &mod).Return(targetedNodes, nil),
-			mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, &mod).Return(currentNMCs, nil),
-			mockReconHelper.EXPECT().prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs).Return(nmcMLDConfigs, nil),
+			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, mod).Return(nil),
+			mockReconHelper.EXPECT().getNodesListBySelector(ctx, mod).Return(targetedNodes, nil),
+			mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, mod).Return(currentNMCs, nil),
+			mockReconHelper.EXPECT().prepareSchedulingData(ctx, mod, targetedNodes, currentNMCs).Return(nmcMLDConfigs, nil),
 			mockReconHelper.EXPECT().enableModuleOnNode(ctx, &mld, &node).Return(nil),
-			mockReconHelper.EXPECT().moduleUpdateWorkerPodsStatus(ctx, &mod, targetedNodes).Return(nil),
+			mockReconHelper.EXPECT().moduleUpdateWorkerPodsStatus(ctx, mod, targetedNodes).Return(nil),
 		)
 
-		res, err := mnr.Reconcile(ctx, req)
+		res, err := mnr.Reconcile(ctx, mod)
 
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).NotTo(HaveOccurred())
@@ -205,63 +182,20 @@ var _ = Describe("Reconcile", func() {
 	It("Good flow, should not run on node", func() {
 		nmcMLDConfigs := map[string]schedulingData{nodeName: disableSchedulingData}
 		gomock.InOrder(
-			mockReconHelper.EXPECT().getRequestedModule(ctx, nsn).Return(&mod, nil),
 			mockNamespaceHelper.EXPECT().setLabel(ctx, mod.Namespace),
-			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, &mod).Return(nil),
-			mockReconHelper.EXPECT().getNodesListBySelector(ctx, &mod).Return(targetedNodes, nil),
-			mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, &mod).Return(currentNMCs, nil),
-			mockReconHelper.EXPECT().prepareSchedulingData(ctx, &mod, targetedNodes, currentNMCs).Return(nmcMLDConfigs, nil),
+			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, mod).Return(nil),
+			mockReconHelper.EXPECT().getNodesListBySelector(ctx, mod).Return(targetedNodes, nil),
+			mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, mod).Return(currentNMCs, nil),
+			mockReconHelper.EXPECT().prepareSchedulingData(ctx, mod, targetedNodes, currentNMCs).Return(nmcMLDConfigs, nil),
 			mockReconHelper.EXPECT().disableModuleOnNode(ctx, mod.Namespace, mod.Name, node.Name).Return(nil),
-			mockReconHelper.EXPECT().moduleUpdateWorkerPodsStatus(ctx, &mod, targetedNodes).Return(nil),
+			mockReconHelper.EXPECT().moduleUpdateWorkerPodsStatus(ctx, mod, targetedNodes).Return(nil),
 		)
 
-		res, err := mnr.Reconcile(ctx, req)
+		res, err := mnr.Reconcile(ctx, mod)
 
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).NotTo(HaveOccurred())
 	})
-})
-
-var _ = Describe("getRequestedModule", func() {
-	var (
-		ctrl *gomock.Controller
-		clnt *client.MockClient
-		mnrh moduleNMCReconcilerHelperAPI
-	)
-
-	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		clnt = client.NewMockClient(ctrl)
-		mnrh = newModuleNMCReconcilerHelper(clnt, nil, nil, nil, nil, operatorNamespace, scheme)
-	})
-
-	ctx := context.Background()
-	moduleName := "moduleName"
-	moduleNamespace := "moduleNamespace"
-	nsn := types.NamespacedName{Name: moduleName, Namespace: moduleNamespace}
-
-	It("good flow", func() {
-		clnt.EXPECT().Get(ctx, nsn, gomock.Any()).DoAndReturn(
-			func(_ interface{}, _ interface{}, module *kmmv1beta1.Module, _ ...ctrlclient.GetOption) error {
-				module.ObjectMeta = metav1.ObjectMeta{Name: moduleName, Namespace: moduleNamespace}
-				return nil
-			},
-		)
-
-		mod, err := mnrh.getRequestedModule(ctx, nsn)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(mod.Name).To(Equal(moduleName))
-		Expect(mod.Namespace).To(Equal(moduleNamespace))
-	})
-
-	It("error flow", func() {
-
-		clnt.EXPECT().Get(ctx, nsn, gomock.Any()).Return(fmt.Errorf("some error"))
-		mod, err := mnrh.getRequestedModule(ctx, nsn)
-		Expect(err).To(HaveOccurred())
-		Expect(mod).To(BeNil())
-	})
-
 })
 
 var _ = Describe("setFinalizerAndStatus", func() {

--- a/internal/controllers/preflightvalidation_reconciler.go
+++ b/internal/controllers/preflightvalidation_reconciler.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	v1beta12 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -30,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	buildv1 "github.com/openshift/api/build/v1"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/filter"
@@ -81,7 +81,9 @@ func (r *PreflightValidationReconciler) SetupWithManager(mgr ctrl.Manager) error
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: 1,
 		}).
-		Complete(r)
+		Complete(
+			reconcile.AsReconciler[*v1beta12.PreflightValidation](r.client, r),
+		)
 }
 
 //+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modules,verbs=get;list;watch
@@ -89,25 +91,14 @@ func (r *PreflightValidationReconciler) SetupWithManager(mgr ctrl.Manager) error
 //+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=preflightvalidations/status,verbs=get;update;patch
 
 // Reconcile Reconiliation entry point
-func (r *PreflightValidationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *PreflightValidationReconciler) Reconcile(ctx context.Context, pv *v1beta12.PreflightValidation) (ctrl.Result, error) {
 	log := ctrl.LoggerFrom(ctx)
 	log.Info("Start PreflightValidation Reconciliation")
-
-	pv := v1beta12.PreflightValidation{}
-	err := r.client.Get(ctx, req.NamespacedName, &pv)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			log.Info("Reconciliation object not found; not reconciling")
-			return ctrl.Result{}, nil
-		}
-		log.Error(err, "preflight validation reconcile failed to find object")
-		return ctrl.Result{}, err
-	}
 
 	// we want the metric just to signal that this customer uses preflight
 	r.metricsAPI.SetKMMPreflightsNum(1)
 
-	reconCompleted, err := r.runPreflightValidation(ctx, &pv)
+	reconCompleted, err := r.runPreflightValidation(ctx, pv)
 	if err != nil {
 		log.Error(err, "runPreflightValidation failed")
 		return ctrl.Result{}, err

--- a/internal/controllers/preflightvalidation_reconciler_test.go
+++ b/internal/controllers/preflightvalidation_reconciler_test.go
@@ -13,9 +13,7 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/preflight"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/statusupdater"
 	"go.uber.org/mock/gomock"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -33,7 +31,6 @@ var _ = Describe("PreflightValidationReconciler_Reconcile", func() {
 		mockMetrics   *metrics.MockMetrics
 		mockSU        *statusupdater.MockPreflightStatusUpdater
 		mockPreflight *preflight.MockPreflightAPI
-		req           reconcile.Request
 		ctx           context.Context
 		nsn           types.NamespacedName
 		pr            *PreflightValidationReconciler
@@ -49,27 +46,8 @@ var _ = Describe("PreflightValidationReconciler_Reconcile", func() {
 			Name:      preflightName,
 			Namespace: namespace,
 		}
-		req = reconcile.Request{NamespacedName: nsn}
 		ctx = context.Background()
 		pr = NewPreflightValidationReconciler(clnt, nil, mockMetrics, mockSU, mockPreflight)
-	})
-
-	It("should do nothing if the Preflight is not available anymore", func() {
-		clnt.EXPECT().Get(ctx, nsn, &v1beta12.PreflightValidation{}).Return(apierrors.NewNotFound(schema.GroupResource{}, preflightName))
-
-		res, err := pr.Reconcile(ctx, req)
-
-		Expect(err).To(BeNil())
-		Expect(res).To(Equal(reconcile.Result{}))
-	})
-
-	It("should return error when failed to get preflight", func() {
-		clnt.EXPECT().Get(ctx, nsn, &v1beta12.PreflightValidation{}).Return(fmt.Errorf("some error"))
-
-		res, err := pr.Reconcile(ctx, req)
-
-		Expect(err).To(HaveOccurred())
-		Expect(res).To(Equal(reconcile.Result{}))
 	})
 
 	It("good flow, all verified", func() {
@@ -91,14 +69,6 @@ var _ = Describe("PreflightValidationReconciler_Reconcile", func() {
 			},
 		}
 		gomock.InOrder(
-			clnt.EXPECT().Get(context.Background(), nsn, &v1beta12.PreflightValidation{}).DoAndReturn(
-				func(_ interface{}, _ interface{}, m *v1beta12.PreflightValidation, _ ...ctrlclient.GetOption) error {
-					m.ObjectMeta = pv.ObjectMeta
-					m.Spec.KernelVersion = pv.Spec.KernelVersion
-					m.Status = pv.Status
-					return nil
-				},
-			),
 			mockMetrics.EXPECT().SetKMMPreflightsNum(1),
 			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
 				func(_ interface{}, list *v1beta12.ModuleList, _ ...interface{}) error {
@@ -118,7 +88,7 @@ var _ = Describe("PreflightValidationReconciler_Reconcile", func() {
 			),
 		)
 
-		res, err := pr.Reconcile(ctx, req)
+		res, err := pr.Reconcile(ctx, &pv)
 
 		Expect(err).To(BeNil())
 		Expect(res).To(Equal(reconcile.Result{}))
@@ -143,14 +113,6 @@ var _ = Describe("PreflightValidationReconciler_Reconcile", func() {
 			},
 		}
 		gomock.InOrder(
-			clnt.EXPECT().Get(context.Background(), nsn, &v1beta12.PreflightValidation{}).DoAndReturn(
-				func(_ interface{}, _ interface{}, m *v1beta12.PreflightValidation, _ ...ctrlclient.GetOption) error {
-					m.ObjectMeta = pv.ObjectMeta
-					m.Spec.KernelVersion = pv.Spec.KernelVersion
-					m.Status = pv.Status
-					return nil
-				},
-			),
 			mockMetrics.EXPECT().SetKMMPreflightsNum(1),
 			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
 				func(_ interface{}, list *v1beta12.ModuleList, _ ...interface{}) error {
@@ -170,7 +132,7 @@ var _ = Describe("PreflightValidationReconciler_Reconcile", func() {
 			),
 		)
 
-		res, err := pr.Reconcile(ctx, req)
+		res, err := pr.Reconcile(ctx, &pv)
 
 		Expect(err).To(BeNil())
 		Expect(res).To(Equal(reconcile.Result{RequeueAfter: time.Second * reconcileRequeueInSeconds}))


### PR DESCRIPTION
Remove boilerplate code and adapt unit tests.

Fixes #1001 

/cc @mresvanis @yevgeny-shnaidman 