### PR TITLE
Removing the `--tarball` flag from the worker flags.

### DIFF
--- a/cmd/worker/funcs_kmod.go
+++ b/cmd/worker/funcs_kmod.go
@@ -59,20 +59,8 @@ func setCommandsFlags() {
 		"",
 		"if set, this value will be written to "+worker.FirmwareClassPathLocation+" and it is also the value that firmware host path is mounted to")
 
-	kmodLoadCmd.Flags().Bool(
-		"tarball",
-		false,
-		"If true, extract the image from a tarball image instead of pulling from the registry",
-	)
-
 	kmodUnloadCmd.Flags().String(
 		worker.FlagFirmwarePath,
 		"",
 		"if set, this the value that firmware host path is mounted to")
-
-	kmodUnloadCmd.Flags().Bool(
-		"tarball",
-		false,
-		"If true, extract the image from a tarball image instead of pulling from the registry",
-	)
 }


### PR DESCRIPTION
Now that we are using CRIO to pull images and the `ImageMounter` interface was removed, the `--tarball` flag isn't being used anymore.

---

/cc @yevgeny-shnaidman @TomerNewman 