### PR TITLE
Adding an init container to the worker pod.

### DIFF
--- a/internal/controllers/nmc_reconciler_test.go
+++ b/internal/controllers/nmc_reconciler_test.go
@@ -259,7 +259,7 @@ var _ = Describe("NodeModulesConfigReconciler_Reconcile", func() {
 })
 
 var moduleConfig = kmmv1beta1.ModuleConfig{
-	KernelVersion:         "kernel version",
+	KernelVersion:         "kernel-version",
 	ContainerImage:        "container image",
 	InsecurePull:          true,
 	InTreeModulesToRemove: []string{"intree1", "intree2"},
@@ -1791,7 +1791,7 @@ var _ = Describe("podManagerImpl_CreateUnloaderPod", func() {
 
 	It("should work as expected", func() {
 
-		expected := getBaseWorkerPod("unload", nmc, ptr.To("some-path"), true, false)
+		expected := getBaseWorkerPod("unload", nmc, ptr.To("/var/lib/firmware"), true, false)
 
 		container, _ := podcmd.FindContainerByName(expected, "worker")
 		Expect(container).NotTo(BeNil())
@@ -1817,7 +1817,8 @@ var _ = Describe("podManagerImpl_CreateUnloaderPod", func() {
 		)
 
 		workerCfg := *workerCfg
-		workerCfg.FirmwareHostPath = ptr.To("some-path")
+		workerCfg.FirmwareHostPath = ptr.To("/var/lib/firmware")
+
 		pm := newPodManager(client, workerImage, scheme, caHelper, &workerCfg)
 		pm.(*podManagerImpl).psh = psh
 
@@ -1946,7 +1947,7 @@ inTreeModulesToRemove:
 - intree1
 - intree2
 insecurePull: true
-kernelVersion: kernel version
+kernelVersion: kernel-version
 modprobe:
   dirName: /dir
   firmwarePath: /firmware-path
@@ -1963,9 +1964,20 @@ modprobe:
 softdep b pre: c
 `
 
+	var initContainerArg = `
+mkdir -p /tmp/dir/lib/modules;
+cp -R /dir/lib/modules/kernel-version /tmp/dir/lib/modules;
+`
+
+	const initContainerArgFirmwareAddition = `
+mkdir -p /tmp/firmware-path;
+cp -R /firmware-path/* /tmp/firmware-path;
+`
+
 	args := []string{"kmod", subcommand, "/etc/kmm-worker/config.yaml"}
 	if withFirmware {
 		args = append(args, "--firmware-path", *firmwareHostPath)
+		initContainerArg = strings.Join([]string{initContainerArg, initContainerArgFirmwareAddition}, "")
 	} else {
 		configAnnotationValue = strings.ReplaceAll(configAnnotationValue, "firmwarePath: /firmware-path\n  ", "")
 	}
@@ -1986,6 +1998,24 @@ softdep b pre: c
 			},
 		},
 		Spec: v1.PodSpec{
+			InitContainers: []v1.Container{
+				{
+					Name:    "image-extractor",
+					Image:   "container image",
+					Command: []string{"/bin/sh", "-c"},
+					Args:    []string{initContainerArg},
+					Resources: v1.ResourceRequirements{
+						Limits:   limits,
+						Requests: requests,
+					},
+					VolumeMounts: []v1.VolumeMount{
+						{
+							Name:      volNameTmp,
+							MountPath: sharedFilesDir,
+						},
+					},
+				},
+			},
 			Containers: []v1.Container{
 				{
 					Name:  "worker",
@@ -2026,6 +2056,11 @@ softdep b pre: c
 							Name:      globalPullSecretName,
 							ReadOnly:  true,
 							MountPath: filepath.Join(worker.PullSecretsDir, "_global", v1.DockerConfigJsonKey),
+						},
+						{
+							Name:      volNameTmp,
+							MountPath: sharedFilesDir,
+							ReadOnly:  true,
 						},
 						{
 							Name:      volNameModulesOrder,
@@ -2119,6 +2154,12 @@ softdep b pre: c
 							Path: worker.GlobalPullSecretPath,
 							Type: &hostPathFile,
 						},
+					},
+				},
+				{
+					Name: volNameTmp,
+					VolumeSource: v1.VolumeSource{
+						EmptyDir: &v1.EmptyDirVolumeSource{},
 					},
 				},
 				{


### PR DESCRIPTION
This init container will be pulled by the container-runtime of the cluster and will copy all `.ko` and firmware files to a shared volume accessible by the worker container to load.

---

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1193
/assign @yevgeny-shnaidman 
/cc @TomerNewman 