### PR TITLE
Start using the new `gitstream` image.

### DIFF
--- a/.github/workflows/gitstream.yml
+++ b/.github/workflows/gitstream.yml
@@ -14,7 +14,7 @@ jobs:
       GO_RELEASE: go1.20.11.linux-amd64.tar.gz
 
     container:
-      image: ghcr.io/qbarrand/gitstream:main
+      image: quay.io/edge-infrastructure/gitstream:latest
 
     permissions:
       actions: write


### PR DESCRIPTION
Since `qbarrand/gitstream` has migrated to `rh-ecosystem-edge/gitstream` a new image `quay.io/edge-infrastructure/gitstream:latest` as replaced the previous `ghcr.io/qbarrand/gitstream:main` image and in order to use the updated most gitstream image we need to use the `quay.io` image which will be the only image updated upon pushes to `rh-ecosystem-edge/gitstream`.

---

/cc @mresvanis 
/hold
Needs to be merged after https://github.com/rh-ecosystem-edge/gitstream/pull/145