### PR TITLE
KMM Module should be Owner-Controller of MIC

### DIFF
--- a/internal/mic/mic.go
+++ b/internal/mic/mic.go
@@ -54,7 +54,7 @@ func (mici *micImpl) CreateOrPatch(ctx context.Context, name, ns string, images 
 			ImageRepoSecret: imageRepoSecret,
 		}
 
-		return controllerutil.SetOwnerReference(owner, mic, mici.scheme)
+		return controllerutil.SetControllerReference(owner, mic, mici.scheme)
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create or patch %s/%s: %v", ns, name, err)

--- a/internal/mic/mic_test.go
+++ b/internal/mic/mic_test.go
@@ -2,6 +2,7 @@ package mic
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -42,13 +43,13 @@ var _ = Describe("ApplyMIC", func() {
 
 	It("should fail if we failed to create or patch", func() {
 
-		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil)
+		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
 
-		err := micAPI.CreateOrPatch(ctx, micName, micNamespace, []v1beta1.ModuleImageSpec{}, nil, nil)
+		err := micAPI.CreateOrPatch(ctx, micName, micNamespace, []v1beta1.ModuleImageSpec{}, nil, &kmmv1beta1.Module{})
 
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("failed to create or patch"))
-		Expect(err.Error()).To(ContainSubstring("cannot call SetOwnerReference"))
+		Expect(err.Error()).To(ContainSubstring("some error"))
 	})
 
 	It("should create the MIC if it doesn't exist", func() {


### PR DESCRIPTION
In order to receive event from MIC, KMM Module should be the controller of the MIC, and not just an owner

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved how ownership metadata is set for resources, ensuring the correct controller is assigned.
	- Updated error handling in tests to more accurately reflect errors from resource retrieval operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->