### PR TITLE
Updating the bundle-hub files.

### DIFF
--- a/bundle-hub/manifests/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
+++ b/bundle-hub/manifests/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.15.0
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: kmm-hub

--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -8,6 +8,11 @@ metadata:
           "apiVersion": "hub.kmm.sigs.x-k8s.io/v1beta1",
           "kind": "ManagedClusterModule",
           "metadata": {
+            "labels": {
+              "app.kubernetes.io/component": "kmm-hub",
+              "app.kubernetes.io/name": "kmm-hub",
+              "app.kubernetes.io/part-of": "kmm"
+            },
             "name": "managedclustermodule-sample"
           },
           "spec": {
@@ -32,11 +37,15 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-06-03T15:27:54Z"
+    createdAt: "2024-09-03T16:21:51Z"
     operatorframework.io/suggested-namespace: openshift-kmm-hub
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/rh-ecosystem-edge/kernel-module-management
+  labels:
+    app.kubernetes.io/component: kmm-hub
+    app.kubernetes.io/name: kmm-hub
+    app.kubernetes.io/part-of: kmm
   name: kernel-module-management-hub.v0.0.1
   namespace: placeholder
 spec:
@@ -219,7 +228,6 @@ spec:
                 - name: RELATED_IMAGE_SIGN
                   value: quay.io/edge-infrastructure/kernel-module-management-signimage:latest
                 image: quay.io/edge-infrastructure/kernel-module-management-operator-hub:latest
-                imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -328,7 +336,6 @@ spec:
                 - --config=controller_config.yaml
                 - --enable-managedclustermodule
                 image: quay.io/edge-infrastructure/kernel-module-management-webhook-server:latest
-                imagePullPolicy: Always
                 livenessProbe:
                   httpGet:
                     path: /healthz

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -63,7 +63,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-09-03T12:40:53Z"
+    createdAt: "2024-09-03T16:21:50Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3


### PR DESCRIPTION
Usually we don't know let PRs to merge if those files are not updated accordingly but for some reason `ci/prow/check-api-changes` is not detecting the changes and we went out of sync.

---

/cc @yevgeny-shnaidman 
This is a follow up on https://github.com/rh-ecosystem-edge/kernel-module-management/pull/1198