### PR TITLE
Updating the operator's `capabilities` to `Seamless Upgrades`.

### DIFF
--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -36,8 +36,8 @@ metadata:
           }
         }
       ]
-    capabilities: Basic Install
-    createdAt: "2025-02-09T09:29:55Z"
+    capabilities: Seamless Upgrades
+    createdAt: "2025-02-26T09:17:19Z"
     operatorframework.io/suggested-namespace: openshift-kmm-hub
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -62,8 +62,8 @@ metadata:
           }
         }
       ]
-    capabilities: Basic Install
-    createdAt: "2025-02-25T07:48:06Z"
+    capabilities: Seamless Upgrades
+    createdAt: "2025-02-26T09:17:18Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/config/manifests-hub/bases/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/config/manifests-hub/bases/kernel-module-management-hub.clusterserviceversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     alm-examples: '[]'
-    capabilities: Basic Install
+    capabilities: Seamless Upgrades
     operatorframework.io/suggested-namespace: openshift-kmm-hub
     repository: https://github.com/rh-ecosystem-edge/kernel-module-management
   name: kernel-module-management-hub.v0.0.0

--- a/config/manifests/bases/kernel-module-management.clusterserviceversion.yaml
+++ b/config/manifests/bases/kernel-module-management.clusterserviceversion.yaml
@@ -3,7 +3,7 @@ kind: ClusterServiceVersion
 metadata:
   annotations:
     alm-examples: '[]'
-    capabilities: Basic Install
+    capabilities: Seamless Upgrades
     operatorframework.io/suggested-namespace: openshift-kmm
     repository: https://github.com/rh-ecosystem-edge/kernel-module-management
   name: kernel-module-management.v0.0.0


### PR DESCRIPTION
The `capability` field refers to the operator maturity level. More info can be found at
https://sdk.operatorframework.io/docs/overview/operator-capabilities/.

This was previously set to `Basic Install` which belongs to operator that doesn't have an upgrade option. This is obviously not the case for KMM, therefore, it is being updated.

---

/assign @yevgeny-shnaidman @TomerNewman 

This is already set correctly u/s:
* [KMM](https://github.com/kubernetes-sigs/kernel-module-management/blob/caf49d1c927bf43de8c83ea3f6afe0302275544c/config/manifests/bases/kernel-module-management.clusterserviceversion.yaml#L6)
* [KMM-hub](https://github.com/kubernetes-sigs/kernel-module-management/blob/caf49d1c927bf43de8c83ea3f6afe0302275544c/config/manifests-hub/bases/kernel-module-management-hub.clusterserviceversion.yaml#L6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced operator upgrade capability: The system now supports seamless upgrades that ensure smoother transitions during version updates and maintenance cycles, reducing interruptions and improving performance. This enhancement reflects our continued commitment to delivering a robust and optimized experience for users managing system updates. Users will benefit from a more efficient update process that minimizes downtime and streamlines system maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->