### PR TITLE
Adding validation to module toleration operator value

### DIFF
--- a/internal/webhook/module.go
+++ b/internal/webhook/module.go
@@ -110,7 +110,7 @@ func validateModule(mod *kmmv1beta1.Module) (admission.Warnings, error) {
 		return nil, fmt.Errorf("failed to validate kernel mappings: %v", err)
 	}
 
-	if err := validateModuleTolerarations(mod); err != nil {
+	if err := validateModuleTolerations(mod); err != nil {
 		return nil, fmt.Errorf("failed to validate Module's tolerations: %v", err)
 	}
 
@@ -212,13 +212,17 @@ func validateModprobe(modprobe kmmv1beta1.ModprobeSpec) error {
 
 	return nil
 }
-func validateModuleTolerarations(mod *kmmv1beta1.Module) error {
+func validateModuleTolerations(mod *kmmv1beta1.Module) error {
 	for _, toleration := range mod.Spec.Tolerations {
-		switch toleration.Effect {
-		case corev1.TaintEffectNoSchedule, corev1.TaintEffectNoExecute, corev1.TaintEffectPreferNoSchedule:
-			continue
-		default:
-			return fmt.Errorf("invalid toleration effect %s. allowed values are NoSchedule, NoExecute, PreferNoSchedule", toleration.Effect)
+
+		if toleration.Operator != corev1.TolerationOpExists && toleration.Operator != corev1.TolerationOpEqual {
+			return fmt.Errorf("toleration operator can be only {Exists, Equal} but got %s", toleration.Operator)
+		}
+
+		if toleration.Effect != corev1.TaintEffectNoSchedule &&
+			toleration.Effect != corev1.TaintEffectNoExecute &&
+			toleration.Effect != corev1.TaintEffectPreferNoSchedule {
+			return fmt.Errorf("toleration effect can be only {NoSchedule, NoExecute, PreferNoSchedule} but got %s", toleration.Effect)
 		}
 	}
 	return nil

--- a/internal/webhook/module_test.go
+++ b/internal/webhook/module_test.go
@@ -558,25 +558,45 @@ var _ = Describe("validateModuleTolerarations", func() {
 		mod := validModule
 		mod.Spec.Tolerations = []v1.Toleration{
 			{
-				Key: "Test-Key1", Operator: "Test-Equal1", Value: "Test-Value1", Effect: v1.TaintEffectPreferNoSchedule,
+				Key: "Test-Key1", Operator: v1.TolerationOpEqual, Value: "Test-Value1", Effect: v1.TaintEffectPreferNoSchedule,
 			},
 			{
-				Key: "Test-Key2", Operator: "Test-Equal2", Value: "Test-Value2", Effect: "Test-Effect",
+				Key: "Test-Key2", Operator: v1.TolerationOpExists, Value: "Test-Value2", Effect: "Invalid-Effect",
 			},
 		}
 
-		err := validateModuleTolerarations(&mod)
+		err := validateModuleTolerations(&mod)
+		Expect(err).To(HaveOccurred())
+	})
+	It("should fail when Module has an invalid toleration operator", func() {
+		mod := validModule
+		mod.Spec.Tolerations = []v1.Toleration{
+			{
+				Key: "Test-Key1", Operator: v1.TolerationOpEqual, Value: "Test-Value1", Effect: v1.TaintEffectPreferNoSchedule,
+			},
+			{
+				Key: "Test-Key2", Operator: "Invalid-operator-value", Value: "Test-Value2", Effect: v1.TaintEffectNoExecute,
+			},
+		}
+
+		err := validateModuleTolerations(&mod)
 		Expect(err).To(HaveOccurred())
 	})
 	It("should work when all tolerations have valid effects ", func() {
 		mod := validModule
 		mod.Spec.Tolerations = []v1.Toleration{
 			{
-				Key: "Test-Key", Operator: "Test-Equal", Value: "Test-Value", Effect: v1.TaintEffectPreferNoSchedule,
+				Key: "Test-Key1", Operator: v1.TolerationOpExists, Value: "Test-Value", Effect: v1.TaintEffectPreferNoSchedule,
+			},
+			{
+				Key: "Test-Key2", Operator: v1.TolerationOpEqual, Value: "Test-Value", Effect: v1.TaintEffectNoSchedule,
+			},
+			{
+				Key: "Test-Key3", Operator: v1.TolerationOpEqual, Value: "Test-Value", Effect: v1.TaintEffectNoExecute,
 			},
 		}
 
-		err := validateModuleTolerarations(&mod)
+		err := validateModuleTolerations(&mod)
 		Expect(err).ToNot(HaveOccurred())
 	})
 


### PR DESCRIPTION
Users can add a toleration to Module with invalid operator values (for example "invalid123"). This commit adds a webhook validation to the toleration operator value, ensuring only: Exists, Equal operator values can be applied.

---

/cc @ybettan @yevgeny-shnaidman 
fixes #1345 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced module configuration validation to enforce stricter checks and provide clearer error messages for invalid inputs.
- **Tests**
  - Expanded test cases to cover various invalid configuration scenarios, ensuring robust behavior across edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->