### PR TITLE
Bumping ACM release to 2.12 in CI

### DIFF
--- a/ci/acm_subscription.yaml
+++ b/ci/acm_subscription.yaml
@@ -13,7 +13,7 @@ metadata:
   name: acm-operator-subscription
   namespace: advanced-cluster-management
 spec:
-  channel: release-2.9
+  channel: release-2.12
   installPlanApproval: Automatic
   name: advanced-cluster-management
   source: redhat-operators


### PR DESCRIPTION
Bumping the ACM release version from 2.9 to 2.12 due to bug when installing ACM in CI jobs.

---

/cc @yevgeny-shnaidman @ybettan 