### PR TITLE
making sure e2e tests works after bumping Openshift version to 4.17 in Openshift/Release jobs

### DIFF
--- a/internal/controllers/nmc_reconciler.go
+++ b/internal/controllers/nmc_reconciler.go
@@ -649,6 +649,7 @@ func (h *nmcReconcilerHelperImpl) UpdateNodeLabels(ctx context.Context, nmc *kmm
 	deprecatedNodeModuleReadyLabels := h.lph.getDeprecatedKernelModuleReadyLabels(*node)
 
 	// get spec labels and their config
+
 	specLabels := h.lph.getSpecLabelsAndTheirConfigs(nmc)
 
 	// get status labels and their config


### PR DESCRIPTION
making sure e2e tests works after bumping Openshift version to 4.17 in Openshift/Release jobs.

this PR should not be merged.