### PR TITLE
Making ImagePullPolicy in NMC optional

### DIFF
--- a/api/v1beta1/nodemodulesconfig_types.go
+++ b/api/v1beta1/nodemodulesconfig_types.go
@@ -25,6 +25,7 @@ type ModuleConfig struct {
 	KernelVersion  string `json:"kernelVersion"`
 	ContainerImage string `json:"containerImage"`
 	// +kubebuilder:default=IfNotPresent
+	//+optional
 	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy"`
 	// When InsecurePull is true, the container image can be pulled without TLS.
 	InsecurePull bool `json:"insecurePull"`

--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-09-08T06:59:15Z"
+    createdAt: "2024-12-12T08:38:46Z"
     operatorframework.io/suggested-namespace: openshift-kmm-hub
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -63,7 +63,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-09-08T06:59:14Z"
+    createdAt: "2024-12-12T08:36:22Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
+++ b/bundle/manifests/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
@@ -160,7 +160,6 @@ spec:
                           type: object
                       required:
                       - containerImage
-                      - imagePullPolicy
                       - insecurePull
                       - kernelVersion
                       - modprobe
@@ -309,7 +308,6 @@ spec:
                           type: object
                       required:
                       - containerImage
-                      - imagePullPolicy
                       - insecurePull
                       - kernelVersion
                       - modprobe

--- a/config/crd/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
@@ -156,7 +156,6 @@ spec:
                           type: object
                       required:
                       - containerImage
-                      - imagePullPolicy
                       - insecurePull
                       - kernelVersion
                       - modprobe
@@ -305,7 +304,6 @@ spec:
                           type: object
                       required:
                       - containerImage
-                      - imagePullPolicy
                       - insecurePull
                       - kernelVersion
                       - modprobe


### PR DESCRIPTION
Currently ImagePullPolicy has a kubebuilder instruction for default value, which automatically makes it a required field. In previous version, this field was optional, meaning: when upgrading KMM operator, the upgrade will fail , since NMC object will be missing the required field
This commit keep the default value, but makes this field optional, in order to solve the upgrade issue