### PR TITLE
Fixing image repo secret extraction for unloading worker pod

### DIFF
--- a/internal/controllers/nmc_reconciler.go
+++ b/internal/controllers/nmc_reconciler.go
@@ -542,16 +542,9 @@ func (h *nmcReconcilerHelperImpl) SyncStatus(ctx context.Context, nmcObj *kmmv1b
 				continue
 			}
 
-			if irsName, err := getImageRepoSecretName(&p); err != nil {
-				logger.Info(
-					utils.WarnString("Error while looking for the imageRepoSecret volume"),
-					"error",
-					err,
-				)
-			} else if irsName != "" {
-				status.ImageRepoSecret = &v1.LocalObjectReference{Name: irsName}
+			if p.Spec.ImagePullSecrets != nil {
+				status.ImageRepoSecret = &p.Spec.ImagePullSecrets[0]
 			}
-
 			status.ServiceAccountName = p.Spec.ServiceAccountName
 
 			status.LastTransitionTime = GetContainerStatus(p.Status.ContainerStatuses, workerContainerName).
@@ -730,9 +723,8 @@ const (
 	configFileName = "config.yaml"
 	configFullPath = volMountPointConfig + "/" + configFileName
 
-	volNameConfig          = "config"
-	volNameImageRepoSecret = "image-repo-secret"
-	volMountPointConfig    = "/etc/kmm-worker"
+	volNameConfig       = "config"
+	volMountPointConfig = "/etc/kmm-worker"
 )
 
 //go:generate mockgen -source=nmc_reconciler.go -package=controllers -destination=mock_nmc_reconciler.go podManager
@@ -1305,22 +1297,6 @@ func setHashAnnotation(pod *v1.Pod) error {
 	pod.Annotations[hashAnnotationKey] = fmt.Sprintf("%d", hash)
 
 	return nil
-}
-
-func getImageRepoSecretName(pod *v1.Pod) (string, error) {
-	for _, v := range pod.Spec.Volumes {
-		if v.Name == volNameImageRepoSecret {
-			svs := v.VolumeSource.Secret
-
-			if svs == nil {
-				return "", fmt.Errorf("volume %s is not of type secret", volNameImageRepoSecret)
-			}
-
-			return svs.SecretName, nil
-		}
-	}
-
-	return "", nil
 }
 
 func getModulesOrderAnnotationValue(modulesNames []string) string {

--- a/internal/controllers/nmc_reconciler_test.go
+++ b/internal/controllers/nmc_reconciler_test.go
@@ -1048,14 +1048,7 @@ var _ = Describe("nmcReconcilerHelperImpl_SyncStatus", func() {
 			},
 			Spec: v1.PodSpec{
 				ServiceAccountName: serviceAccountName,
-				Volumes: []v1.Volume{
-					{
-						Name: volNameImageRepoSecret,
-						VolumeSource: v1.VolumeSource{
-							Secret: &v1.SecretVolumeSource{SecretName: irsName},
-						},
-					},
-				},
+				ImagePullSecrets:   []v1.LocalObjectReference{v1.LocalObjectReference{Name: irsName}},
 			},
 			Status: v1.PodStatus{
 				Phase: v1.PodSucceeded,


### PR DESCRIPTION
image repo secret wasd previously extracted from the volume that was mapped into the loading pod. Since the volume no longer exists, we must extract it from the imagePullSecret of the loading pod