### PR TITLE
Filtering out node heartbeats events for the NMC controller.

### DIFF
--- a/internal/controllers/nmc_reconciler.go
+++ b/internal/controllers/nmc_reconciler.go
@@ -200,7 +200,7 @@ func (r *NMCReconciler) SetupWithManager(ctx context.Context, mgr manager.Manage
 		Watches(
 			&v1.Node{},
 			handler.EnqueueRequestsFromMapFunc(nodeToNMCMapFunc),
-			builder.WithPredicates(filter.SkipDeletions()),
+			builder.WithPredicates(filter.NMCReconcilerNodePredicate()),
 		).
 		Complete(r)
 }

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -9,6 +9,7 @@ import (
 	imagev1 "github.com/openshift/api/image/v1"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/node"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubectl/pkg/util/podutils"
@@ -148,6 +149,56 @@ func ListModulesForNMC(_ context.Context, obj client.Object) []reconcile.Request
 	}
 
 	return modules.UnsortedList()
+}
+
+func skipNodeHeartbeat() predicate.Predicate {
+
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+
+			oldNode, okOld := e.ObjectOld.(*v1.Node)
+			newNode, okNew := e.ObjectNew.(*v1.Node)
+			if !okOld || !okNew {
+				return false
+			}
+
+			oldNodeCopy := oldNode.DeepCopy()
+			newNodeCopy := newNode.DeepCopy()
+
+			// clear heartbeat timestamp for each condition
+			for i, _ := range oldNodeCopy.Status.Conditions {
+				oldNodeCopy.Status.Conditions[i].LastHeartbeatTime = metav1.Time{}
+			}
+			for i, _ := range newNodeCopy.Status.Conditions {
+				newNodeCopy.Status.Conditions[i].LastHeartbeatTime = metav1.Time{}
+			}
+
+			// clear the resource version as it gets updated with every heartbeat
+			oldNodeCopy.ResourceVersion = ""
+			newNodeCopy.ResourceVersion = ""
+
+			// clear kubelet update managedfields timestamp
+			for i, mf := range oldNodeCopy.ManagedFields {
+				if mf.Manager == "kubelet" {
+					oldNodeCopy.ManagedFields[i].Time = nil
+				}
+			}
+			for i, mf := range newNodeCopy.ManagedFields {
+				if mf.Manager == "kubelet" {
+					newNodeCopy.ManagedFields[i].Time = nil
+				}
+			}
+
+			return !reflect.DeepEqual(oldNodeCopy, newNodeCopy)
+		},
+	}
+}
+
+func NMCReconcilerNodePredicate() predicate.Predicate {
+	return predicate.And(
+		skipDeletions,
+		skipNodeHeartbeat(),
+	)
 }
 
 func ModuleReconcilerNodePredicate() predicate.Predicate {

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -2,6 +2,7 @@ package filter
 
 import (
 	"context"
+	"time"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -113,6 +114,59 @@ var _ = Describe("nodeBecomesSchedulable", func() {
 		Entry("old non-schedulable, new non-schedulable", false, false, false),
 		Entry("old non-schedulable, new schedulable", false, true, true),
 	)
+})
+
+var _ = Describe("skipNodeHeartbeat", func() {
+
+	It("should return false if the only diff is the heartbeat", func() {
+
+		oldNode := v1.Node{
+			Status: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					{
+						LastHeartbeatTime: metav1.NewTime(time.Unix(1, 0)),
+					},
+				},
+			},
+		}
+
+		newNode := v1.Node{
+			Status: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					{
+						LastHeartbeatTime: metav1.NewTime(time.Unix(2, 0)),
+					},
+				},
+			},
+		}
+
+		res := skipNodeHeartbeat().Update(event.UpdateEvent{ObjectOld: &oldNode, ObjectNew: &newNode})
+		Expect(res).To(BeFalse())
+
+	})
+
+	It("should return true if there is a non heartbeat diff", func() {
+
+		oldNode := v1.Node{
+			Status: v1.NodeStatus{
+				NodeInfo: v1.NodeSystemInfo{
+					KernelVersion: "v1",
+				},
+			},
+		}
+
+		newNode := v1.Node{
+			Status: v1.NodeStatus{
+				NodeInfo: v1.NodeSystemInfo{
+					KernelVersion: "v2",
+				},
+			},
+		}
+
+		res := skipNodeHeartbeat().Update(event.UpdateEvent{ObjectOld: &oldNode, ObjectNew: &newNode})
+		Expect(res).To(BeTrue())
+
+	})
 })
 
 var _ = Describe("moduleBuildSuccess", func() {


### PR DESCRIPTION
Node heartbeats are there to let the k8s API server that the node is still connected and functional and if not filtered, it will spam the events the NMC controller gets.

The NMC controller, is trying to garbage collect pods for NMCs that were removed - it causes a constant reconciliation even when no Module, and therefore no NMC, are applied to the cluster.

This commit is fixing this issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved filtering of node update events to ignore changes related only to heartbeat timestamps, reducing unnecessary reconciliations.
- **Bug Fixes**
  - Enhanced event handling to better distinguish meaningful node changes from routine status updates.
- **Tests**
  - Added tests to verify correct filtering of node update events based on heartbeat and other significant changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->