### PR TITLE
Removing `gcr.io/kubebuilder/kube-rbac-proxy` from the `kustomize` manifests.

### DIFF
--- a/config/manager-base/kustomization.yaml
+++ b/config/manager-base/kustomization.yaml
@@ -11,9 +11,6 @@ patches:
 - path: ocp.patch.yaml
 
 images:
-- name: gcr.io/kubebuilder/kube-rbac-proxy
-  newName: registry.redhat.io/openshift4/ose-kube-rbac-proxy
-  newTag: v4.13
 - name: must-gather
   newName: quay.io/edge-infrastructure/kernel-module-management-must-gather
   newTag: latest


### PR DESCRIPTION

This image replacement is not used anymore.

---

/assign @yevgeny-shnaidman @TomerNewman 