### PR TITLE
Adding `ModuleImagesConfig` and `ModuleBuildSignConfig` CRDs manifests.

### DIFF
--- a/api/v1beta1/modulebuildsignconfig_types.go
+++ b/api/v1beta1/modulebuildsignconfig_types.go
@@ -24,7 +24,7 @@ import (
 // +kubebuilder:subresource:status
 
 // ModuleBuildSignConfig keeps the request for images' build/sign for a KMM Module.
-// +kubebuilder:resource:path=modulebuildsignconfig,scope=Namespaced,shortName=mbsc
+// +kubebuilder:resource:path=modulebuildsignconfigs,scope=Namespaced,shortName=mbsc
 // +operator-sdk:csv:customresourcedefinitions:displayName="Module Build Sign Config"
 type ModuleBuildSignConfig struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/api/v1beta1/nodemodulesconfig_types.go
+++ b/api/v1beta1/nodemodulesconfig_types.go
@@ -85,7 +85,6 @@ type NodeModulesConfigStatus struct {
 // +kubebuilder:subresource:status
 
 // NodeModulesConfig keeps spec and state of the KMM modules on a node.
-// +kubebuilder:resource:path=nodemodulesconfigs,scope=Cluster
 // +kubebuilder:resource:path=nodemodulesconfigs,scope=Cluster,shortName=nmc
 // +operator-sdk:csv:customresourcedefinitions:displayName="Node Modules Config"
 type NodeModulesConfig struct {

--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-01-30T12:27:43Z"
+    createdAt: "2025-02-03T08:50:59Z"
     operatorframework.io/suggested-namespace: openshift-kmm-hub
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -63,7 +63,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-01-30T12:27:42Z"
+    createdAt: "2025-02-03T08:50:57Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -78,6 +78,12 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
+    - kind: ModuleBuildSignConfig
+      name: modulebuildsignconfigs.kmm.sigs.x-k8s.io
+      version: v1beta1
+    - kind: ModuleImagesConfig
+      name: moduleimagesconfigs.kmm.sigs.x-k8s.io
+      version: v1beta1
     - description: Module describes how to load a module on different kernel versions
       displayName: Module
       kind: Module

--- a/bundle/manifests/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
+++ b/bundle/manifests/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
@@ -1,0 +1,271 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kmm
+    app.kubernetes.io/name: kmm
+    app.kubernetes.io/part-of: kmm
+  name: modulebuildsignconfigs.kmm.sigs.x-k8s.io
+spec:
+  group: kmm.sigs.x-k8s.io
+  names:
+    kind: ModuleBuildSignConfig
+    listKind: ModuleBuildSignConfigList
+    plural: modulebuildsignconfigs
+    shortNames:
+    - mbsc
+    singular: modulebuildsignconfig
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ModuleBuildSignConfig keeps the request for images' build/sign
+          for a KMM Module.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              ModuleImagesConfigSpec describes the images of the Module whose status needs to be verified
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              imageRepoSecret:
+                description: ImageRepoSecret contains pull secret for the image's
+                  repo, if needed
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              images:
+                items:
+                  description: ModuleImageSpec describes the image whose state needs
+                    to be queried
+                  properties:
+                    build:
+                      description: Build contains build instructions, in case image
+                        needs building
+                      properties:
+                        baseImageRegistryTLS:
+                          description: BaseImageRegistryTLS contains settings determining
+                            how to access registries of the base images in the build-process'
+                            Dockerfile.
+                          properties:
+                            insecure:
+                              description: If Insecure is true, the operator will
+                                be able to access a registry in an insecure (plain
+                                HTTP) protocol.
+                              type: boolean
+                            insecureSkipTLSVerify:
+                              description: If InsecureSkipTLSVerify, the operator
+                                will accept any certificate provided by the registry.
+                              type: boolean
+                          type: object
+                        buildArgs:
+                          description: BuildArgs is an array of build variables that
+                            are provided to the image building backend.
+                          items:
+                            description: BuildArg represents a build argument used
+                              when building a container image.
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        dockerfileConfigMap:
+                          description: ConfigMap that holds Dockerfile contents
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        kanikoParams:
+                          description: KanikoParams is used to customize the building
+                            process of the image.
+                          properties:
+                            tag:
+                              description: Kaniko image tag to use when creating the
+                                build Job
+                              type: string
+                          type: object
+                        secrets:
+                          description: |-
+                            Secrets is an optional list of secrets to be made available to the build system.
+                            Those secrets should be used for private resources such as a private Github repo.
+                            For container registries auth use module.spec.imagePullSecret instead.
+                          items:
+                            description: |-
+                              LocalObjectReference contains enough information to let you locate the
+                              referenced object inside the same namespace.
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                        selector:
+                          additionalProperties:
+                            type: string
+                          description: Selector describes on which nodes will run
+                            the building process.
+                          type: object
+                      required:
+                      - dockerfileConfigMap
+                      type: object
+                    image:
+                      description: image
+                      type: string
+                    sign:
+                      description: Sign contains sign instructions, in case image
+                        needs signing
+                      properties:
+                        certSecret:
+                          description: a secret containing the public key used to
+                            sign kernel modules for secureboot
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        filesToSign:
+                          description: paths inside the image for the kernel modules
+                            to sign (if ommited all kmods are signed)
+                          items:
+                            type: string
+                          type: array
+                        keySecret:
+                          description: a secret containing the private key used to
+                            sign kernel modules for secureboot
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        unsignedImage:
+                          description: Image to sign, ignored if a Build is present,
+                            required otherwise
+                          type: string
+                        unsignedImageRegistryTLS:
+                          description: UnsignedImageRegistryTLS contains settings
+                            determining how to access registries of the unsigned image.
+                          properties:
+                            insecure:
+                              description: If Insecure is true, the operator will
+                                be able to access a registry in an insecure (plain
+                                HTTP) protocol.
+                              type: boolean
+                            insecureSkipTLSVerify:
+                              description: If InsecureSkipTLSVerify, the operator
+                                will accept any certificate provided by the registry.
+                              type: boolean
+                          type: object
+                      required:
+                      - certSecret
+                      - keySecret
+                      type: object
+                  required:
+                  - image
+                  type: object
+                type: array
+              regeneration:
+                description: updating counter triggers a new reconcilation
+                format: int64
+                type: integer
+            required:
+            - images
+            - regeneration
+            type: object
+          status:
+            description: |-
+              ModuleImagesConfigStatus describes the status of the images that need to be verified (defined in the spec)
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              imagesStates:
+                items:
+                  properties:
+                    image:
+                      description: image
+                      type: string
+                    status:
+                      description: |-
+                        status of the image
+                        one of: Exists, notExists
+                      type: string
+                  required:
+                  - image
+                  - status
+                  type: object
+                type: array
+            required:
+            - imagesStates
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/bundle/manifests/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -1,0 +1,271 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kmm
+    app.kubernetes.io/name: kmm
+    app.kubernetes.io/part-of: kmm
+  name: moduleimagesconfigs.kmm.sigs.x-k8s.io
+spec:
+  group: kmm.sigs.x-k8s.io
+  names:
+    kind: ModuleImagesConfig
+    listKind: ModuleImagesConfigList
+    plural: moduleimagesconfigs
+    shortNames:
+    - mic
+    singular: moduleimagesconfig
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ModuleImagesConfig keeps the request for images' state for a
+          KMM Module.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              ModuleImagesConfigSpec describes the images of the Module whose status needs to be verified
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              imageRepoSecret:
+                description: ImageRepoSecret contains pull secret for the image's
+                  repo, if needed
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              images:
+                items:
+                  description: ModuleImageSpec describes the image whose state needs
+                    to be queried
+                  properties:
+                    build:
+                      description: Build contains build instructions, in case image
+                        needs building
+                      properties:
+                        baseImageRegistryTLS:
+                          description: BaseImageRegistryTLS contains settings determining
+                            how to access registries of the base images in the build-process'
+                            Dockerfile.
+                          properties:
+                            insecure:
+                              description: If Insecure is true, the operator will
+                                be able to access a registry in an insecure (plain
+                                HTTP) protocol.
+                              type: boolean
+                            insecureSkipTLSVerify:
+                              description: If InsecureSkipTLSVerify, the operator
+                                will accept any certificate provided by the registry.
+                              type: boolean
+                          type: object
+                        buildArgs:
+                          description: BuildArgs is an array of build variables that
+                            are provided to the image building backend.
+                          items:
+                            description: BuildArg represents a build argument used
+                              when building a container image.
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        dockerfileConfigMap:
+                          description: ConfigMap that holds Dockerfile contents
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        kanikoParams:
+                          description: KanikoParams is used to customize the building
+                            process of the image.
+                          properties:
+                            tag:
+                              description: Kaniko image tag to use when creating the
+                                build Job
+                              type: string
+                          type: object
+                        secrets:
+                          description: |-
+                            Secrets is an optional list of secrets to be made available to the build system.
+                            Those secrets should be used for private resources such as a private Github repo.
+                            For container registries auth use module.spec.imagePullSecret instead.
+                          items:
+                            description: |-
+                              LocalObjectReference contains enough information to let you locate the
+                              referenced object inside the same namespace.
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                        selector:
+                          additionalProperties:
+                            type: string
+                          description: Selector describes on which nodes will run
+                            the building process.
+                          type: object
+                      required:
+                      - dockerfileConfigMap
+                      type: object
+                    image:
+                      description: image
+                      type: string
+                    sign:
+                      description: Sign contains sign instructions, in case image
+                        needs signing
+                      properties:
+                        certSecret:
+                          description: a secret containing the public key used to
+                            sign kernel modules for secureboot
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        filesToSign:
+                          description: paths inside the image for the kernel modules
+                            to sign (if ommited all kmods are signed)
+                          items:
+                            type: string
+                          type: array
+                        keySecret:
+                          description: a secret containing the private key used to
+                            sign kernel modules for secureboot
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        unsignedImage:
+                          description: Image to sign, ignored if a Build is present,
+                            required otherwise
+                          type: string
+                        unsignedImageRegistryTLS:
+                          description: UnsignedImageRegistryTLS contains settings
+                            determining how to access registries of the unsigned image.
+                          properties:
+                            insecure:
+                              description: If Insecure is true, the operator will
+                                be able to access a registry in an insecure (plain
+                                HTTP) protocol.
+                              type: boolean
+                            insecureSkipTLSVerify:
+                              description: If InsecureSkipTLSVerify, the operator
+                                will accept any certificate provided by the registry.
+                              type: boolean
+                          type: object
+                      required:
+                      - certSecret
+                      - keySecret
+                      type: object
+                  required:
+                  - image
+                  type: object
+                type: array
+              regeneration:
+                description: updating counter triggers a new reconcilation
+                format: int64
+                type: integer
+            required:
+            - images
+            - regeneration
+            type: object
+          status:
+            description: |-
+              ModuleImagesConfigStatus describes the status of the images that need to be verified (defined in the spec)
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              imagesStates:
+                items:
+                  properties:
+                    image:
+                      description: image
+                      type: string
+                    status:
+                      description: |-
+                        status of the image
+                        one of: Exists, notExists
+                      type: string
+                  required:
+                  - image
+                  - status
+                  type: object
+                type: array
+            required:
+            - imagesStates
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/config/crd/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
@@ -4,13 +4,13 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.16.1
-  name: modulebuildsignconfig.kmm.sigs.x-k8s.io
+  name: modulebuildsignconfigs.kmm.sigs.x-k8s.io
 spec:
   group: kmm.sigs.x-k8s.io
   names:
     kind: ModuleBuildSignConfig
     listKind: ModuleBuildSignConfigList
-    plural: modulebuildsignconfig
+    plural: modulebuildsignconfigs
     shortNames:
     - mbsc
     singular: modulebuildsignconfig

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -7,6 +7,8 @@ kind: Kustomization
 resources:
 - bases/kmm.sigs.x-k8s.io_modules.yaml
 - bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
+- bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+- bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
 - bases/kmm.sigs.x-k8s.io_preflightvalidations.yaml
 - bases/kmm.sigs.x-k8s.io_preflightvalidationsocp.yaml
 #+kubebuilder:scaffold:crdkustomizeresource


### PR DESCRIPTION
Those are new API objects that were recently introduced but were not added to the manifest files.

---

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1333
/assign @yevgeny-shnaidman @TomerNewman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new custom resources for managing kernel module build signing and image configurations.
  - Upgraded preflight validation resources to an improved API version.

- **Chores**
  - Refined resource naming conventions for greater consistency.
  - Updated metadata timestamps to reflect the latest deployment information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->