### PR TITLE
Use the correct pull secret for image pulls in builds

### DIFF
--- a/internal/build/ocpbuild/maker.go
+++ b/internal/build/ocpbuild/maker.go
@@ -153,8 +153,9 @@ func (m *maker) MakeBuildTemplate(
 				Strategy: buildv1.BuildStrategy{
 					Type: buildv1.DockerBuildStrategyType,
 					DockerStrategy: &buildv1.DockerBuildStrategy{
-						BuildArgs: envVarsFromKMMBuildArgs(buildArgs),
-						Volumes:   buildVolumesFromBuildSecrets(kmmBuild.Secrets),
+						BuildArgs:  envVarsFromKMMBuildArgs(buildArgs),
+						Volumes:    buildVolumesFromBuildSecrets(kmmBuild.Secrets),
+						PullSecret: mld.ImageRepoSecret,
 					},
 				},
 				Output:         buildTarget,

--- a/internal/build/ocpbuild/maker_test.go
+++ b/internal/build/ocpbuild/maker_test.go
@@ -144,7 +144,8 @@ var _ = Describe("Maker_MakeBuildTemplate", func() {
 								v1.EnvVar{Name: "MOD_NAME", Value: moduleName},
 								v1.EnvVar{Name: "MOD_NAMESPACE", Value: namespace},
 							),
-							Volumes: buildVolumesFromBuildSecrets(buildSecrets),
+							Volumes:    buildVolumesFromBuildSecrets(buildSecrets),
+							PullSecret: &irs,
 						},
 					},
 					Output: buildv1.BuildOutput{
@@ -162,8 +163,8 @@ var _ = Describe("Maker_MakeBuildTemplate", func() {
 
 		if imagePullSecret != nil {
 			mld.ImageRepoSecret = imagePullSecret
-
 			expected.Spec.CommonSpec.Output.PushSecret = imagePullSecret
+			expected.Spec.Strategy.DockerStrategy.PullSecret = imagePullSecret
 		}
 
 		if len(buildSecrets) > 0 {


### PR DESCRIPTION
Currently, when a build attempts to pull an image from a private registry, it fails due to the absence of the appropriate pull secret.
This commit ensures that the module's pull secret is included in the build's YAML, allowing it to authenticate to the private registries and pull images from there.

---

/cc @ybettan @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the build process to support secure image pulling from private repositories by incorporating a new secret configuration.
	- Introduced a `PullSecret` field in the build configuration for improved authentication with image repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->