### PR TITLE
MGMT-16723: Mount the global pull secret under the right name

### DIFF
--- a/internal/controllers/nmc_reconciler.go
+++ b/internal/controllers/nmc_reconciler.go
@@ -1030,7 +1030,7 @@ func (p *podManagerImpl) baseWorkerPod(
 		{
 			Name:      globalPullSecretName,
 			ReadOnly:  true,
-			MountPath: filepath.Join(worker.PullSecretsDir, globalPullSecretName),
+			MountPath: filepath.Join(worker.PullSecretsDir, "_global", v1.DockerConfigJsonKey),
 		},
 	}
 

--- a/internal/controllers/nmc_reconciler_test.go
+++ b/internal/controllers/nmc_reconciler_test.go
@@ -1750,7 +1750,7 @@ softdep b pre: c
 						{
 							Name:      globalPullSecretName,
 							ReadOnly:  true,
-							MountPath: filepath.Join(worker.PullSecretsDir, globalPullSecretName),
+							MountPath: filepath.Join(worker.PullSecretsDir, "_global", v1.DockerConfigJsonKey),
 						},
 						{
 							Name:      volNameModulesOrder,


### PR DESCRIPTION
Pull secret files mounted in the worker filesystem need to be named either `.dockercfg` or `.dockerconfigjson`.

/cc @mresvanis @yevgeny-shnaidman 