### PR TITLE
feat: update nodeAffinity from required to preferred

### DIFF
--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -313,7 +313,7 @@ spec:
             spec:
               affinity:
                 nodeAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
+                  preferredDuringSchedulingIgnoredDuringExecution:
                     nodeSelectorTerms:
                     - matchExpressions:
                       - key: node-role.kubernetes.io/control-plane

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -429,7 +429,7 @@ spec:
             spec:
               affinity:
                 nodeAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
+                  preferredDuringSchedulingIgnoredDuringExecution:
                     nodeSelectorTerms:
                     - matchExpressions:
                       - key: node-role.kubernetes.io/control-plane

--- a/config/manager-base/manager.yaml
+++ b/config/manager-base/manager.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       affinity:
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
+          preferredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
               - key: node-role.kubernetes.io/control-plane

--- a/config/webhook-server/deployment.yaml
+++ b/config/webhook-server/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       affinity:
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
+          preferredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
               - matchExpressions:
                   - key: node-role.kubernetes.io/control-plane


### PR DESCRIPTION
This is related to: https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1438

There are a few ways to address this issue, but here is one idea - to switch nodeaffinity from Required to Preferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated deployment configurations to enable more flexible pod scheduling.
  - Changed node affinity settings from strict requirements to preferences, allowing improved workload placement while retaining targeted node selection criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->