### PR TITLE
Bumping to `go1.23`.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 as builder
+FROM golang:1.23 as builder
 
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -31,7 +31,7 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
 
 ARG TARGET
 
-COPY --from=builder /opt/app-root/src/${TARGET} /usr/local/bin/manager
+COPY --from=builder /go/${TARGET} /usr/local/bin/manager
 
 RUN microdnf update -y && \
     microdnf install -y shadow-utils && \

--- a/Dockerfile.kmm-operator-build
+++ b/Dockerfile.kmm-operator-build
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine3.19
+FROM golang:1.23-alpine3.21
 
 ENV GO111MODULE=on
 ENV GOFLAGS=""

--- a/Dockerfile.webhook
+++ b/Dockerfile.webhook
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 as builder
+FROM golang:1.23 as builder
 
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -27,6 +27,6 @@ RUN make webhook-server
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
 
-COPY --from=builder /opt/app-root/src/webhook-server /usr/local/bin/webhook-server
+COPY --from=builder /go/webhook-server /usr/local/bin/webhook-server
 
 ENTRYPOINT ["/usr/local/bin/webhook-server"]

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21 as builder
+FROM golang:1.23 as builder
 
 # Add the vendored dependencies
 COPY vendor vendor
@@ -30,7 +30,7 @@ RUN microdnf update -y && \
     microdnf install -y kmod shadow-utils && \
     microdnf clean all
 
-COPY --from=builder /opt/app-root/src/worker /usr/local/bin/worker
+COPY --from=builder /go/worker /usr/local/bin/worker
 
 RUN ["groupadd", "--system", "-g", "201", "kmm"]
 RUN ["useradd", "--system", "-u", "201", "-g", "201", "-s", "/sbin/nologin", "kmm"]

--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ controller-gen: ## Download controller-gen locally if necessary.
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 .PHONY: golangci-lint
 golangci-lint: ## Download golangci-lint locally if necessary.
-	$(call go-get-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.1)
+	$(call go-get-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.2)
 
 .PHONY: mockgen
 mockgen: ## Install mockgen locally.

--- a/ci/prow/lint
+++ b/ci/prow/lint
@@ -2,8 +2,6 @@
 
 set -euxo pipefail
 
-export GOCACHE=/tmp
-
 # Generate code and compare with the current source.
 # Fail with a diff if some files are outdated.
 go install go.uber.org/mock/mockgen@v0.2.0
@@ -16,4 +14,4 @@ fi
 
 export GOLANGCI_LINT_CACHE=/tmp
 
-make lint GOLANGCI_LINT=/usr/bin/golangci-lint
+make lint

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/rh-ecosystem-edge/kernel-module-management
 
-go 1.21
+go 1.23.0
 
-toolchain go1.22.2
+toolchain go1.23.4
 
 require (
 	github.com/a8m/envsubst v1.4.2

--- a/internal/controllers/nmc_reconciler_test.go
+++ b/internal/controllers/nmc_reconciler_test.go
@@ -384,10 +384,10 @@ var _ = Describe("NodeModulesConfigReconciler_Reconcile", func() {
 			wh.EXPECT().SyncStatus(ctx, nmc).Return(nil),
 			kubeClient.EXPECT().Get(ctx, types.NamespacedName{Name: nmc.Name}, &node).Return(nil),
 			nm.EXPECT().IsNodeSchedulable(&node, nil).Return(true),
-			wh.EXPECT().ProcessModuleSpec(contextWithValueMatch, nmc, &spec0, &status0, &node).Return(fmt.Errorf(errorMeassge)),
-			wh.EXPECT().ProcessUnconfiguredModuleStatus(contextWithValueMatch, nmc, &status2, &node).Return(fmt.Errorf(errorMeassge)),
-			wh.EXPECT().GarbageCollectInUseLabels(ctx, nmc).Return(fmt.Errorf(errorMeassge)),
-			wh.EXPECT().UpdateNodeLabels(ctx, nmc, &node).Return(nil, nil, fmt.Errorf(errorMeassge)),
+			wh.EXPECT().ProcessModuleSpec(contextWithValueMatch, nmc, &spec0, &status0, &node).Return(errors.New(errorMeassge)),
+			wh.EXPECT().ProcessUnconfiguredModuleStatus(contextWithValueMatch, nmc, &status2, &node).Return(errors.New(errorMeassge)),
+			wh.EXPECT().GarbageCollectInUseLabels(ctx, nmc).Return(errors.New(errorMeassge)),
+			wh.EXPECT().UpdateNodeLabels(ctx, nmc, &node).Return(nil, nil, errors.New(errorMeassge)),
 		)
 
 		_, err = r.Reconcile(ctx, req)


### PR DESCRIPTION
---

/assign @yevgeny-shnaidman @TomerNewman 
Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1283

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated `golangci-lint` version from `v1.53.1` to `v1.62.2`
	- Updated Go version from `1.21` to `1.23.0`
	- Updated toolchain version from `go1.22.2` to `go1.23.4`
	- Updated base images in multiple Dockerfiles to `golang:1.23`
	- Simplified lint command in CI script

- **Tests**
	- Improved error handling in test cases for `NodeModulesConfigReconciler`
	- Enhanced error reporting consistency in test scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->