### PR TITLE
Revert "Bump ubi9/go-toolset from 1.21 to 9.5"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:9.5 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21 as builder
 
 # Copy the Go Modules manifests
 COPY go.mod go.mod

--- a/Dockerfile.webhook
+++ b/Dockerfile.webhook
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:9.5 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21 as builder
 
 # Copy the Go Modules manifests
 COPY go.mod go.mod

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:9.5 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21 as builder
 
 # Add the vendored dependencies
 COPY vendor vendor


### PR DESCRIPTION
Reverts rh-ecosystem-edge/kernel-module-management#1245

---

/assign @yevgeny-shnaidman 
/cc @TomerNewman 