### PR TITLE
Refusing `Modules` with container images without a sha or a tag.

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -129,10 +129,6 @@ func (r *registry) getPullOptions(ctx context.Context, image string, tlsOptions 
 		repo = tag[0]
 	}
 
-	if repo == "" {
-		return nil, fmt.Errorf("image url %s is not valid, does not contain hash or tag", image)
-	}
-
 	options := []crane.Option{
 		crane.WithContext(ctx),
 	}

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -57,14 +57,6 @@ var _ = Describe("ImageExists", func() {
 			Expect(err.Error()).To(ContainSubstring("failed to get pull options for image"))
 		})
 
-		It("should fail if the image name isn't valid", func() {
-
-			_, err = reg.ImageExists(ctx, invalidImage, &kmmv1beta1.TLSOptions{}, nil)
-
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("does not contain hash or tag"))
-		})
-
 		It("should fail if it cannot get key chain from secret", func() {
 
 			mockRegistryAuthGetter.EXPECT().GetKeyChain(ctx).Return(nil, errors.New("some error"))
@@ -220,14 +212,6 @@ var _ = Describe("GetLayersDigests", func() {
 
 		AfterEach(func() {
 			Expect(err.Error()).To(ContainSubstring("failed to get pull options for image"))
-		})
-
-		It("should fail if the image name isn't valid", func() {
-
-			_, err = reg.ImageExists(ctx, invalidImage, &kmmv1beta1.TLSOptions{}, nil)
-
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("does not contain hash or tag"))
 		})
 
 		It("should fail if it cannot get key chain from secret", func() {
@@ -391,13 +375,6 @@ var _ = Describe("GetDigest", func() {
 
 		AfterEach(func() {
 			Expect(err.Error()).To(ContainSubstring("failed to get pull options for image"))
-		})
-
-		It("should fail if the image name isn't valid", func() {
-			_, err = reg.GetDigest(ctx, invalidImage, &kmmv1beta1.TLSOptions{}, nil)
-
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("does not contain hash or tag"))
 		})
 
 		It("should fail if it cannot get key chain from secret", func() {

--- a/internal/webhook/module.go
+++ b/internal/webhook/module.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/go-logr/logr"
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
@@ -111,9 +112,25 @@ func validateModule(mod *kmmv1beta1.Module) (admission.Warnings, error) {
 	return nil, validateModprobe(mod.Spec.ModuleLoader.Container.Modprobe)
 }
 
+func validateImageFormat(img string) error {
+
+	if !strings.Contains(img, ":") && !strings.Contains(img, "@") {
+		return fmt.Errorf("container image must explicitely set a tag or digest; got: %s", img)
+	}
+
+	return nil
+}
+
 func validateModuleLoaderContainerSpec(container kmmv1beta1.ModuleLoaderContainerSpec) error {
+
 	if container.InTreeModulesToRemove != nil && container.InTreeModuleToRemove != "" { //nolint:staticcheck
 		return fmt.Errorf("only one of the Container's fields: InTreeModulesToRemove or InTreeModuleToRemove can be defined")
+	}
+
+	if contImg := container.ContainerImage; contImg != "" {
+		if err := validateImageFormat(contImg); err != nil {
+			return fmt.Errorf("failed to validate image format: %v", err)
+		}
 	}
 
 	for idx, km := range container.KernelMappings {
@@ -129,8 +146,12 @@ func validateModuleLoaderContainerSpec(container kmmv1beta1.ModuleLoaderContaine
 			return fmt.Errorf("invalid regexp at index %d: %v", idx, err)
 		}
 
-		if container.ContainerImage == "" && km.ContainerImage == "" {
-			return fmt.Errorf("missing spec.moduleLoader.container.kernelMappings[%d].containerImage", idx)
+		if kmImg := km.ContainerImage; kmImg == "" {
+			if container.ContainerImage == "" {
+				return fmt.Errorf("missing spec.moduleLoader.container.kernelMappings[%d].containerImage", idx)
+			}
+		} else if err := validateImageFormat(kmImg); err != nil {
+			return fmt.Errorf("failed to validate image format: %v", err)
 		}
 
 		if km.InTreeModulesToRemove != nil && km.InTreeModuleToRemove != "" { //nolint:staticcheck


### PR DESCRIPTION
In the current code, we handle differently build/sign and deploying a pre-built kmod.

This is the current behavior:
* If a `build`/`sign` section is set in the module, and the image tag isn't specified, then we will return an error.
* If there are no `build`/`sign` section, and the image tag isn't specified, then we will default to the `latest` tag.

This change is adjusting the behavior of both workflow to enforce the customer to explicitely set a sha or a tag in his container image.

---

/cc @yevgeny-shnaidman @TomerNewman 
**This is a cherry-pick**
Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1153