### PR TITLE
Adding GetImageSpec API to the mbsc package

### DIFF
--- a/internal/mbsc/mbsc.go
+++ b/internal/mbsc/mbsc.go
@@ -19,6 +19,7 @@ type MBSC interface {
 	Get(ctx context.Context, name, namespace string) (*kmmv1beta1.ModuleBuildSignConfig, error)
 	CreateOrPatch(ctx context.Context, micObj *kmmv1beta1.ModuleImagesConfig,
 		moduleImageSpec *kmmv1beta1.ModuleImageSpec, action kmmv1beta1.BuildOrSignAction) error
+	GetImageSpec(mbscObj *kmmv1beta1.ModuleBuildSignConfig, image string) *kmmv1beta1.ModuleBuildSignSpec
 }
 
 type mbsc struct {
@@ -57,6 +58,15 @@ func (m *mbsc) CreateOrPatch(ctx context.Context, micObj *kmmv1beta1.ModuleImage
 		return controllerutil.SetOwnerReference(micObj, mbscObj, m.scheme)
 	})
 	return err
+}
+
+func (m *mbsc) GetImageSpec(mbscObj *kmmv1beta1.ModuleBuildSignConfig, image string) *kmmv1beta1.ModuleBuildSignSpec {
+	for _, imageSpec := range mbscObj.Spec.Images {
+		if imageSpec.Image == image {
+			return &imageSpec
+		}
+	}
+	return nil
 }
 
 func setModuleImageSpec(mbscObj *kmmv1beta1.ModuleBuildSignConfig, moduleImageSpec *kmmv1beta1.ModuleImageSpec, action kmmv1beta1.BuildOrSignAction) {

--- a/internal/mbsc/mbsc_test.go
+++ b/internal/mbsc/mbsc_test.go
@@ -165,3 +165,29 @@ var _ = Describe("CreateOrPatch", func() {
 		Expect(err).To(HaveOccurred())
 	})
 })
+
+var _ = Describe("GetImageSpec", func() {
+	testMBSC := kmmv1beta1.ModuleBuildSignConfig{
+		Spec: kmmv1beta1.ModuleBuildSignConfigSpec{
+			Images: []kmmv1beta1.ModuleBuildSignSpec{
+				{
+					ModuleImageSpec: kmmv1beta1.ModuleImageSpec{
+						Image: "test image1",
+					},
+				},
+			},
+		},
+	}
+	mbsc := New(nil, nil)
+
+	It("image's spec exists in MBSC", func() {
+		By("image's spec exists in MBSC")
+		res := mbsc.GetImageSpec(&testMBSC, "test image1")
+		Expect(res).ToNot(BeNil())
+		Expect(res.Image).To(Equal("test image1"))
+
+		By("image's spec does not exists in MBSC")
+		res = mbsc.GetImageSpec(&testMBSC, "test image2")
+		Expect(res).To(BeNil())
+	})
+})

--- a/internal/mbsc/mock_mbsc.go
+++ b/internal/mbsc/mock_mbsc.go
@@ -67,3 +67,17 @@ func (mr *MockMBSCMockRecorder) Get(ctx, name, namespace any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockMBSC)(nil).Get), ctx, name, namespace)
 }
+
+// GetImageSpec mocks base method.
+func (m *MockMBSC) GetImageSpec(mbscObj *v1beta1.ModuleBuildSignConfig, image string) *v1beta1.ModuleBuildSignSpec {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetImageSpec", mbscObj, image)
+	ret0, _ := ret[0].(*v1beta1.ModuleBuildSignSpec)
+	return ret0
+}
+
+// GetImageSpec indicates an expected call of GetImageSpec.
+func (mr *MockMBSCMockRecorder) GetImageSpec(mbscObj, image any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageSpec", reflect.TypeOf((*MockMBSC)(nil).GetImageSpec), mbscObj, image)
+}


### PR DESCRIPTION
Adding GetImageSpec API which returns image spec in MBSC object based on the image name. Currently will be used by the MIC controller, but will probbably be used by MBSC controller also

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added functionality to retrieve image details by image name, enhancing configuration management.
- **Tests**
	- Introduced comprehensive tests to validate the lookup behavior for both existing and non-existing images.
	- Improved testing utilities to better simulate and verify image retrieval functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->