### PR TITLE
Passing the MBSC object as an input to buildsign.Manager interface

### DIFF
--- a/internal/controllers/mbsc_reconciler.go
+++ b/internal/controllers/mbsc_reconciler.go
@@ -125,7 +125,7 @@ func (mrh *mbscReconcilerHelper) updateStatus(ctx context.Context, mbscObj *kmmv
 	patchFrom := client.MergeFrom(mbscObj.DeepCopy())
 	for _, imageSpec := range mbscObj.Spec.Images {
 		status, err := mrh.buildSignAPI.GetStatus(ctx, mbscObj.Name, mbscObj.Namespace, imageSpec.ModuleImageSpec.KernelVersion,
-			imageSpec.Action, &mbscObj.ObjectMeta)
+			imageSpec.Action, mbscObj)
 		if err != nil || status == kmmv1beta1.BuildOrSignStatus("") {
 			// either we could not get the status or the status is empty
 			errs = append(errs, err)
@@ -150,7 +150,7 @@ func (mrh *mbscReconcilerHelper) processImagesSpecs(ctx context.Context, mbscObj
 			continue
 		}
 		mld := createMLD(mbscObj, &imageSpec.ModuleImageSpec)
-		err := mrh.buildSignAPI.Sync(ctx, mld, true, imageSpec.Action, &mbscObj.ObjectMeta)
+		err := mrh.buildSignAPI.Sync(ctx, mld, true, imageSpec.Action, mbscObj)
 		if err != nil {
 			errs = append(errs, err)
 			logger.Info(utils.WarnString("sync for image %s, action %s failed: %v"), imageSpec.Image, imageSpec.Action, err)
@@ -163,7 +163,7 @@ func (mrh *mbscReconcilerHelper) garbageCollect(ctx context.Context, mbscObj *km
 	logger := log.FromContext(ctx)
 
 	// Garbage collect for successfully finished build pods
-	deleted, err := mrh.buildSignAPI.GarbageCollect(ctx, mbscObj.Name, mbscObj.Namespace, kmmv1beta1.BuildImage, &mbscObj.ObjectMeta)
+	deleted, err := mrh.buildSignAPI.GarbageCollect(ctx, mbscObj.Name, mbscObj.Namespace, kmmv1beta1.BuildImage, mbscObj)
 	if err != nil {
 		return fmt.Errorf("could not garbage collect build objects: %v", err)
 	}
@@ -171,7 +171,7 @@ func (mrh *mbscReconcilerHelper) garbageCollect(ctx context.Context, mbscObj *km
 	logger.Info("Garbage-collected Build objects", "names", deleted)
 
 	// Garbage collect for successfully finished sign pods
-	deleted, err = mrh.buildSignAPI.GarbageCollect(ctx, mbscObj.Name, mbscObj.Namespace, kmmv1beta1.SignImage, &mbscObj.ObjectMeta)
+	deleted, err = mrh.buildSignAPI.GarbageCollect(ctx, mbscObj.Name, mbscObj.Namespace, kmmv1beta1.SignImage, mbscObj)
 	if err != nil {
 		return fmt.Errorf("could not garbage collect sign objects: %v", err)
 	}

--- a/internal/controllers/mbsc_reconciler_test.go
+++ b/internal/controllers/mbsc_reconciler_test.go
@@ -136,12 +136,12 @@ var _ = Describe("updateStatus", func() {
 			},
 		}
 		gomock.InOrder(
-			mockManager.EXPECT().GetStatus(ctx, "some name", "some namespace", "kernel version 1", kmmv1beta1.BuildImage, &testMBSC.ObjectMeta).
+			mockManager.EXPECT().GetStatus(ctx, "some name", "some namespace", "kernel version 1", kmmv1beta1.BuildImage, &testMBSC).
 				Return(kmmv1beta1.ActionSuccess, nil),
 			mockMBSC.EXPECT().SetImageStatus(&testMBSC, "image 1", kmmv1beta1.BuildImage, kmmv1beta1.ActionSuccess),
-			mockManager.EXPECT().GetStatus(ctx, "some name", "some namespace", "kernel version 2", kmmv1beta1.SignImage, &testMBSC.ObjectMeta).
+			mockManager.EXPECT().GetStatus(ctx, "some name", "some namespace", "kernel version 2", kmmv1beta1.SignImage, &testMBSC).
 				Return(kmmv1beta1.BuildOrSignStatus(""), nil),
-			mockManager.EXPECT().GetStatus(ctx, "some name", "some namespace", "kernel version 3", kmmv1beta1.BuildImage, &testMBSC.ObjectMeta).
+			mockManager.EXPECT().GetStatus(ctx, "some name", "some namespace", "kernel version 3", kmmv1beta1.BuildImage, &testMBSC).
 				Return(kmmv1beta1.BuildOrSignStatus(""), fmt.Errorf("some error")),
 			clnt.EXPECT().Status().Return(statusWriter),
 			statusWriter.EXPECT().Patch(ctx, &testMBSC, gomock.Any()).Return(nil),
@@ -203,9 +203,9 @@ var _ = Describe("processImagesSpecs", func() {
 		gomock.InOrder(
 			mockMBSC.EXPECT().GetImageStatus(&testMBSC, "image 1", kmmv1beta1.BuildImage).Return(kmmv1beta1.ActionSuccess),
 			mockMBSC.EXPECT().GetImageStatus(&testMBSC, "image 2", kmmv1beta1.SignImage).Return(kmmv1beta1.ActionFailure),
-			mockManager.EXPECT().Sync(ctx, gomock.Any(), true, kmmv1beta1.SignImage, &testMBSC.ObjectMeta).Return(nil),
+			mockManager.EXPECT().Sync(ctx, gomock.Any(), true, kmmv1beta1.SignImage, &testMBSC).Return(nil),
 			mockMBSC.EXPECT().GetImageStatus(&testMBSC, "image 3", kmmv1beta1.BuildImage).Return(kmmv1beta1.BuildOrSignStatus("")),
-			mockManager.EXPECT().Sync(ctx, gomock.Any(), true, kmmv1beta1.BuildImage, &testMBSC.ObjectMeta).Return(fmt.Errorf("some error")),
+			mockManager.EXPECT().Sync(ctx, gomock.Any(), true, kmmv1beta1.BuildImage, &testMBSC).Return(fmt.Errorf("some error")),
 		)
 
 		err := mrh.processImagesSpecs(ctx, &testMBSC)
@@ -240,15 +240,15 @@ var _ = Describe("garbageCollect", func() {
 
 	It("check all flows", func() {
 		By("garbage collect for build failed")
-		mockManager.EXPECT().GarbageCollect(ctx, "some name", "some namespace", kmmv1beta1.BuildImage, &testMBSC.ObjectMeta).Return(nil, fmt.Errorf("some error"))
+		mockManager.EXPECT().GarbageCollect(ctx, "some name", "some namespace", kmmv1beta1.BuildImage, &testMBSC).Return(nil, fmt.Errorf("some error"))
 		err := mrh.garbageCollect(ctx, &testMBSC)
 		Expect(err).To(HaveOccurred())
 
 		By("garbage collect for sign failed")
 		gomock.InOrder(
-			mockManager.EXPECT().GarbageCollect(ctx, "some name", "some namespace", kmmv1beta1.BuildImage, &testMBSC.ObjectMeta).
+			mockManager.EXPECT().GarbageCollect(ctx, "some name", "some namespace", kmmv1beta1.BuildImage, &testMBSC).
 				Return([]string{}, nil),
-			mockManager.EXPECT().GarbageCollect(ctx, "some name", "some namespace", kmmv1beta1.SignImage, &testMBSC.ObjectMeta).
+			mockManager.EXPECT().GarbageCollect(ctx, "some name", "some namespace", kmmv1beta1.SignImage, &testMBSC).
 				Return(nil, fmt.Errorf("some error")),
 		)
 		err = mrh.garbageCollect(ctx, &testMBSC)
@@ -256,8 +256,8 @@ var _ = Describe("garbageCollect", func() {
 
 		By("success")
 		gomock.InOrder(
-			mockManager.EXPECT().GarbageCollect(ctx, "some name", "some namespace", kmmv1beta1.BuildImage, &testMBSC.ObjectMeta).Return([]string{}, nil),
-			mockManager.EXPECT().GarbageCollect(ctx, "some name", "some namespace", kmmv1beta1.SignImage, &testMBSC.ObjectMeta).Return([]string{}, nil),
+			mockManager.EXPECT().GarbageCollect(ctx, "some name", "some namespace", kmmv1beta1.BuildImage, &testMBSC).Return([]string{}, nil),
+			mockManager.EXPECT().GarbageCollect(ctx, "some name", "some namespace", kmmv1beta1.SignImage, &testMBSC).Return([]string{}, nil),
 		)
 		err = mrh.garbageCollect(ctx, &testMBSC)
 		Expect(err).To(BeNil())


### PR DESCRIPTION
Manager interface receives the meta.Object as an input parameter. It passes it to SetControllerReference function, which also expects meta.Object. But inside the function, the it is cast into runtime.Object interface, which requires implementation of DeepCopy function, which is implemented by the whole MBSC object

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability by updating how certain internal operations handle object data, ensuring more accurate processing.

- **Tests**
  - Updated tests to align with changes in object handling, maintaining consistency and test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->