### PR TITLE
Day1 feature support multiple kmod

### DIFF
--- a/pkg/mcproducer/templates/machine-config.gotmpl
+++ b/pkg/mcproducer/templates/machine-config.gotmpl
@@ -34,7 +34,7 @@ spec:
             [Install]
             WantedBy=multi-user.target
           enabled: true
-          name: "replace-kernel-module.service"
+          name: "{{.MachineConfigName}}-replace-kernel-module.service"
         - contents: |
             [Unit]
             Description=Pull oot kernel module image
@@ -56,7 +56,7 @@ spec:
             [Install]
             WantedBy=multi-user.target
           enabled: true
-          name: "pull-kernel-module-image.service"
+          name: "{{.MachineConfigName}}-pull-kernel-module-image.service"
         - enabled: false
           mask: true
           name: crio-wipe.service

--- a/pkg/mcproducer/testdata/machineconfig-test.yaml
+++ b/pkg/mcproducer/testdata/machineconfig-test.yaml
@@ -34,7 +34,7 @@ spec:
             [Install]
             WantedBy=multi-user.target
           enabled: true
-          name: "replace-kernel-module.service"
+          name: "name-replace-kernel-module.service"
         - contents: |
             [Unit]
             Description=Pull oot kernel module image
@@ -56,7 +56,7 @@ spec:
             [Install]
             WantedBy=multi-user.target
           enabled: true
-          name: "pull-kernel-module-image.service"
+          name: "name-pull-kernel-module-image.service"
         - enabled: false
           mask: true
           name: crio-wipe.service


### PR DESCRIPTION
Previously, the `replace-kernel-module.service` and `pull-kernel-module-image.service` files were created without differentiation for each kernel module, leading to potential overlap. This update introduces a prefix using <kmod_name>, resulting in service files named `<kmod_name>-replace-kernel-module.service` and `<kmod_name>-pull-kernel-module-image.service`, thereby resolving the issue.

---

/assign @yevgeny-shnaidman
/cc @ybettan 