### PR TITLE
Adding tolerations specifications from Module to device plugin pods

### DIFF
--- a/internal/controllers/device_plugin_reconciler.go
+++ b/internal/controllers/device_plugin_reconciler.go
@@ -400,6 +400,7 @@ func (dsci *daemonSetCreatorImpl) setDevicePluginAsDesired(
 				NodeSelector:       nodeSelector,
 				ServiceAccountName: serviceAccountName,
 				Volumes:            append([]v1.Volume{devicePluginVolume}, mod.Spec.DevicePlugin.Volumes...),
+				Tolerations:        mod.Spec.Tolerations,
 			},
 		},
 	}

--- a/internal/controllers/device_plugin_reconciler_test.go
+++ b/internal/controllers/device_plugin_reconciler_test.go
@@ -654,6 +654,12 @@ var _ = Describe("DevicePluginReconciler_setDevicePluginAsDesired", func() {
 		args := []string{"some", "args"}
 		command := []string{"some", "command"}
 
+		testToleration := v1.Toleration{
+			Key:    "test-key",
+			Value:  "test-value",
+			Effect: v1.TaintEffectNoExecute,
+		}
+
 		const ipp = v1.PullIfNotPresent
 
 		mod := kmmv1beta1.Module{
@@ -681,6 +687,7 @@ var _ = Describe("DevicePluginReconciler_setDevicePluginAsDesired", func() {
 				},
 				ImageRepoSecret: &repoSecret,
 				Selector:        map[string]string{"has-feature-x": "true"},
+				Tolerations:     []v1.Toleration{testToleration},
 			},
 		}
 		ds := appsv1.DaemonSet{
@@ -759,6 +766,7 @@ var _ = Describe("DevicePluginReconciler_setDevicePluginAsDesired", func() {
 							},
 							dpVol,
 						},
+						Tolerations: []v1.Toleration{testToleration},
 					},
 				},
 			},


### PR DESCRIPTION
Curently tolerations are applied only to worker pods, but not to the DevicePlugin pod. This PR adds the toleration definition from Module to the DevicePlugin's pod.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced custom toleration settings for device scheduling, allowing deployments to better accommodate diverse node conditions and improve overall scheduling flexibility.

- **Tests**
  - Updated test cases to ensure the new toleration settings are correctly applied and validated, enhancing confidence in deployment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->