### PR TITLE
Generating `ModuleConfigImages` objects during `Module` reconciliation.

### DIFF
--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-02-05T08:03:25Z"
+    createdAt: "2025-02-09T09:29:55Z"
     operatorframework.io/suggested-namespace: openshift-kmm-hub
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -63,7 +63,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-02-05T08:03:23Z"
+    createdAt: "2025-02-09T09:29:53Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -209,6 +209,18 @@ spec:
         - apiGroups:
           - kmm.sigs.x-k8s.io
           resources:
+          - moduleimagesconfigs
+          - nodemodulesconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - kmm.sigs.x-k8s.io
+          resources:
           - modules
           - preflightvalidations/status
           - preflightvalidationsocp
@@ -235,17 +247,6 @@ spec:
           - get
           - patch
           - update
-        - apiGroups:
-          - kmm.sigs.x-k8s.io
-          resources:
-          - nodemodulesconfigs
-          verbs:
-          - create
-          - delete
-          - get
-          - list
-          - patch
-          - watch
         - apiGroups:
           - kmm.sigs.x-k8s.io
           resources:

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strconv"
 
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/mic"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/node"
 
 	buildv1 "github.com/openshift/api/build/v1"
@@ -141,6 +142,7 @@ func main() {
 	)
 
 	kernelAPI := module.NewKernelMapper(buildHelperAPI, sign.NewSignerHelper())
