### PR TITLE
Renaming the webhook deployment from `webhook-server` to `webhook`.

### DIFF
--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-12-15T08:56:31Z"
+    createdAt: "2024-12-23T09:43:32Z"
     operatorframework.io/suggested-namespace: openshift-kmm-hub
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -298,7 +298,7 @@ spec:
           app.kubernetes.io/name: kmm-hub
           app.kubernetes.io/part-of: kmm
           control-plane: webhook-server
-        name: kmm-operator-hub-webhook-server
+        name: kmm-operator-hub-webhook
         spec:
           replicas: 1
           selector:
@@ -447,7 +447,7 @@ spec:
   - admissionReviewVersions:
     - v1
     containerPort: 443
-    deploymentName: kmm-operator-hub-webhook-server
+    deploymentName: kmm-operator-hub-webhook
     failurePolicy: Fail
     generateName: vmanagedclustermodule.kb.io
     rules:

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -63,7 +63,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-12-15T08:56:31Z"
+    createdAt: "2024-12-23T09:43:31Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -453,7 +453,7 @@ spec:
           app.kubernetes.io/name: kmm
           app.kubernetes.io/part-of: kmm
           control-plane: webhook-server
-        name: kmm-operator-webhook-server
+        name: kmm-operator-webhook
         spec:
           replicas: 1
           selector:
@@ -628,7 +628,7 @@ spec:
     conversionCRDs:
     - preflightvalidations.kmm.sigs.x-k8s.io
     - preflightvalidationsocp.kmm.sigs.x-k8s.io
-    deploymentName: kmm-operator-webhook-server
+    deploymentName: kmm-operator-webhook
     generateName: cpreflightvalidationspreflightvalidationsocp.kb.io
     sideEffects: None
     targetPort: 9443
@@ -637,7 +637,7 @@ spec:
   - admissionReviewVersions:
     - v1
     containerPort: 443
-    deploymentName: kmm-operator-webhook-server
+    deploymentName: kmm-operator-webhook
     failurePolicy: Fail
     generateName: namespace-deletion.kmm.sigs.k8s.io
     rules:
@@ -656,7 +656,7 @@ spec:
   - admissionReviewVersions:
     - v1
     containerPort: 443
-    deploymentName: kmm-operator-webhook-server
+    deploymentName: kmm-operator-webhook
     failurePolicy: Fail
     generateName: vmodule.kb.io
     rules:

--- a/ci/prow/e2e-hub-spoke-incluster-build
+++ b/ci/prow/e2e-hub-spoke-incluster-build
@@ -39,7 +39,7 @@ if [ "$SKIP_MAKE_DEPLOY_HUB" == true ]; then
 else
   echo "Deploy KMMO-Hub..."
   make deploy-hub
-  oc wait --for=condition=Available --timeout=1m deployment/kmm-operator-hub-controller deployment/kmm-operator-hub-webhook-server -n ${HUB_OPERATOR_NAMESPACE}
+  oc wait --for=condition=Available --timeout=1m deployment/kmm-operator-hub-controller deployment/kmm-operator-hub-webhook -n ${HUB_OPERATOR_NAMESPACE}
 fi
 
 if [ "$SKIP_MAKE_DEPLOY" == true ]; then
@@ -47,7 +47,7 @@ if [ "$SKIP_MAKE_DEPLOY" == true ]; then
 else
   echo "Deploy KMM..."
   make deploy KUSTOMIZE_CONFIG_DEFAULT=ci/install-ci-spoke
-  oc wait --for=condition=Available --timeout=1m deployment/kmm-operator-controller deployment/kmm-operator-webhook-server -n ${OPERATOR_NAMESPACE}
+  oc wait --for=condition=Available --timeout=1m deployment/kmm-operator-controller deployment/kmm-operator-webhook -n ${OPERATOR_NAMESPACE}
 fi
 
 # Apply resources

--- a/ci/prow/e2e-incluster-build
+++ b/ci/prow/e2e-incluster-build
@@ -38,7 +38,7 @@ oc debug "node/${NODE}" -- chroot host/ sudo modprobe dummy
 echo "Verify that dummy is loaded"
 oc debug "node/${NODE}" -- chroot host/ lsmod | grep dummy
 
-oc wait --for=condition=Available deployment/kmm-operator-controller deployment/kmm-operator-webhook-server -n openshift-kmm
+oc wait --for=condition=Available deployment/kmm-operator-controller deployment/kmm-operator-webhook -n openshift-kmm
 
 echo "Add resources"
 oc apply -k ci/e2e

--- a/ci/prow/operator-upgrade
+++ b/ci/prow/operator-upgrade
@@ -23,4 +23,7 @@ oc wait --for=condition=Available -n openshift-kmm --timeout=1m deployment/kmm-o
 ./bin/operator-sdk run bundle-upgrade "$OO_BUNDLE" \
     --namespace openshift-kmm \
     --timeout 5m0s
-oc wait --for=condition=Available -n openshift-kmm --timeout=1m deployment/kmm-operator-controller
+
+oc wait --for=condition=Available -n openshift-kmm --timeout=1m \
+    deployment/kmm-operator-controller \
+    deployment/kmm-operator-webhook

--- a/config/deploy-hub/kustomization.yaml
+++ b/config/deploy-hub/kustomization.yaml
@@ -13,7 +13,7 @@ resources:
 patches:
 - target:
     kind: Deployment
-    name: webhook-server
+    name: webhook
   patch: |-
     - op: add
       path: /spec/template/spec/containers/0/args/-

--- a/config/deploy/kustomization.yaml
+++ b/config/deploy/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
 patches:
 - target:
     kind: Deployment
-    name: webhook-server
+    name: webhook
   patch: |-
     - op: add
       path: /spec/template/spec/containers/0/args/-

--- a/config/webhook-cert/kustomization.yaml
+++ b/config/webhook-cert/kustomization.yaml
@@ -6,7 +6,7 @@ patches:
     apiVersion: apps/v1
     kind: Deployment
     metadata:
-      name: webhook-server
+      name: webhook
       namespace: system
     spec:
       template:

--- a/config/webhook-server/deployment.yaml
+++ b/config/webhook-server/deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: webhook-server
+  name: webhook
   namespace: system
   labels:
     control-plane: webhook-server


### PR DESCRIPTION
* When we generate files with `controller-gen` it generates a service called `webhook-service` and it is not configurable.

* When we deploy KMM with OLM, OLM deploys a service for the webhook called `<webhook-deployment-name>-service.

Therefore, before this change, we were getting 2 services for the same deployment. One generated by `controller-gen` and added to the bundle manifests and the other one created "on the fly" by OLM.

This change will make OLM find an already existing service called `webhook-service` in the cluster because the deployment is called `webhook`, therefore, it won't create a second service as before.

Services in KMM's namespace before the changes:
```
kmm-operator-controller-metrics-service   ClusterIP   10.129.169.25   <none>  8443/TCP   2d2h
kmm-operator-webhook-server-service       ClusterIP   10.130.107.158  <none>  443/TCP    2d2h
kmm-operator-webhook-service              ClusterIP   10.128.244.171  <none>  443/TCP    2d2h
```

Services in KMM's namespace after the changes:
```
kmm-operator-controller-metrics-service   ClusterIP   10.99.75.82     <none>  8443/TCP   88m
kmm-operator-webhook-service              ClusterIP   10.105.163.241  <none>  443/TCP    88m
```

---

/assign @yevgeny-shnaidman @TomerNewman 
Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1280 