### PR TITLE
Adding validation to module toleration effect

### DIFF
--- a/internal/webhook/module_test.go
+++ b/internal/webhook/module_test.go
@@ -18,6 +18,7 @@ package webhook
 
 import (
 	"context"
+	v1 "k8s.io/api/core/v1"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -550,4 +551,33 @@ var _ = Describe("ValidateDelete", func() {
 		_, err := moduleWebhook.ValidateDelete(context.TODO(), &kmmv1beta1.Module{})
 		Expect(err).To(MatchError(NotImplemented))
 	})
+})
+
+var _ = Describe("validateModuleTolerarations", func() {
+	It("should fail when Module has an invalid toleration effect", func() {
+		mod := validModule
+		mod.Spec.Tolerations = []v1.Toleration{
+			{
+				Key: "Test-Key1", Operator: "Test-Equal1", Value: "Test-Value1", Effect: v1.TaintEffectPreferNoSchedule,
+			},
+			{
+				Key: "Test-Key2", Operator: "Test-Equal2", Value: "Test-Value2", Effect: "Test-Effect",
+			},
+		}
+
+		err := validateModuleTolerarations(&mod)
+		Expect(err).To(HaveOccurred())
+	})
+	It("should work when all tolerations have valid effects ", func() {
+		mod := validModule
+		mod.Spec.Tolerations = []v1.Toleration{
+			{
+				Key: "Test-Key", Operator: "Test-Equal", Value: "Test-Value", Effect: v1.TaintEffectPreferNoSchedule,
+			},
+		}
+
+		err := validateModuleTolerarations(&mod)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
 })


### PR DESCRIPTION
Users can add a toleration to Module with
invalid effects (for example "blabla").
This commit adds a webhook validation
to the toleration effect value, ensuring only:
NoExecute,  NoSchedule, PreferNoSchedule
can be applied.

---

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1326

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation for Kubernetes module tolerations
  - Implemented checks to ensure only valid toleration effects are used

- **Tests**
  - Added comprehensive test coverage for toleration validation logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->