### PR TITLE
Bumping to `go1.23` in Github workflows (CI).

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
     - if: matrix.language == 'go'
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version: '1.23'
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
---

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1284
/assign @yevgeny-shnaidman @TomerNewman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow to use Go version 1.23 for CodeQL analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->