### PR TITLE
deploying bundle with https instead http in operator-upgrade job

### DIFF
--- a/ci/prow/operator-upgrade
+++ b/ci/prow/operator-upgrade
@@ -15,7 +15,6 @@ latest_published_bundle=$(grpcurl -d '{"pkgName": "kernel-module-management", "c
 # Deploy the current bundle
 ./bin/operator-sdk run bundle ${latest_published_bundle} \
     --namespace openshift-kmm \
-    --use-http \
     --timeout 5m0s
 oc wait --for=condition=Available -n openshift-kmm --timeout=1m deployment/kmm-operator-controller
 


### PR DESCRIPTION
When we deploy kmm bundle in operator-upgrade job, we use http instead of https, even though we run it against a secure registry (registry.redhat.io), so the job keeps to fail.
This commit changes it to use https.

---

/cc @ybettan @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated deployment process to remove the use of the `--use-http` flag when running operator bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->