### PR TITLE
Adding ocpbuildAnnotations API to ocpbuildmanager

### DIFF
--- a/internal/buildsign/ocpbuild/mock_ocbuildmanager.go
+++ b/internal/buildsign/ocpbuild/mock_ocbuildmanager.go
@@ -128,6 +128,20 @@ func (mr *MockocpbuildManagerMockRecorder) isOCPBuildChanged(existingBuild, newB
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "isOCPBuildChanged", reflect.TypeOf((*MockocpbuildManager)(nil).isOCPBuildChanged), existingBuild, newBuild)
 }
 
+// ocpbuildAnnotations mocks base method.
+func (m *MockocpbuildManager) ocpbuildAnnotations(hash uint64) map[string]string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ocpbuildAnnotations", hash)
+	ret0, _ := ret[0].(map[string]string)
+	return ret0
+}
+
+// ocpbuildAnnotations indicates an expected call of ocpbuildAnnotations.
+func (mr *MockocpbuildManagerMockRecorder) ocpbuildAnnotations(hash any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ocpbuildAnnotations", reflect.TypeOf((*MockocpbuildManager)(nil).ocpbuildAnnotations), hash)
+}
+
 // ocpbuildLabels mocks base method.
 func (m *MockocpbuildManager) ocpbuildLabels(modName, kernelVersion, ocpbuildType string) map[string]string {
 	m.ctrl.T.Helper()

--- a/internal/buildsign/ocpbuild/ocpbuildmanager.go
+++ b/internal/buildsign/ocpbuild/ocpbuildmanager.go
@@ -38,6 +38,7 @@ type ocpbuildManager interface {
 	createOCPBuild(ctx context.Context, build *buildv1.Build) error
 	deleteOCPBuild(ctx context.Context, build *buildv1.Build) error
 	ocpbuildLabels(modName, kernelVersion, ocpbuildType string) map[string]string
+	ocpbuildAnnotations(hash uint64) map[string]string
 }
 
 type ocpbuildManagerImpl struct {
@@ -147,6 +148,10 @@ func (omi *ocpbuildManagerImpl) ocpbuildLabels(modName, kernelVersion, ocpbuildT
 	labels["app.kubernetes.io/part-of"] = "kmm"
 
 	return labels
+}
+
+func (omi *ocpbuildManagerImpl) ocpbuildAnnotations(hash uint64) map[string]string {
+	return map[string]string{hashAnnotation: fmt.Sprintf("%d", hash)}
 }
 
 func filterOCPBuildsByOwner(builds []buildv1.Build, owner metav1.Object) []buildv1.Build {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for generating annotations based on a unique identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->