### PR TITLE
Changing the type of Generation from int to string

### DIFF
--- a/api/v1beta1/moduleimagesconfig_types.go
+++ b/api/v1beta1/moduleimagesconfig_types.go
@@ -41,7 +41,7 @@ type ModuleImageSpec struct {
 	// image
 	Image string `json:"image"`
 	// generation counter of the image config
-	Generation int `json:"generation"`
+	Generation string `json:"generation"`
 
 	// Build contains build instructions, in case image needs building
 	// +optional
@@ -70,7 +70,7 @@ type ModuleImageState struct {
 	// one of: Exists, notExists
 	Status ImageState `json:"status"`
 	// observedGeneration counter is updated on each status update
-	ObservedGeneration int `json:"observedGeneration"`
+	ObservedGeneration string `json:"observedGeneration"`
 }
 
 // ModuleImagesConfigStatus describes the status of the images that need to be verified (defined in the spec)

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -63,7 +63,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-01-30T07:49:32Z"
+    createdAt: "2025-01-30T09:14:13Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/config/crd/bases/kmm.sigs.x-k8s.io_modulebuildsignconfig.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_modulebuildsignconfig.yaml
@@ -155,7 +155,7 @@ spec:
                       type: object
                     generation:
                       description: generation counter of the image config
-                      type: integer
+                      type: string
                     image:
                       description: image
                       type: string
@@ -243,7 +243,7 @@ spec:
                     observedGeneration:
                       description: observedGeneration counter is updated on each status
                         update
-                      type: integer
+                      type: string
                     status:
                       description: |-
                         status of the image

--- a/config/crd/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -155,7 +155,7 @@ spec:
                       type: object
                     generation:
                       description: generation counter of the image config
-                      type: integer
+                      type: string
                     image:
                       description: image
                       type: string
@@ -243,7 +243,7 @@ spec:
                     observedGeneration:
                       description: observedGeneration counter is updated on each status
                         update
-                      type: integer
+                      type: string
                     status:
                       description: |-
                         status of the image


### PR DESCRIPTION
Generation is used only for exact comparison, and its value is stored also in the labels of the pull pods. It will be much easier to store it as a string, which will remove the necessaty to convert it back and forth

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **API Changes**
	- Modified generation and observed generation fields from integer to string type across multiple configuration resources
	- Updated type definitions in ModuleImagesConfig and ModuleBuildSignConfig Custom Resource Definitions
	- Updated ClusterServiceVersion manifest with a new creation timestamp

<!-- end of auto-generated comment: release notes by coderabbit.ai -->