### PR TITLE
Updating skipper

### DIFF
--- a/Dockerfile.kmm-operator-build
+++ b/Dockerfile.kmm-operator-build
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:rhel-8-release-golang-1.21-openshift-4.18
+FROM golang:1.21-alpine3.19
 
 ENV GO111MODULE=on
 ENV GOFLAGS=""
@@ -6,8 +6,10 @@ ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=amd64
 
-RUN yum install -y podman docker
+RUN ["apk", "add", "bash", "make", "docker", "curl", "shadow", "git"]
 RUN go install go.uber.org/mock/mockgen@v0.3.0
 RUN curl -L "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /tmp/kubectl
 RUN install -o root -g root -m 0755 /tmp/kubectl /usr/local/bin/kubectl
-COPY --from=quay.io/openshift/origin-cli:latest /usr/bin/oc /usr/bin
+RUN ln -s /usr/local/bin/kubectl /usr/bin/oc
+RUN chmod +x /usr/bin/oc
+


### PR DESCRIPTION
Currently skipper does not support communication
with podman images repo on the host, while rhel images do not support docker. This PR reverts to alpine and use symlink to simulate OC executable