### PR TITLE
Adding SetImageStatus API to mbsc package

### DIFF
--- a/internal/mbsc/mbsc.go
+++ b/internal/mbsc/mbsc.go
@@ -20,6 +20,7 @@ type MBSC interface {
 	CreateOrPatch(ctx context.Context, micObj *kmmv1beta1.ModuleImagesConfig,
 		moduleImageSpec *kmmv1beta1.ModuleImageSpec, action kmmv1beta1.BuildOrSignAction) error
 	GetImageSpec(mbscObj *kmmv1beta1.ModuleBuildSignConfig, image string) *kmmv1beta1.ModuleBuildSignSpec
+	SetImageStatus(mbscObj *kmmv1beta1.ModuleBuildSignConfig, image string, action kmmv1beta1.BuildOrSignAction, status kmmv1beta1.BuildOrSignStatus)
 }
 
 type mbsc struct {
@@ -67,6 +68,21 @@ func (m *mbsc) GetImageSpec(mbscObj *kmmv1beta1.ModuleBuildSignConfig, image str
 		}
 	}
 	return nil
+}
+
+func (m *mbsc) SetImageStatus(mbscObj *kmmv1beta1.ModuleBuildSignConfig, image string, action kmmv1beta1.BuildOrSignAction, status kmmv1beta1.BuildOrSignStatus) {
+	imageState := kmmv1beta1.BuildSignImageState{
+		Image:  image,
+		Action: action,
+		Status: status,
+	}
+	for i, imageStatus := range mbscObj.Status.Images {
+		if imageStatus.Image == image {
+			mbscObj.Status.Images[i] = imageState
+			return
+		}
+	}
+	mbscObj.Status.Images = append(mbscObj.Status.Images, imageState)
 }
 
 func setModuleImageSpec(mbscObj *kmmv1beta1.ModuleBuildSignConfig, moduleImageSpec *kmmv1beta1.ModuleImageSpec, action kmmv1beta1.BuildOrSignAction) {

--- a/internal/mbsc/mbsc_test.go
+++ b/internal/mbsc/mbsc_test.go
@@ -191,3 +191,38 @@ var _ = Describe("GetImageSpec", func() {
 		Expect(res).To(BeNil())
 	})
 })
+
+var _ = Describe("SetImageSpec", func() {
+	testMBSC := kmmv1beta1.ModuleBuildSignConfig{
+		Status: kmmv1beta1.ModuleBuildSignConfigStatus{
+			Images: []kmmv1beta1.BuildSignImageState{
+				{
+					Image:  "image1",
+					Status: kmmv1beta1.ActionSuccess,
+					Action: kmmv1beta1.BuildImage,
+				},
+				{
+					Image:  "image2",
+					Status: kmmv1beta1.ActionFailure,
+					Action: kmmv1beta1.SignImage,
+				},
+			},
+		},
+	}
+
+	mbscAPI := New(nil, nil)
+
+	It("set images status for both present and not present statuses", func() {
+		By("image status is present")
+		mbscAPI.SetImageStatus(&testMBSC, "image1", kmmv1beta1.SignImage, kmmv1beta1.ActionFailure)
+		Expect(testMBSC.Status.Images[0].Image).To(Equal("image1"))
+		Expect(testMBSC.Status.Images[0].Status).To(Equal(kmmv1beta1.ActionFailure))
+		Expect(testMBSC.Status.Images[0].Action).To(Equal(kmmv1beta1.SignImage))
+
+		By("image status is not present")
+		mbscAPI.SetImageStatus(&testMBSC, "image3", kmmv1beta1.BuildImage, kmmv1beta1.ActionSuccess)
+		Expect(testMBSC.Status.Images[2].Image).To(Equal("image3"))
+		Expect(testMBSC.Status.Images[2].Status).To(Equal(kmmv1beta1.ActionSuccess))
+		Expect(testMBSC.Status.Images[2].Action).To(Equal(kmmv1beta1.BuildImage))
+	})
+})

--- a/internal/mbsc/mock_mbsc.go
+++ b/internal/mbsc/mock_mbsc.go
@@ -81,3 +81,15 @@ func (mr *MockMBSCMockRecorder) GetImageSpec(mbscObj, image any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImageSpec", reflect.TypeOf((*MockMBSC)(nil).GetImageSpec), mbscObj, image)
 }
+
+// SetImageStatus mocks base method.
+func (m *MockMBSC) SetImageStatus(mbscObj *v1beta1.ModuleBuildSignConfig, image string, action v1beta1.BuildOrSignAction, status v1beta1.BuildOrSignStatus) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetImageStatus", mbscObj, image, action, status)
+}
+
+// SetImageStatus indicates an expected call of SetImageStatus.
+func (mr *MockMBSCMockRecorder) SetImageStatus(mbscObj, image, action, status any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetImageStatus", reflect.TypeOf((*MockMBSC)(nil).SetImageStatus), mbscObj, image, action, status)
+}


### PR DESCRIPTION
This API will be used by the mbsc controller to set the status of the image into the MBSC object

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced image status management now allows for updating and adding image statuses seamlessly.
  
- **Tests**
	- Implemented comprehensive tests to verify the image status management functionality, ensuring robust system performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->