### PR TITLE
support inTree removal scenario for nodes without .ko files

### DIFF
--- a/internal/utils/mock_filesystem_helper.go
+++ b/internal/utils/mock_filesystem_helper.go
@@ -37,6 +37,21 @@ func (m *MockFSHelper) EXPECT() *MockFSHelperMockRecorder {
 	return m.recorder
 }
 
+// FileExists mocks base method.
+func (m *MockFSHelper) FileExists(root, fileRegex string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FileExists", root, fileRegex)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FileExists indicates an expected call of FileExists.
+func (mr *MockFSHelperMockRecorder) FileExists(root, fileRegex any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FileExists", reflect.TypeOf((*MockFSHelper)(nil).FileExists), root, fileRegex)
+}
+
 // RemoveSrcFilesFromDst mocks base method.
 func (m *MockFSHelper) RemoveSrcFilesFromDst(srcDir, dstDir string) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Modprobe will fail with error in case it cannot find an appropriate .ko file when asked to remove a kernel module. With in-tree removal scenario, modporbe search path is /lib/modules on the host, and not the worker image.
This PR contains the following:
1) Adding FileExists function that check the presence of a file under
   a search path based on a regexp
2) in worker flow, in case in-tree removal scenario is requisted, worker
   will verify if the requested .ko file(s) are present on the host,
   remove from the request missing files and will proceed with the
   removal scenario for the rest
3) unit-test