+	micAPI := mic.NewModuleImagesConfigAPI(client, scheme)
 
 	dpc := controllers.NewDevicePluginReconciler(
 		client,
@@ -163,6 +165,7 @@ func main() {
 		client,
 		kernelAPI,
 		registryAPI,
+		micAPI,
 		nmcHelper,
 		filterAPI,
 		nodeAPI,

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -87,6 +87,18 @@ rules:
 - apiGroups:
   - kmm.sigs.x-k8s.io
   resources:
+  - moduleimagesconfigs
+  - nodemodulesconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - kmm.sigs.x-k8s.io
+  resources:
   - modules
   - preflightvalidations/status
   - preflightvalidationsocp
@@ -113,17 +125,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - kmm.sigs.x-k8s.io
-  resources:
-  - nodemodulesconfigs
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - watch
 - apiGroups:
   - kmm.sigs.x-k8s.io
   resources:

--- a/internal/controllers/mock_module_reconciler.go
+++ b/internal/controllers/mock_module_reconciler.go
@@ -99,6 +99,20 @@ func (mr *MockmoduleReconcilerHelperAPIMockRecorder) getNMCsByModuleSet(ctx, mod
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getNMCsByModuleSet", reflect.TypeOf((*MockmoduleReconcilerHelperAPI)(nil).getNMCsByModuleSet), ctx, mod)
 }
 
+// handleMIC mocks base method.
+func (m *MockmoduleReconcilerHelperAPI) handleMIC(ctx context.Context, mod *v1beta1.Module, nodes []v1.Node) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "handleMIC", ctx, mod, nodes)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// handleMIC indicates an expected call of handleMIC.
+func (mr *MockmoduleReconcilerHelperAPIMockRecorder) handleMIC(ctx, mod, nodes any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleMIC", reflect.TypeOf((*MockmoduleReconcilerHelperAPI)(nil).handleMIC), ctx, mod, nodes)
+}
+
 // moduleUpdateWorkerPodsStatus mocks base method.
 func (m *MockmoduleReconcilerHelperAPI) moduleUpdateWorkerPodsStatus(ctx context.Context, mod *v1beta1.Module, targetedNodes []v1.Node) error {
 	m.ctrl.T.Helper()

--- a/internal/controllers/module_reconciler_test.go
+++ b/internal/controllers/module_reconciler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/meta"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/mic"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/module"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/nmc"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/node"
@@ -40,6 +41,7 @@ var _ = Describe("Reconcile", func() {
 		mod                 *kmmv1beta1.Module
 		mr                  *ModuleReconciler
 		mn                  *node.MockNode
+		mockMicAPI          *mic.MockMIC
 	)
 
 	BeforeEach(func() {
@@ -47,6 +49,7 @@ var _ = Describe("Reconcile", func() {
 		mockNamespaceHelper = NewMocknamespaceLabeler(ctrl)
 		mockReconHelper = NewMockmoduleReconcilerHelperAPI(ctrl)
 		mn = node.NewMockNode(ctrl)
+		mockMicAPI = mic.NewMockMIC(ctrl)
 
 		mod = &kmmv1beta1.Module{
 			ObjectMeta: metav1.ObjectMeta{Name: moduleName, Namespace: namespace},
@@ -56,6 +59,7 @@ var _ = Describe("Reconcile", func() {
 			nsLabeler:   mockNamespaceHelper,
 			reconHelper: mockReconHelper,
 			nodeAPI:     mn,
+			micAPI:      mockMicAPI,
 		}
 	})
 
@@ -88,6 +92,7 @@ var _ = Describe("Reconcile", func() {
 	type errorFlowTestCase struct {
 		setFinalizerAndStatusError bool
 		getNodesError              bool
+		handleMICError             bool
 		getNMCsMapError            bool
 		prepareSchedulingError     bool
 		shouldBeOnNode             bool
@@ -118,6 +123,12 @@ var _ = Describe("Reconcile", func() {
 			goto executeTestFunction
 		}
 		mn.EXPECT().GetNodesListBySelector(ctx, mod.Spec.Selector, nil).Return(targetedNodes, nil)
+		if c.handleMICError {
+			mockReconHelper.EXPECT().handleMIC(ctx, mod, targetedNodes).Return(returnedError)
+			goto executeTestFunction
+		} else {
+			mockReconHelper.EXPECT().handleMIC(ctx, mod, targetedNodes).Return(nil)
+		}
 		if c.getNMCsMapError {
 			mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, mod).Return(nil, returnedError)
 			goto executeTestFunction
@@ -157,6 +168,7 @@ var _ = Describe("Reconcile", func() {
 	},
 		Entry("setFinalizerAndStatus failed", errorFlowTestCase{setFinalizerAndStatusError: true}),
 		Entry("getNodesListBySelector failed", errorFlowTestCase{getNodesError: true}),
+		Entry("handleMIC failed", errorFlowTestCase{handleMICError: true}),
 		Entry("getNMCsByModuleMap failed", errorFlowTestCase{getNMCsMapError: true}),
 		Entry("prepareSchedulingData failed", errorFlowTestCase{prepareSchedulingError: true}),
 		Entry("enableModuleOnNode failed", errorFlowTestCase{shouldBeOnNode: true, disableEnableError: true}),
@@ -171,6 +183,7 @@ var _ = Describe("Reconcile", func() {
 			mockNamespaceHelper.EXPECT().setLabel(ctx, mod.Namespace),
 			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, mod).Return(nil),
 			mn.EXPECT().GetNodesListBySelector(ctx, mod.Spec.Selector, nil).Return(targetedNodes, nil),
+			mockReconHelper.EXPECT().handleMIC(ctx, mod, targetedNodes).Return(nil),
 			mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, mod).Return(currentNMCs, nil),
 			mockReconHelper.EXPECT().prepareSchedulingData(ctx, mod, targetedNodes, currentNMCs).Return(nmcMLDConfigs, nil),
 			mockReconHelper.EXPECT().enableModuleOnNode(ctx, &mld, &node).Return(nil),
@@ -189,6 +202,7 @@ var _ = Describe("Reconcile", func() {
 			mockNamespaceHelper.EXPECT().setLabel(ctx, mod.Namespace),
 			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, mod).Return(nil),
 			mn.EXPECT().GetNodesListBySelector(ctx, mod.Spec.Selector, nil).Return(targetedNodes, nil),
+			mockReconHelper.EXPECT().handleMIC(ctx, mod, targetedNodes).Return(nil),
 			mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, mod).Return(currentNMCs, nil),
 			mockReconHelper.EXPECT().prepareSchedulingData(ctx, mod, targetedNodes, currentNMCs).Return(nmcMLDConfigs, nil),
 			mockReconHelper.EXPECT().disableModuleOnNode(ctx, mod.Namespace, mod.Name, node.Name).Return(nil),
@@ -216,7 +230,7 @@ var _ = Describe("setFinalizerAndStatus", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
 		statusWriter = client.NewMockStatusWriter(ctrl)
-		mrh = newModuleReconcilerHelper(clnt, nil, nil, nil, nil, operatorNamespace, scheme)
+		mrh = newModuleReconcilerHelper(clnt, nil, nil, nil, nil, nil, operatorNamespace, scheme)
 		mod = kmmv1beta1.Module{}
 		expectedMod = mod.DeepCopy()
 	})
@@ -279,7 +293,7 @@ var _ = Describe("finalizeModule", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
 		helper = nmc.NewMockHelper(ctrl)
-		mrh = newModuleReconcilerHelper(clnt, nil, nil, helper, nil, operatorNamespace, scheme)
+		mrh = newModuleReconcilerHelper(clnt, nil, nil, nil, helper, nil, operatorNamespace, scheme)
 		mod = &kmmv1beta1.Module{
 			ObjectMeta: metav1.ObjectMeta{Name: moduleName, Namespace: moduleNamespace},
 		}
@@ -379,6 +393,88 @@ var _ = Describe("finalizeModule", func() {
 	})
 })
 
+var _ = Describe("handleMIC", func() {
+
+	const (
+		moduleName      = "moduleName"
+		moduleNamespace = "moduleNamespace"
+	)
+
+	var (
+		ctx              context.Context
+		ctrl             *gomock.Controller
+		clnt             *client.MockClient
+		mockKernelMapper *module.MockKernelMapper
+		mockMICAPI       *mic.MockMIC
+		helper           *nmc.MockHelper
+		mrh              moduleReconcilerHelperAPI
+		mod              *kmmv1beta1.Module
+		targetedNodes    []v1.Node
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		mockKernelMapper = module.NewMockKernelMapper(ctrl)
+		mockMICAPI = mic.NewMockMIC(ctrl)
+		helper = nmc.NewMockHelper(ctrl)
+		mrh = newModuleReconcilerHelper(clnt, mockKernelMapper, nil, mockMICAPI, helper, nil, operatorNamespace, scheme)
+		mod = &kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      moduleName,
+				Namespace: moduleNamespace,
+			},
+			Spec: kmmv1beta1.ModuleSpec{
+				ImageRepoSecret: &v1.LocalObjectReference{
+					Name: "my-secret",
+				},
+			},
+		}
+		targetedNodes = []v1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: nodeName,
+				},
+			},
+		}
+	})
+
+	It("should return an error if we failed to get moduleLoaderData for kernel", func() {
+
+		mockKernelMapper.EXPECT().GetModuleLoaderDataForKernel(mod, gomock.Any()).Return(nil, errors.New("some error"))
+		mockMICAPI.EXPECT().ApplyMIC(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret, mod).Return(nil)
+
+		err := mrh.handleMIC(ctx, mod, targetedNodes)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to get moduleLoaderData for kernel"))
+	})
+
+	It("should return an error if we failed to apply the MIC", func() {
+
+		img := "example.registry.com/org/image:tag"
+		mld := &api.ModuleLoaderData{ContainerImage: img}
+		mockKernelMapper.EXPECT().GetModuleLoaderDataForKernel(mod, gomock.Any()).Return(mld, nil)
+		mockMICAPI.EXPECT().ApplyMIC(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret,
+			mod).Return(errors.New("some error"))
+
+		err := mrh.handleMIC(ctx, mod, targetedNodes)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to apply"))
+	})
+
+	It("should work as expected", func() {
+
+		img := "example.registry.com/org/image:tag"
+		mld := &api.ModuleLoaderData{ContainerImage: img}
+		mockKernelMapper.EXPECT().GetModuleLoaderDataForKernel(mod, gomock.Any()).Return(mld, nil)
+		mockMICAPI.EXPECT().ApplyMIC(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret, mod).Return(nil)
+
+		err := mrh.handleMIC(ctx, mod, targetedNodes)
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
 var _ = Describe("getNMCsByModuleSet", func() {
 	var (
 		ctrl *gomock.Controller
@@ -389,7 +485,7 @@ var _ = Describe("getNMCsByModuleSet", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
-		mrh = newModuleReconcilerHelper(clnt, nil, nil, nil, nil, operatorNamespace, scheme)
+		mrh = newModuleReconcilerHelper(clnt, nil, nil, nil, nil, nil, operatorNamespace, scheme)
 	})
 
 	ctx := context.Background()
@@ -454,7 +550,7 @@ var _ = Describe("prepareSchedulingData", func() {
 		clnt = client.NewMockClient(ctrl)
 		mockKernel = module.NewMockKernelMapper(ctrl)
 		mockHelper = nmc.NewMockHelper(ctrl)
-		mrh = newModuleReconcilerHelper(clnt, mockKernel, nil, mockHelper, nil, operatorNamespace, scheme)
+		mrh = newModuleReconcilerHelper(clnt, mockKernel, nil, nil, mockHelper, nil, operatorNamespace, scheme)
 		node = v1.Node{
 			ObjectMeta: metav1.ObjectMeta{Name: nodeName},
 			Status: v1.NodeStatus{
@@ -653,7 +749,7 @@ var _ = Describe("enableModuleOnNode", func() {
 		rgst = registry.NewMockRegistry(ctrl)
 		authFactory = auth.NewMockRegistryAuthGetterFactory(ctrl)
 		authGetter = &auth.MockRegistryAuthGetter{}
-		mrh = newModuleReconcilerHelper(clnt, nil, rgst, helper, authFactory, operatorNamespace, scheme)
+		mrh = newModuleReconcilerHelper(clnt, nil, rgst, nil, helper, authFactory, operatorNamespace, scheme)
 		node = v1.Node{
 			ObjectMeta: metav1.ObjectMeta{Name: "nodeName"},
 		}
@@ -770,7 +866,7 @@ var _ = Describe("disableModuleOnNode", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
 		helper = nmc.NewMockHelper(ctrl)
-		mrh = newModuleReconcilerHelper(clnt, nil, nil, helper, nil, operatorNamespace, scheme)
+		mrh = newModuleReconcilerHelper(clnt, nil, nil, nil, helper, nil, operatorNamespace, scheme)
 		nodeName = "node name"
 		moduleName = "moduleName"
 		moduleNamespace = "moduleNamespace"

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -198,6 +198,13 @@ func (f *Filter) ImageStreamReconcilerPredicate() predicate.Predicate {
 	}
 }
 
+func ModuleReconcileMICPredicate() predicate.Predicate {
+	return predicate.And(
+		skipCreations,
+		skipDeletions,
+	)
+}
+
 func NodeUpdateKernelChangedPredicate() predicate.Predicate {
 	return predicate.Funcs{
 		UpdateFunc: func(updateEvent event.UpdateEvent) bool {


### PR DESCRIPTION
The `Module` reconciler will now generate and update `ModuleImagesConfig`s objects in the cluster.

At this point, those objects aren't reconciled by any controller but they will in the upcoming commits. For this reason, the `Module` controller isn't checking the `MIC`'s status but instead keep checking if images exists using direct HTTP calls.

---

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1354
/assign @TomerNewman @yevgeny-shnaidman 