### PR TITLE
Changing the names of the APIs of mic package to align with mbsc package

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -142,7 +142,7 @@ func main() {
 	)
 
 	kernelAPI := module.NewKernelMapper(buildHelperAPI, sign.NewSignerHelper())
-	micAPI := mic.NewModuleImagesConfigAPI(client, scheme)
+	micAPI := mic.New(client, scheme)
 
 	dpc := controllers.NewDevicePluginReconciler(
 		client,

--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -387,7 +387,7 @@ func (mrh *moduleReconcilerHelper) handleMIC(ctx context.Context, mod *kmmv1beta
 		images = append(images, mis)
 	}
 
-	if err := mrh.micAPI.ApplyMIC(ctx, mod.Name, mod.Namespace, images, mod.Spec.ImageRepoSecret, mod); err != nil {
+	if err := mrh.micAPI.CreateOrPatch(ctx, mod.Name, mod.Namespace, images, mod.Spec.ImageRepoSecret, mod); err != nil {
 		errs = append(errs, fmt.Errorf("failed to apply %s/%s MIC: %v", mod.Namespace, mod.Name, err))
 	}
 

--- a/internal/controllers/module_reconciler_test.go
+++ b/internal/controllers/module_reconciler_test.go
@@ -443,7 +443,7 @@ var _ = Describe("handleMIC", func() {
 	It("should return an error if we failed to get moduleLoaderData for kernel", func() {
 
 		mockKernelMapper.EXPECT().GetModuleLoaderDataForKernel(mod, gomock.Any()).Return(nil, errors.New("some error"))
-		mockMICAPI.EXPECT().ApplyMIC(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret, mod).Return(nil)
+		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret, mod).Return(nil)
 
 		err := mrh.handleMIC(ctx, mod, targetedNodes)
 		Expect(err).To(HaveOccurred())
@@ -455,7 +455,7 @@ var _ = Describe("handleMIC", func() {
 		img := "example.registry.com/org/image:tag"
 		mld := &api.ModuleLoaderData{ContainerImage: img}
 		mockKernelMapper.EXPECT().GetModuleLoaderDataForKernel(mod, gomock.Any()).Return(mld, nil)
-		mockMICAPI.EXPECT().ApplyMIC(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret,
+		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret,
 			mod).Return(errors.New("some error"))
 
 		err := mrh.handleMIC(ctx, mod, targetedNodes)
@@ -468,7 +468,7 @@ var _ = Describe("handleMIC", func() {
 		img := "example.registry.com/org/image:tag"
 		mld := &api.ModuleLoaderData{ContainerImage: img}
 		mockKernelMapper.EXPECT().GetModuleLoaderDataForKernel(mod, gomock.Any()).Return(mld, nil)
-		mockMICAPI.EXPECT().ApplyMIC(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret, mod).Return(nil)
+		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret, mod).Return(nil)
 
 		err := mrh.handleMIC(ctx, mod, targetedNodes)
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/mic/mic.go
+++ b/internal/mic/mic.go
@@ -16,7 +16,7 @@ import (
 //go:generate mockgen -source=mic.go -package=mic -destination=mock_mic.go
 
 type MIC interface {
-	ApplyMIC(ctx context.Context, name, ns string, images []kmmv1beta1.ModuleImageSpec,
+	CreateOrPatch(ctx context.Context, name, ns string, images []kmmv1beta1.ModuleImageSpec,
 		imageRepoSecret *v1.LocalObjectReference, owner metav1.Object) error
 	GetModuleImageSpec(micObj *kmmv1beta1.ModuleImagesConfig, image string) *kmmv1beta1.ModuleImageSpec
 	SetImageStatus(micObj *kmmv1beta1.ModuleImagesConfig, image string, status kmmv1beta1.ImageState)
@@ -28,14 +28,14 @@ type micImpl struct {
 	scheme *runtime.Scheme
 }
 
-func NewModuleImagesConfigAPI(client client.Client, scheme *runtime.Scheme) MIC {
+func New(client client.Client, scheme *runtime.Scheme) MIC {
 	return &micImpl{
 		client: client,
 		scheme: scheme,
 	}
 }
 
-func (mici *micImpl) ApplyMIC(ctx context.Context, name, ns string, images []kmmv1beta1.ModuleImageSpec,
+func (mici *micImpl) CreateOrPatch(ctx context.Context, name, ns string, images []kmmv1beta1.ModuleImageSpec,
 	imageRepoSecret *v1.LocalObjectReference, owner metav1.Object) error {
 
 	logger := log.FromContext(ctx)

--- a/internal/mic/mic_test.go
+++ b/internal/mic/mic_test.go
@@ -36,7 +36,7 @@ var _ = Describe("ApplyMIC", func() {
 		ctx = context.Background()
 		ctrl = gomock.NewController(GinkgoT())
 		mockClient = client.NewMockClient(ctrl)
-		micAPI = NewModuleImagesConfigAPI(mockClient, scheme)
+		micAPI = New(mockClient, scheme)
 		utilruntime.Must(v1beta1.AddToScheme(scheme))
 	})
 
@@ -44,7 +44,7 @@ var _ = Describe("ApplyMIC", func() {
 
 		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil)
 
-		err := micAPI.ApplyMIC(ctx, micName, micNamespace, []v1beta1.ModuleImageSpec{}, nil, nil)
+		err := micAPI.CreateOrPatch(ctx, micName, micNamespace, []v1beta1.ModuleImageSpec{}, nil, nil)
 
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("failed to create or patch"))
@@ -80,7 +80,7 @@ var _ = Describe("ApplyMIC", func() {
 			},
 		}
 
-		err := micAPI.ApplyMIC(ctx, micName, micNamespace, images, imageRepoSecret, owner)
+		err := micAPI.CreateOrPatch(ctx, micName, micNamespace, images, imageRepoSecret, owner)
 
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -126,7 +126,7 @@ var _ = Describe("ApplyMIC", func() {
 			},
 		}
 
-		err := micAPI.ApplyMIC(ctx, micName, micNamespace, images, nil, owner)
+		err := micAPI.CreateOrPatch(ctx, micName, micNamespace, images, nil, owner)
 
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -138,7 +138,7 @@ var _ = Describe("GetModuleImageSpec", func() {
 	)
 
 	BeforeEach(func() {
-		micAPI = NewModuleImagesConfigAPI(nil, nil)
+		micAPI = New(nil, nil)
 	})
 
 	testMic := kmmv1beta1.ModuleImagesConfig{
@@ -173,7 +173,7 @@ var _ = Describe("SetImageStatus", func() {
 	)
 
 	BeforeEach(func() {
-		micAPI = NewModuleImagesConfigAPI(nil, nil)
+		micAPI = New(nil, nil)
 	})
 
 	testMic := kmmv1beta1.ModuleImagesConfig{
@@ -211,7 +211,7 @@ var _ = Describe("GetImageState", func() {
 	)
 
 	BeforeEach(func() {
-		micAPI = NewModuleImagesConfigAPI(nil, nil)
+		micAPI = New(nil, nil)
 	})
 
 	testMic := kmmv1beta1.ModuleImagesConfig{

--- a/internal/mic/mock_mic.go
+++ b/internal/mic/mock_mic.go
@@ -41,18 +41,18 @@ func (m *MockMIC) EXPECT() *MockMICMockRecorder {
 	return m.recorder
 }
 
-// ApplyMIC mocks base method.
-func (m *MockMIC) ApplyMIC(ctx context.Context, name, ns string, images []v1beta1.ModuleImageSpec, imageRepoSecret *v1.LocalObjectReference, owner v10.Object) error {
+// CreateOrPatch mocks base method.
+func (m *MockMIC) CreateOrPatch(ctx context.Context, name, ns string, images []v1beta1.ModuleImageSpec, imageRepoSecret *v1.LocalObjectReference, owner v10.Object) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ApplyMIC", ctx, name, ns, images, imageRepoSecret, owner)
+	ret := m.ctrl.Call(m, "CreateOrPatch", ctx, name, ns, images, imageRepoSecret, owner)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// ApplyMIC indicates an expected call of ApplyMIC.
-func (mr *MockMICMockRecorder) ApplyMIC(ctx, name, ns, images, imageRepoSecret, owner any) *gomock.Call {
+// CreateOrPatch indicates an expected call of CreateOrPatch.
+func (mr *MockMICMockRecorder) CreateOrPatch(ctx, name, ns, images, imageRepoSecret, owner any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyMIC", reflect.TypeOf((*MockMIC)(nil).ApplyMIC), ctx, name, ns, images, imageRepoSecret, owner)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrPatch", reflect.TypeOf((*MockMIC)(nil).CreateOrPatch), ctx, name, ns, images, imageRepoSecret, owner)
 }
 
 // GetImageState mocks base method.


### PR DESCRIPTION
1) changing ApplyMIC to CreateOrPatch
2) chaning NewModuleImagesConfigAPI to New

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined module configuration management so that configurations are automatically created or updated as needed.
	- Simplified the initialization process to enhance overall consistency, reliability, and system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->