### PR TITLE
Adding a `.` as a valid character for `Module`s' name.

### DIFF
--- a/internal/nmc/labels.go
+++ b/internal/nmc/labels.go
@@ -6,8 +6,8 @@ import (
 )
 
 var (
-	reConfiguredLabel = regexp.MustCompile(`^beta\.kmm\.node\.kubernetes\.io/([a-zA-Z0-9-]+)\.([a-zA-Z0-9-]+)\.module-configured$`)
-	reInUseLabel      = regexp.MustCompile(`^beta\.kmm\.node\.kubernetes\.io/([a-zA-Z0-9-]+)\.([a-zA-Z0-9-]+)\.module-in-use$`)
+	reConfiguredLabel = regexp.MustCompile(`^beta\.kmm\.node\.kubernetes\.io/([a-zA-Z0-9-]+)\.([a-zA-Z0-9-\.]+)\.module-configured$`)
+	reInUseLabel      = regexp.MustCompile(`^beta\.kmm\.node\.kubernetes\.io/([a-zA-Z0-9-]+)\.([a-zA-Z0-9-\.]+)\.module-in-use$`)
 )
 
 func IsModuleConfiguredLabel(s string) (bool, string, string) {

--- a/internal/nmc/labels_test.go
+++ b/internal/nmc/labels_test.go
@@ -14,6 +14,15 @@ var _ = Describe("ModuleConfiguredLabel", func() {
 			Equal("beta.kmm.node.kubernetes.io/a.b.module-configured"),
 		)
 	})
+
+	It("should work as expected with a dot in the name", func() {
+
+		Expect(
+			ModuleConfiguredLabel("a", "b.1"),
+		).To(
+			Equal("beta.kmm.node.kubernetes.io/a.b.1.module-configured"),
+		)
+	})
 })
 
 var _ = Describe("ModuleInUseLabel", func() {
@@ -23,6 +32,15 @@ var _ = Describe("ModuleInUseLabel", func() {
 			ModuleInUseLabel("a", "b"),
 		).To(
 			Equal("beta.kmm.node.kubernetes.io/a.b.module-in-use"),
+		)
+	})
+
+	It("should work as expected with a dot in the name", func() {
+
+		Expect(
+			ModuleInUseLabel("a", "b.1"),
+		).To(
+			Equal("beta.kmm.node.kubernetes.io/a.b.1.module-in-use"),
 		)
 	})
 })
@@ -47,6 +65,7 @@ var _ = Describe("IsModuleConfiguredLabel", func() {
 		Entry(nil, "beta.kmm.node.kubernetes.io/..module-configured", false, "", ""),
 		Entry(nil, "beta.kmm.node.kubernetes.io/a123.b456.module-configured", true, "a123", "b456"),
 		Entry(nil, "beta.kmm.node.kubernetes.io/with-hypen.withouthypen.module-configured", true, "with-hypen", "withouthypen"),
+		Entry(nil, "beta.kmm.node.kubernetes.io/my-namespace.my-name.stil-my-name.module-configured", true, "my-namespace", "my-name.stil-my-name"),
 	)
 })
 
@@ -70,5 +89,6 @@ var _ = Describe("IsModuleInUseLabel", func() {
 		Entry(nil, "beta.kmm.node.kubernetes.io/..module-in-use", false, "", ""),
 		Entry(nil, "beta.kmm.node.kubernetes.io/a123.b456.module-in-use", true, "a123", "b456"),
 		Entry(nil, "beta.kmm.node.kubernetes.io/with-hypen.withouthypen.module-in-use", true, "with-hypen", "withouthypen"),
+		Entry(nil, "beta.kmm.node.kubernetes.io/my-namespace.my-name.stil-my-name.module-in-use", true, "my-namespace", "my-name.stil-my-name"),
 	)
 })


### PR DESCRIPTION
When a `Module` is deleted, the `NMC` controller is removing the labels for this `Module` in the `NMC` object.

As long as those labels for a specific module exists, the module's finalizer will not be removed upon module deletion and the module will keep hanging forever if deleted.

When a module is created with a `.` in its name, the created label for `NMC` doesn't match the expected regexp for this label and, therefore, not removed upon module's deletion.

Adding the `.` will allow the label to match the regexp, be removed upon deletion and deleting the module gracefully.

---

/assign @yevgeny-shnaidman @TomerNewman 
Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1292 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated label matching to support additional characters (periods) in Kubernetes label names
	- Improved label validation to handle more complex naming conventions

- **Tests**
	- Added test cases to verify label parsing and generation with dot-containing names

<!-- end of auto-generated comment: release notes by coderabbit.ai -->