### PR TITLE
Un-exporting some of `WorkerPodManager` interface env variables.

### DIFF
--- a/internal/controllers/nmc_reconciler.go
+++ b/internal/controllers/nmc_reconciler.go
@@ -345,7 +345,7 @@ func (h *nmcReconcilerHelperImpl) ProcessModuleSpec(
 		return nil
 	}
 
-	if p.Labels[pod.ActionLabelKey] != pod.WorkerActionLoad {
+	if !h.podManager.IsLoaderPod(p) {
 		logger.Info("Worker Pod is not loading the kmod; doing nothing")
 		return nil
 	}
@@ -360,7 +360,7 @@ func (h *nmcReconcilerHelperImpl) ProcessModuleSpec(
 		return fmt.Errorf("could not create the Pod template for %s: %v", podName, err)
 	}
 
-	if podTemplate.Annotations[pod.HashAnnotationKey] != p.Annotations[pod.HashAnnotationKey] {
+	if h.podManager.HashAnnotationDiffer(podTemplate, p) {
 		logger.Info("Hash differs, deleting pod")
 		return h.podManager.DeletePod(ctx, p)
 	}
@@ -405,7 +405,7 @@ func (h *nmcReconcilerHelperImpl) ProcessUnconfiguredModuleStatus(
 		return h.podManager.CreateUnloaderPod(ctx, nmcObj, status)
 	}
 
-	if p.Labels[pod.ActionLabelKey] == pod.WorkerActionLoad {
+	if h.podManager.IsLoaderPod(p) {
 		logger.Info("Worker Pod is loading the kmod; deleting it")
 		return h.podManager.DeletePod(ctx, p)
 	}
@@ -420,7 +420,7 @@ func (h *nmcReconcilerHelperImpl) ProcessUnconfiguredModuleStatus(
 		return fmt.Errorf("could not create the Pod template for %s: %v", podName, err)
 	}
 
-	if podTemplate.Annotations[pod.HashAnnotationKey] != p.Annotations[pod.HashAnnotationKey] {
+	if h.podManager.HashAnnotationDiffer(podTemplate, p) {
 		logger.Info("Hash differs, deleting pod")
 		return h.podManager.DeletePod(ctx, p)
 	}
@@ -506,7 +506,7 @@ func (h *nmcReconcilerHelperImpl) SyncStatus(ctx context.Context, nmcObj *kmmv1b
 			podsToDelete = append(podsToDelete, p)
 
 		case v1.PodSucceeded:
-			if p.Labels[pod.ActionLabelKey] == pod.WorkerActionUnload {
+			if h.podManager.IsUnloaderPod(&p) {
 				podsToDelete = append(podsToDelete, p)
 				nmc.RemoveModuleStatus(&nmcObj.Status.Modules, modNamespace, modName)
 				break
@@ -521,7 +521,8 @@ func (h *nmcReconcilerHelperImpl) SyncStatus(ctx context.Context, nmcObj *kmmv1b
 				}
 			}
 
-			if err = yaml.UnmarshalStrict([]byte(p.Annotations[pod.ConfigAnnotationKey]), &status.Config); err != nil {
+			configAnnotation := h.podManager.GetConfigAnnotation(&p)
+			if err = yaml.UnmarshalStrict([]byte(configAnnotation), &status.Config); err != nil {
 				errs = append(
 					errs,
 					fmt.Errorf("%s: could not unmarshal the ModuleConfig from YAML: %v", podNSN, err),

--- a/internal/controllers/nmc_reconciler_test.go
+++ b/internal/controllers/nmc_reconciler_test.go
@@ -14,7 +14,6 @@ import (
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	testclient "github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
-	"github.com/rh-ecosystem-edge/kernel-module-management/internal/meta"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/nmc"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/node"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/pod"
@@ -682,10 +681,11 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessModuleSpec", func() {
 	)
 
 	It("should do nothing if the pod is not loading a kmod", func() {
-		mockWorkerPodManager.
-			EXPECT().
-			GetWorkerPod(ctx, podName, namespace).
-			Return(&v1.Pod{}, nil)
+
+		gomock.InOrder(
+			mockWorkerPodManager.EXPECT().GetWorkerPod(ctx, podName, namespace).Return(&v1.Pod{}, nil),
+			mockWorkerPodManager.EXPECT().IsLoaderPod(gomock.Any()).Return(true),
+		)
 
 		Expect(
 			wh.ProcessModuleSpec(ctx, nmc, spec, status, nil),
@@ -695,16 +695,11 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessModuleSpec", func() {
 	})
 
 	It("should do nothing if the worker container has not restarted", func() {
-		pod := v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{pod.ActionLabelKey: pod.WorkerActionLoad},
-			},
-		}
 
-		mockWorkerPodManager.
-			EXPECT().
-			GetWorkerPod(ctx, podName, namespace).
-			Return(&pod, nil)
+		gomock.InOrder(
+			mockWorkerPodManager.EXPECT().GetWorkerPod(ctx, podName, namespace).Return(&v1.Pod{}, nil),
+			mockWorkerPodManager.EXPECT().IsLoaderPod(gomock.Any()).Return(true),
+		)
 
 		Expect(
 			wh.ProcessModuleSpec(ctx, nmc, spec, status, nil),
@@ -715,9 +710,6 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessModuleSpec", func() {
 
 	It("should return an error if there was an error making the Pod template", func() {
 		pod := v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{pod.ActionLabelKey: pod.WorkerActionLoad},
-			},
 			Status: v1.PodStatus{
 				ContainerStatuses: []v1.ContainerStatus{
 					{
@@ -729,14 +721,9 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessModuleSpec", func() {
 		}
 
 		gomock.InOrder(
-			mockWorkerPodManager.
-				EXPECT().
-				GetWorkerPod(ctx, podName, namespace).
-				Return(&pod, nil),
-			mockWorkerPodManager.
-				EXPECT().
-				LoaderPodTemplate(ctx, nmc, spec).
-				Return(nil, errors.New("random error")),
+			mockWorkerPodManager.EXPECT().GetWorkerPod(ctx, podName, namespace).Return(&pod, nil),
+			mockWorkerPodManager.EXPECT().IsLoaderPod(&pod).Return(true),
+			mockWorkerPodManager.EXPECT().LoaderPodTemplate(ctx, nmc, spec).Return(nil, errors.New("random error")),
 		)
 
 		Expect(
@@ -748,10 +735,6 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessModuleSpec", func() {
 
 	It("should delete the existing pod if its hash annotation is outdated", func() {
 		p := v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels:      map[string]string{pod.ActionLabelKey: pod.WorkerActionLoad},
-				Annotations: map[string]string{pod.HashAnnotationKey: "123"},
-			},
 			Status: v1.PodStatus{
 				ContainerStatuses: []v1.ContainerStatus{
 					{
@@ -763,20 +746,13 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessModuleSpec", func() {
 		}
 
 		podTemplate := p.DeepCopy()
-		podTemplate.Annotations[pod.HashAnnotationKey] = "456"
 
 		gomock.InOrder(
-			mockWorkerPodManager.
-				EXPECT().
-				GetWorkerPod(ctx, podName, namespace).
-				Return(&p, nil),
-			mockWorkerPodManager.
-				EXPECT().
-				LoaderPodTemplate(ctx, nmc, spec).
-				Return(podTemplate, nil),
-			mockWorkerPodManager.
-				EXPECT().
-				DeletePod(ctx, &p),
+			mockWorkerPodManager.EXPECT().GetWorkerPod(ctx, podName, namespace).Return(&p, nil),
+			mockWorkerPodManager.EXPECT().IsLoaderPod(&p).Return(true),
+			mockWorkerPodManager.EXPECT().LoaderPodTemplate(ctx, nmc, spec).Return(podTemplate, nil),
+			mockWorkerPodManager.EXPECT().HashAnnotationDiffer(gomock.Any(), gomock.Any()).Return(true),
+			mockWorkerPodManager.EXPECT().DeletePod(ctx, &p),
 		)
 
 		Expect(
@@ -857,13 +833,13 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessUnconfiguredModuleStatus", func
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      podName,
 				Namespace: namespace,
-				Labels:    map[string]string{pod.ActionLabelKey: pod.WorkerActionLoad},
 			},
 		}
 
 		gomock.InOrder(
 			nm.EXPECT().NodeBecomeReadyAfter(&node, status.LastTransitionTime).Return(false),
 			mockWorkerPodManager.EXPECT().GetWorkerPod(ctx, podName, namespace).Return(&pod, nil),
+			mockWorkerPodManager.EXPECT().IsLoaderPod(&pod).Return(true),
 			mockWorkerPodManager.EXPECT().DeletePod(ctx, &pod),
 		)
 
@@ -885,6 +861,7 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessUnconfiguredModuleStatus", func
 		gomock.InOrder(
 			nm.EXPECT().NodeBecomeReadyAfter(&node, status.LastTransitionTime).Return(false),
 			mockWorkerPodManager.EXPECT().GetWorkerPod(ctx, podName, namespace).Return(&pod, nil),
+			mockWorkerPodManager.EXPECT().IsLoaderPod(&pod).Return(false),
 		)
 
 		Expect(
@@ -913,6 +890,7 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessUnconfiguredModuleStatus", func
 		gomock.InOrder(
 			nm.EXPECT().NodeBecomeReadyAfter(&node, status.LastTransitionTime).Return(false),
 			mockWorkerPodManager.EXPECT().GetWorkerPod(ctx, podName, namespace).Return(&pod, nil),
+			mockWorkerPodManager.EXPECT().IsLoaderPod(&pod).Return(false),
 			mockWorkerPodManager.EXPECT().UnloaderPodTemplate(ctx, nmc, status).Return(nil, errors.New("random error")),
 		)
 
@@ -926,9 +904,8 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessUnconfiguredModuleStatus", func
 	It("should delete the existing pod if its hash annotation is outdated", func() {
 		p := v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:        podName,
-				Namespace:   namespace,
-				Annotations: map[string]string{pod.HashAnnotationKey: "123"},
+				Name:      podName,
+				Namespace: namespace,
 			},
 			Status: v1.PodStatus{
 				ContainerStatuses: []v1.ContainerStatus{
@@ -941,12 +918,13 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessUnconfiguredModuleStatus", func
 		}
 
 		podTemplate := p.DeepCopy()
-		podTemplate.Annotations[pod.HashAnnotationKey] = "456"
 
 		gomock.InOrder(
 			nm.EXPECT().NodeBecomeReadyAfter(&node, status.LastTransitionTime).Return(false),
 			mockWorkerPodManager.EXPECT().GetWorkerPod(ctx, podName, namespace).Return(&p, nil),
+			mockWorkerPodManager.EXPECT().IsLoaderPod(&p).Return(false),
 			mockWorkerPodManager.EXPECT().UnloaderPodTemplate(ctx, nmc, status).Return(podTemplate, nil),
+			mockWorkerPodManager.EXPECT().HashAnnotationDiffer(gomock.Any(), gomock.Any()).Return(true),
 			mockWorkerPodManager.EXPECT().DeletePod(ctx, &p),
 		)
 
@@ -1078,7 +1056,6 @@ var _ = Describe("nmcReconcilerHelperImpl_SyncStatus", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: modNamespace,
 				Labels: map[string]string{
-					pod.ActionLabelKey:        pod.WorkerActionUnload,
 					constants.ModuleNameLabel: modName,
 				},
 			},
@@ -1087,6 +1064,7 @@ var _ = Describe("nmcReconcilerHelperImpl_SyncStatus", func() {
 
 		gomock.InOrder(
 			mockWorkerPodManager.EXPECT().ListWorkerPodsOnNode(ctx, nmcName).Return([]v1.Pod{pod}, nil),
+			mockWorkerPodManager.EXPECT().IsUnloaderPod(&pod).Return(true),
 			kubeClient.EXPECT().Status().Return(sw),
 			sw.EXPECT().Patch(ctx, nmc, gomock.Any()),
 			mockWorkerPodManager.EXPECT().DeletePod(ctx, &pod),
@@ -1143,7 +1121,6 @@ var _ = Describe("nmcReconcilerHelperImpl_SyncStatus", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: modNamespace,
 				Labels: map[string]string{
-					pod.ActionLabelKey:        pod.WorkerActionLoad,
 					constants.ModuleNameLabel: modName,
 				},
 			},
@@ -1167,10 +1144,11 @@ var _ = Describe("nmcReconcilerHelperImpl_SyncStatus", func() {
 
 		b, err := yaml.Marshal(cfg)
 		Expect(err).NotTo(HaveOccurred())
-		meta.SetAnnotation(&p, pod.ConfigAnnotationKey, string(b))
 
 		gomock.InOrder(
 			mockWorkerPodManager.EXPECT().ListWorkerPodsOnNode(ctx, nmcName).Return([]v1.Pod{p}, nil),
+			mockWorkerPodManager.EXPECT().IsUnloaderPod(&p).Return(false),
+			mockWorkerPodManager.EXPECT().GetConfigAnnotation(&p).Return(string(b)),
 			kubeClient.EXPECT().Status().Return(sw),
 			sw.EXPECT().Patch(ctx, nmc, gomock.Any()),
 			mockWorkerPodManager.EXPECT().DeletePod(ctx, &p),
@@ -1223,7 +1201,6 @@ var _ = Describe("nmcReconcilerHelperImpl_SyncStatus", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: modNamespace,
 				Labels: map[string]string{
-					pod.ActionLabelKey:        pod.WorkerActionUnload,
 					constants.ModuleNameLabel: modName,
 				},
 			},
@@ -1232,6 +1209,7 @@ var _ = Describe("nmcReconcilerHelperImpl_SyncStatus", func() {
 
 		gomock.InOrder(
 			mockWorkerPodManager.EXPECT().ListWorkerPodsOnNode(ctx, nmcName).Return([]v1.Pod{pod}, nil),
+			mockWorkerPodManager.EXPECT().IsUnloaderPod(&pod).Return(true),
 			kubeClient.EXPECT().Status().Return(sw),
 			sw.EXPECT().Patch(ctx, nmc, gomock.Any()).Return(fmt.Errorf("some error")),
 		)

--- a/internal/pod/mock_workerpodmanager.go
+++ b/internal/pod/mock_workerpodmanager.go
@@ -83,6 +83,20 @@ func (mr *MockWorkerPodManagerMockRecorder) DeletePod(ctx, pod any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePod", reflect.TypeOf((*MockWorkerPodManager)(nil).DeletePod), ctx, pod)
 }
 
+// GetConfigAnnotation mocks base method.
+func (m *MockWorkerPodManager) GetConfigAnnotation(p *v1.Pod) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetConfigAnnotation", p)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetConfigAnnotation indicates an expected call of GetConfigAnnotation.
+func (mr *MockWorkerPodManagerMockRecorder) GetConfigAnnotation(p any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigAnnotation", reflect.TypeOf((*MockWorkerPodManager)(nil).GetConfigAnnotation), p)
+}
+
 // GetWorkerPod mocks base method.
 func (m *MockWorkerPodManager) GetWorkerPod(ctx context.Context, podName, namespace string) (*v1.Pod, error) {
 	m.ctrl.T.Helper()
@@ -96,6 +110,48 @@ func (m *MockWorkerPodManager) GetWorkerPod(ctx context.Context, podName, namesp
 func (mr *MockWorkerPodManagerMockRecorder) GetWorkerPod(ctx, podName, namespace any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkerPod", reflect.TypeOf((*MockWorkerPodManager)(nil).GetWorkerPod), ctx, podName, namespace)
+}
+
+// HashAnnotationDiffer mocks base method.
+func (m *MockWorkerPodManager) HashAnnotationDiffer(p1, p2 *v1.Pod) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HashAnnotationDiffer", p1, p2)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HashAnnotationDiffer indicates an expected call of HashAnnotationDiffer.
+func (mr *MockWorkerPodManagerMockRecorder) HashAnnotationDiffer(p1, p2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HashAnnotationDiffer", reflect.TypeOf((*MockWorkerPodManager)(nil).HashAnnotationDiffer), p1, p2)
+}
+
+// IsLoaderPod mocks base method.
+func (m *MockWorkerPodManager) IsLoaderPod(p *v1.Pod) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsLoaderPod", p)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsLoaderPod indicates an expected call of IsLoaderPod.
+func (mr *MockWorkerPodManagerMockRecorder) IsLoaderPod(p any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsLoaderPod", reflect.TypeOf((*MockWorkerPodManager)(nil).IsLoaderPod), p)
+}
+
+// IsUnloaderPod mocks base method.
+func (m *MockWorkerPodManager) IsUnloaderPod(p *v1.Pod) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsUnloaderPod", p)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsUnloaderPod indicates an expected call of IsUnloaderPod.
+func (mr *MockWorkerPodManagerMockRecorder) IsUnloaderPod(p any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsUnloaderPod", reflect.TypeOf((*MockWorkerPodManager)(nil).IsUnloaderPod), p)
 }
 
 // ListWorkerPodsOnNode mocks base method.

--- a/internal/pod/workerpodmanager_test.go
+++ b/internal/pod/workerpodmanager_test.go
@@ -150,7 +150,7 @@ var _ = Describe("CreateLoaderPod", func() {
 		hash, err := hashstructure.Hash(expected, hashstructure.FormatV2, nil)
 		Expect(err).NotTo(HaveOccurred())
 
-		expected.Annotations[HashAnnotationKey] = fmt.Sprintf("%d", hash)
+		expected.Annotations[hashAnnotationKey] = fmt.Sprintf("%d", hash)
 
 		gomock.InOrder(
 			client.EXPECT().Create(ctx, cmpmock.DiffEq(expected)),
@@ -215,7 +215,7 @@ var _ = Describe("CreateLoaderPod", func() {
 			hash, err := hashstructure.Hash(expected, hashstructure.FormatV2, nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			expected.Annotations[HashAnnotationKey] = fmt.Sprintf("%d", hash)
+			expected.Annotations[hashAnnotationKey] = fmt.Sprintf("%d", hash)
 
 			gomock.InOrder(
 				client.EXPECT().Create(ctx, cmpmock.DiffEq(expected)),
@@ -320,7 +320,7 @@ var _ = Describe("CreateUnloaderPod", func() {
 		hash, err := hashstructure.Hash(expected, hashstructure.FormatV2, nil)
 		Expect(err).NotTo(HaveOccurred())
 
-		expected.Annotations[HashAnnotationKey] = fmt.Sprintf("%d", hash)
+		expected.Annotations[hashAnnotationKey] = fmt.Sprintf("%d", hash)
 
 		client.EXPECT().Create(ctx, cmpmock.DiffEq(expected))
 
@@ -391,7 +391,7 @@ var _ = Describe("ListWorkerPodsOnNode", func() {
 	})
 
 	opts := []interface{}{
-		ctrlclient.HasLabels{ActionLabelKey},
+		ctrlclient.HasLabels{actionLabelKey},
 		ctrlclient.MatchingFields{".spec.nodeName": nodeName},
 	}
 
@@ -437,9 +437,9 @@ func getBaseWorkerPod(subcommand string, owner ctrlclient.Object, firmwareHostPa
 		volNameVarLibFirmware = "lib-firmware"
 	)
 
-	action := WorkerActionLoad
+	action := workerActionLoad
 	if !isLoaderPod {
-		action = WorkerActionUnload
+		action = workerActionUnload
 	}
 
 	hostPathDirectory := v1.HostPathDirectory
@@ -493,11 +493,11 @@ cp -R /firmware-path/* /tmp/firmware-path;
 				"app.kubernetes.io/component": "worker",
 				"app.kubernetes.io/name":      "kmm",
 				"app.kubernetes.io/part-of":   "kmm",
-				ActionLabelKey:                string(action),
+				actionLabelKey:                string(action),
 				constants.ModuleNameLabel:     moduleName,
 			},
 			Annotations: map[string]string{
-				ConfigAnnotationKey: configAnnotationValue,
+				configAnnotationKey: configAnnotationValue,
 				modulesOrderKey:     modulesOrderValue,
 			},
 		},
@@ -579,7 +579,7 @@ cp -R /firmware-path/* /tmp/firmware-path;
 								{
 									Path: "config.yaml",
 									FieldRef: &v1.ObjectFieldSelector{
-										FieldPath: fmt.Sprintf("metadata.annotations['%s']", ConfigAnnotationKey),
+										FieldPath: fmt.Sprintf("metadata.annotations['%s']", configAnnotationKey),
 									},
 								},
 							},


### PR DESCRIPTION
When this interface was transitioned to the `pod` package, it was copied as is (as much as possible) and some variables had to be exported to be used as before.

Once the transition done, it was simpler to review some of those new exported env variables and convert them to usefull methods inside the `WorkerPodManager` interface. 

---

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1399 
/assign @yevgeny-shnaidman @TomerNewman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Optimized system process handling for improved reliability and a more robust user experience. Standardized configuration conventions for consistent operations.
- **Tests**
  - Enhanced validations to ensure accurate process state management and stable performance while reinforcing improved system coverage and reliability.
- **Chore**
  - Updated supporting utilities to strengthen testing, promote code integrity, and support seamless integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->