### PR TITLE
Fixing metrics generation due to kube-rbac-proxy removal

### DIFF
--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2025-03-03T10:39:34Z"
+    createdAt: "2025-03-20T12:29:17Z"
     operatorframework.io/suggested-namespace: openshift-kmm-hub
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -247,6 +247,9 @@ spec:
                 - mountPath: /etc/pki/ca-trust/extracted/pem
                   name: trusted-ca
                   readOnly: true
+                - mountPath: /certs
+                  name: metrics-tls
+                  readOnly: true
                 - mountPath: /controller_config.yaml
                   name: manager-config
                   subPath: controller_config.yaml
@@ -276,6 +279,10 @@ spec:
                       - key: service-ca.crt
                         path: ocp-service-ca-bundle.pem
                       name: kmm-operator-hub-service-ca
+              - name: metrics-tls
+                secret:
+                  defaultMode: 420
+                  secretName: metrics-service-cert
               - configMap:
                   name: kmm-operator-hub-manager-config
                 name: manager-config

--- a/bundle-hub/manifests/kmm-operator-hub-controller-metrics-service_v1_service.yaml
+++ b/bundle-hub/manifests/kmm-operator-hub-controller-metrics-service_v1_service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: metrics-service-cert
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: kmm-hub
@@ -13,7 +15,7 @@ spec:
   - name: https
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: metrics
   selector:
     app.kubernetes.io/component: kmm-hub
     app.kubernetes.io/name: kmm-hub

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -63,7 +63,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2025-03-19T18:30:34Z"
+    createdAt: "2025-03-20T11:15:21Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -363,6 +363,9 @@ spec:
                 - mountPath: /etc/pki/ca-trust/extracted/pem
                   name: trusted-ca
                   readOnly: true
+                - mountPath: /certs
+                  name: metrics-tls
+                  readOnly: true
                 - mountPath: /controller_config.yaml
                   name: manager-config
                   subPath: controller_config.yaml
@@ -392,6 +395,10 @@ spec:
                       - key: service-ca.crt
                         path: ocp-service-ca-bundle.pem
                       name: kmm-operator-service-ca
+              - name: metrics-tls
+                secret:
+                  defaultMode: 420
+                  secretName: metrics-service-cert
               - configMap:
                   name: kmm-operator-manager-config
                 name: manager-config

--- a/bundle/manifests/kmm-operator-controller-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
+++ b/bundle/manifests/kmm-operator-controller-metrics-monitor_monitoring.coreos.com_v1_servicemonitor.yaml
@@ -14,7 +14,10 @@ spec:
     port: https
     scheme: https
     tlsConfig:
-      insecureSkipVerify: true
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+      keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
+      serverName: kmm-operator-controller-metrics-service.openshift-kmm.svc
   selector:
     matchLabels:
       control-plane: controller

--- a/bundle/manifests/kmm-operator-controller-metrics-service_v1_service.yaml
+++ b/bundle/manifests/kmm-operator-controller-metrics-service_v1_service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: metrics-service-cert
   creationTimestamp: null
   labels:
     app.kubernetes.io/component: kmm
@@ -13,7 +15,7 @@ spec:
   - name: https
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: metrics
   selector:
     app.kubernetes.io/component: kmm
     app.kubernetes.io/name: kmm

--- a/config/manager-base/ocp.patch.yaml
+++ b/config/manager-base/ocp.patch.yaml
@@ -21,6 +21,9 @@ spec:
             - name: trusted-ca
               mountPath: /etc/pki/ca-trust/extracted/pem
               readOnly: true
+            - name: metrics-tls
+              mountPath: /certs
+              readOnly: true
       nodeSelector:
         node-role.kubernetes.io/master: ''
       securityContext:
@@ -40,6 +43,10 @@ spec:
                   items:
                     - key: service-ca.crt
                       path: ocp-service-ca-bundle.pem
+        - name: metrics-tls
+          secret:
+            defaultMode: 420
+            secretName: metrics-service-cert
       tolerations:
         - key: node-role.kubernetes.io/master
           operator: Equal

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -14,7 +14,10 @@ spec:
       scheme: https
       bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       tlsConfig:
-        insecureSkipVerify: true
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        certFile: /etc/prometheus/secrets/metrics-client-certs/tls.crt
+        keyFile: /etc/prometheus/secrets/metrics-client-certs/tls.key
+        serverName: kmm-operator-controller-metrics-service.openshift-kmm.svc
   selector:
     matchLabels:
       control-plane: controller

--- a/config/rbac-base/auth_proxy_service.yaml
+++ b/config/rbac-base/auth_proxy_service.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: metrics-service-cert
   labels:
     control-plane: controller
   name: controller-metrics-service
@@ -10,6 +12,6 @@ spec:
   - name: https
     port: 8443
     protocol: TCP
-    targetPort: https
+    targetPort: metrics
   selector:
     control-plane: controller

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,6 +78,7 @@ func (c *Config) ManagerOptions(logger logr.Logger) *manager.Options {
 	metrics := server.Options{
 		BindAddress:   c.Metrics.BindAddress,
 		SecureServing: c.Metrics.SecureServing,
+		CertDir:       "/certs",
 	}
 
 	if c.Metrics.EnableAuthnAuthz {


### PR DESCRIPTION
Sinc KMM metrics' server is being scraped directly by prometheus, the following changes are needed:
1. metrics service si configured to produce the certificate secret via SA Operator
2. created certificates are mounted into the metrics pod (operator)
3. serviceMonitor is configured to use prometheus CA
4. metrics service is fixed to address the correct port name of the operator's pod

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced secure TLS configuration for metrics monitoring and service endpoints by integrating certificate secrets and updated TLS settings.
  - Improved service routing with updated annotations and port mappings, ensuring better certificate management.

- **Chores**
  - Refreshed manifest timestamps and extended configuration options by adding a dedicated certificate directory for metrics management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->