### PR TITLE
PreflightValidation: populate old status keys

### DIFF
--- a/api/v1beta1/preflightvalidation_types.go
+++ b/api/v1beta1/preflightvalidation_types.go
@@ -123,6 +123,9 @@ func v1beta1StatusFromV1beta2(s v1beta2.PreflightValidationStatus) PreflightVali
 		for _, v := range s.Modules {
 			v := v
 			res.CRStatuses[v.Namespace+"/"+v.Name] = &v.CRBaseStatus
+
+			// This may lead to collisions, but at least we preserve backwards compatibility.
+			res.CRStatuses[v.Name] = &v.CRBaseStatus
 		}
 	}
 

--- a/api/v1beta1/preflightvalidation_types_test.go
+++ b/api/v1beta1/preflightvalidation_types_test.go
@@ -54,7 +54,9 @@ var _ = Describe("PreflightValidation_ConvertFrom", func() {
 			Status: PreflightValidationStatus{
 				CRStatuses: map[string]*CRStatus{
 					"namespace-1/module-1": &baseStatus1,
+					"module-1":             &baseStatus1,
 					"namespace-2/module-2": &baseStatus2,
+					"module-2":             &baseStatus2,
 				},
 			},
 		}


### PR DESCRIPTION
Also populate old-style, un-namespaced status keys to remain compatible with clients designed for pre-2.1 KMM.

Fixes #1067