### PR TITLE
Making images field in mic resource optional

### DIFF
--- a/api/v1beta1/moduleimagesconfig_types.go
+++ b/api/v1beta1/moduleimagesconfig_types.go
@@ -50,9 +50,8 @@ type ModuleImageSpec struct {
 
 // ModuleImagesConfigSpec describes the images of the Module whose status needs to be verified
 // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
-// +kubebuilder:validation:Required
 type ModuleImagesConfigSpec struct {
-	Images []ModuleImageSpec `json:"images"`
+	Images []ModuleImageSpec `json:"images,omitempty"`
 
 	// ImageRepoSecret contains pull secret for the image's repo, if needed
 	// +optional

--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2025-02-26T09:17:19Z"
+    createdAt: "2025-03-03T10:39:34Z"
     operatorframework.io/suggested-namespace: openshift-kmm-hub
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -63,7 +63,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2025-02-26T09:17:18Z"
+    createdAt: "2025-03-03T10:39:33Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/bundle/manifests/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -226,8 +226,6 @@ spec:
                   - image
                   type: object
                 type: array
-            required:
-            - images
             type: object
           status:
             description: |-

--- a/config/crd/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -222,8 +222,6 @@ spec:
                   - image
                   type: object
                 type: array
-            required:
-            - images
             type: object
           status:
             description: |-

--- a/internal/controllers/module_reconciler_test.go
+++ b/internal/controllers/module_reconciler_test.go
@@ -463,6 +463,12 @@ var _ = Describe("handleMIC", func() {
 		Expect(err.Error()).To(ContainSubstring("failed to apply"))
 	})
 
+	It("should not do anything if targetedNodes is empty", func() {
+		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret, mod).Return(nil)
+		err := mrh.handleMIC(ctx, mod, []v1.Node{})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 	It("should work as expected", func() {
 
 		img := "example.registry.com/org/image:tag"


### PR DESCRIPTION
Until now, when the node selectors were not match to any of the actual nodes, it still tried to create mic resource, even though we expect it to do nothing. This commit making the images field in mic optional, that way creating or patching mic with an empty images field will not fail constantly.

(cherry picked from commit fc2a73e293e5be8c8e602434fd9b6bc41ac8639e)

---

fixes #1377
/cc @ybettan @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Module configuration is now more flexible: the "images" property is optional and will be omitted from outputs when empty, simplifying resource creation and deployment.
  
- **Bug Fixes**
  - Enhanced test coverage for the module reconciler, ensuring correct behavior when no targeted nodes are present.

- **Chores**
  - Updated creation timestamps in service metadata files to reflect recent revisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->