### PR TITLE
Fixing the firmware configuration documentation.

### DIFF
--- a/docs/mkdocs/documentation/configure.md
+++ b/docs/mkdocs/documentation/configure.md
@@ -84,7 +84,7 @@ Determines the value of the `seLinuxOptions.type` field of the worker container'
 [SecurityContext](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/).  
 Recommended value: `spc_t`.
 
-#### `worker.setFirmwareClassPath`
+#### `worker.firmwareHostPath`
 
 If set, the value of this field will be written by the worker into the `/sys/module/firmware_class/parameters/path` file
 on the node.


### PR DESCRIPTION
The config fields to be used in order to modify the firmware path on the host but the user was changed rom `setFirmwareClassPath` to `firmwareHostPath` but the documentation wasn't update accordingly. This commit is about to fix that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the header in the worker configuration documentation to reflect the revised naming convention for the firmware path, while keeping the descriptive details and recommended values unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->