### PR TITLE
BootID support for KMM

### DIFF
--- a/api/v1beta1/nodemodulesconfig_types.go
+++ b/api/v1beta1/nodemodulesconfig_types.go
@@ -68,6 +68,8 @@ type NodeModuleStatus struct {
 	Config ModuleConfig `json:"config,omitempty"`
 	//+optional
 	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
+	//+optional
+	BootId string `json:"bootId,omitempty"`
 }
 
 // NodeModuleConfigStatus is the most recently observed status of the KMM modules on node.

--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2025-03-20T12:29:17Z"
+    createdAt: "2025-05-04T10:24:11Z"
     operatorframework.io/suggested-namespace: openshift-kmm-hub
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -63,7 +63,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2025-04-30T11:06:55Z"
+    createdAt: "2025-05-04T10:24:10Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
+++ b/bundle/manifests/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
@@ -245,6 +245,8 @@ spec:
                   state status
                 items:
                   properties:
+                    bootId:
+                      type: string
                     config:
                       properties:
                         containerImage:

--- a/config/crd/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
@@ -241,6 +241,8 @@ spec:
                   state status
                 items:
                   properties:
+                    bootId:
+                      type: string
                     config:
                       properties:
                         containerImage:

--- a/internal/controllers/mock_nmc_reconciler.go
+++ b/internal/controllers/mock_nmc_reconciler.go
@@ -125,17 +125,17 @@ func (mr *MocknmcReconcilerHelperMockRecorder) RemovePodFinalizers(ctx, nodeName
 }
 
 // SyncStatus mocks base method.
-func (m *MocknmcReconcilerHelper) SyncStatus(ctx context.Context, nmc *v1beta1.NodeModulesConfig) error {
+func (m *MocknmcReconcilerHelper) SyncStatus(ctx context.Context, nmc *v1beta1.NodeModulesConfig, node *v1.Node) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SyncStatus", ctx, nmc)
+	ret := m.ctrl.Call(m, "SyncStatus", ctx, nmc, node)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SyncStatus indicates an expected call of SyncStatus.
-func (mr *MocknmcReconcilerHelperMockRecorder) SyncStatus(ctx, nmc any) *gomock.Call {
+func (mr *MocknmcReconcilerHelperMockRecorder) SyncStatus(ctx, nmc, node any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncStatus", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).SyncStatus), ctx, nmc)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncStatus", reflect.TypeOf((*MocknmcReconcilerHelper)(nil).SyncStatus), ctx, nmc, node)
 }
 
 // UpdateNodeLabels mocks base method.

--- a/internal/controllers/nmc_reconciler.go
+++ b/internal/controllers/nmc_reconciler.go
@@ -93,7 +93,12 @@ func (r *NMCReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 		return reconcile.Result{}, fmt.Errorf("could not get NodeModuleState %s: %v", req.NamespacedName, err)
 	}
 
-	if err := r.helper.SyncStatus(ctx, &nmcObj); err != nil {
+	node := v1.Node{}
+	if err := r.client.Get(ctx, types.NamespacedName{Name: nmcObj.Name}, &node); err != nil {
+		return ctrl.Result{}, fmt.Errorf("could not get node %s: %v", nmcObj.Name, err)
+	}
+
+	if err := r.helper.SyncStatus(ctx, &nmcObj, &node); err != nil {
 		return reconcile.Result{}, fmt.Errorf("could not reconcile status for NodeModulesConfig %s: %v", nmcObj.Name, err)
 	}
 
@@ -104,11 +109,6 @@ func (r *NMCReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 	for i := 0; i < len(nmcObj.Status.Modules); i++ {
 		status := nmcObj.Status.Modules[i]
 		statusMap[status.Namespace+"/"+status.Name] = &nmcObj.Status.Modules[i]
-	}
-
-	node := v1.Node{}
-	if err := r.client.Get(ctx, types.NamespacedName{Name: nmcObj.Name}, &node); err != nil {
-		return ctrl.Result{}, fmt.Errorf("could not get node %s: %v", nmcObj.Name, err)
 	}
 
 	errs := make([]error, 0, len(nmcObj.Spec.Modules)+len(nmcObj.Status.Modules))
@@ -223,7 +223,7 @@ type nmcReconcilerHelper interface {
 	ProcessModuleSpec(ctx context.Context, nmc *kmmv1beta1.NodeModulesConfig, spec *kmmv1beta1.NodeModuleSpec, status *kmmv1beta1.NodeModuleStatus, node *v1.Node) error
 	ProcessUnconfiguredModuleStatus(ctx context.Context, nmc *kmmv1beta1.NodeModulesConfig, status *kmmv1beta1.NodeModuleStatus, node *v1.Node) error
 	RemovePodFinalizers(ctx context.Context, nodeName string) error
-	SyncStatus(ctx context.Context, nmc *kmmv1beta1.NodeModulesConfig) error
+	SyncStatus(ctx context.Context, nmc *kmmv1beta1.NodeModulesConfig, node *v1.Node) error
 	UpdateNodeLabels(ctx context.Context, nmc *kmmv1beta1.NodeModulesConfig, node *v1.Node) ([]types.NamespacedName, []types.NamespacedName, error)
 	RecordEvents(node *v1.Node, loadedModules, unloadedModules []types.NamespacedName)
 }
@@ -377,7 +377,7 @@ func (h *nmcReconcilerHelperImpl) ProcessModuleSpec(
 			return h.podManager.CreateLoaderPod(ctx, nmcObj, spec)
 		}
 
-		if h.nodeAPI.NodeBecomeReadyAfter(node, status.LastTransitionTime) {
+		if h.nodeAPI.IsNodeRebooted(node, status.BootId) {
 			logger.Info("node has been rebooted and become ready after kernel module was loaded; creating loader Pod")
 			return h.podManager.CreateLoaderPod(ctx, nmcObj, spec)
 		}
@@ -428,7 +428,7 @@ func (h *nmcReconcilerHelperImpl) ProcessUnconfiguredModuleStatus(
 	/* node was rebooted, spec not set so no kernel module is loaded, no need to unload.
 	   it also fixes the scenario when node's kernel was upgraded, so unload pod will fail anyway
 	*/
-	if h.nodeAPI.NodeBecomeReadyAfter(node, status.LastTransitionTime) {
+	if h.nodeAPI.IsNodeRebooted(node, status.BootId) {
 		logger.Info("node was rebooted and spec is missing: delete the status to allow Module CR unload, if needed")
 		patchFrom := client.MergeFrom(nmcObj.DeepCopy())
 		nmc.RemoveModuleStatus(&nmcObj.Status.Modules, status.Namespace, status.Name)
@@ -496,7 +496,7 @@ func (h *nmcReconcilerHelperImpl) RemovePodFinalizers(ctx context.Context, nodeN
 	return errors.Join(errs...)
 }
 
-func (h *nmcReconcilerHelperImpl) SyncStatus(ctx context.Context, nmcObj *kmmv1beta1.NodeModulesConfig) error {
+func (h *nmcReconcilerHelperImpl) SyncStatus(ctx context.Context, nmcObj *kmmv1beta1.NodeModulesConfig, node *v1.Node) error {
 	logger := ctrl.LoggerFrom(ctx)
 
 	logger.Info("Syncing status")
@@ -581,6 +581,7 @@ func (h *nmcReconcilerHelperImpl) SyncStatus(ctx context.Context, nmcObj *kmmv1b
 				State.
 				Terminated.
 				FinishedAt
+			status.BootId = node.Status.NodeInfo.BootID
 
 			nmc.SetModuleStatus(&nmcObj.Status.Modules, *status)
 

--- a/internal/controllers/nmc_reconciler_test.go
+++ b/internal/controllers/nmc_reconciler_test.go
@@ -87,7 +87,7 @@ var _ = Describe("NodeModulesConfigReconciler_Reconcile", func() {
 		nmc := &kmmv1beta1.NodeModulesConfig{
 			ObjectMeta: metav1.ObjectMeta{Name: nmcName},
 		}
-
+		node := v1.Node{}
 		gomock.InOrder(
 			kubeClient.
 				EXPECT().
@@ -95,7 +95,8 @@ var _ = Describe("NodeModulesConfigReconciler_Reconcile", func() {
 				Do(func(_ context.Context, _ types.NamespacedName, kubeNmc ctrlclient.Object, _ ...ctrlclient.Options) {
 					*kubeNmc.(*kmmv1beta1.NodeModulesConfig) = *nmc
 				}),
-			wh.EXPECT().SyncStatus(ctx, nmc).Return(errors.New("random error")),
+			kubeClient.EXPECT().Get(ctx, types.NamespacedName{Name: nmc.Name}, &node).Return(nil),
+			wh.EXPECT().SyncStatus(ctx, nmc, &node).Return(errors.New("random error")),
 		)
 
 		_, err := r.Reconcile(ctx, req)
@@ -114,7 +115,6 @@ var _ = Describe("NodeModulesConfigReconciler_Reconcile", func() {
 				Do(func(_ context.Context, _ types.NamespacedName, kubeNmc ctrlclient.Object, _ ...ctrlclient.Options) {
 					*kubeNmc.(*kmmv1beta1.NodeModulesConfig) = *nmc
 				}),
-			wh.EXPECT().SyncStatus(ctx, nmc),
 			kubeClient.EXPECT().Get(ctx, types.NamespacedName{Name: nmc.Name}, &node).Return(fmt.Errorf("some error")),
 		)
 
@@ -157,13 +157,13 @@ var _ = Describe("NodeModulesConfigReconciler_Reconcile", func() {
 				Do(func(_ context.Context, _ types.NamespacedName, kubeNmc ctrlclient.Object, _ ...ctrlclient.Options) {
 					*kubeNmc.(*kmmv1beta1.NodeModulesConfig) = *nmc
 				}),
-			wh.EXPECT().SyncStatus(ctx, nmc),
 			kubeClient.EXPECT().Get(ctx, types.NamespacedName{Name: nmc.Name}, &v1.Node{}).DoAndReturn(
 				func(_ context.Context, _ types.NamespacedName, fetchedNode *v1.Node, _ ...ctrlclient.Options) error {
 					*fetchedNode = node
 					return nil
 				},
 			),
+			wh.EXPECT().SyncStatus(ctx, nmc, &node),
 			nm.EXPECT().IsNodeSchedulable(&node, nil).Return(false),
 			nm.EXPECT().UpdateLabels(ctx, &node, nil, []string{kmodName}).DoAndReturn(
 				func(_ context.Context, obj ctrlclient.Object, _, _ []string) error {
@@ -213,13 +213,13 @@ var _ = Describe("NodeModulesConfigReconciler_Reconcile", func() {
 				Do(func(_ context.Context, _ types.NamespacedName, kubeNmc ctrlclient.Object, _ ...ctrlclient.Options) {
 					*kubeNmc.(*kmmv1beta1.NodeModulesConfig) = *nmc
 				}),
-			wh.EXPECT().SyncStatus(ctx, nmc),
 			kubeClient.EXPECT().Get(ctx, types.NamespacedName{Name: nmc.Name}, &v1.Node{}).DoAndReturn(
 				func(_ context.Context, _ types.NamespacedName, fetchedNode *v1.Node, _ ...ctrlclient.Options) error {
 					*fetchedNode = node
 					return nil
 				},
 			),
+			wh.EXPECT().SyncStatus(ctx, nmc, &node),
 			nm.EXPECT().IsNodeSchedulable(&node, nil).Return(false),
 			nm.EXPECT().UpdateLabels(ctx, &node, nil, []string{kmodName}).DoAndReturn(
 				func(_ context.Context, obj ctrlclient.Object, _, _ []string) error {
@@ -294,8 +294,8 @@ var _ = Describe("NodeModulesConfigReconciler_Reconcile", func() {
 				Do(func(_ context.Context, _ types.NamespacedName, kubeNmc ctrlclient.Object, _ ...ctrlclient.Options) {
 					*kubeNmc.(*kmmv1beta1.NodeModulesConfig) = *nmc
 				}),
-			wh.EXPECT().SyncStatus(ctx, nmc),
 			kubeClient.EXPECT().Get(ctx, types.NamespacedName{Name: nmc.Name}, &node).Return(nil),
+			wh.EXPECT().SyncStatus(ctx, nmc, &node),
 			nm.EXPECT().IsNodeSchedulable(&node, nil).Return(true),
 			wh.EXPECT().ProcessModuleSpec(contextWithValueMatch, nmc, &spec0, &status0, &node),
 			nm.EXPECT().IsNodeSchedulable(&node, nil).Return(true),
@@ -376,8 +376,8 @@ var _ = Describe("NodeModulesConfigReconciler_Reconcile", func() {
 				Do(func(_ context.Context, _ types.NamespacedName, kubeNmc ctrlclient.Object, _ ...ctrlclient.Options) {
 					*kubeNmc.(*kmmv1beta1.NodeModulesConfig) = *nmc
 				}),
-			wh.EXPECT().SyncStatus(ctx, nmc).Return(nil),
 			kubeClient.EXPECT().Get(ctx, types.NamespacedName{Name: nmc.Name}, &node).Return(nil),
+			wh.EXPECT().SyncStatus(ctx, nmc, &node).Return(nil),
 			nm.EXPECT().IsNodeSchedulable(&node, nil).Return(true),
 			wh.EXPECT().ProcessModuleSpec(contextWithValueMatch, nmc, &spec0, &status0, &node).Return(errors.New(errorMeassge)),
 			wh.EXPECT().ProcessUnconfiguredModuleStatus(contextWithValueMatch, nmc, &status2, &node).Return(errors.New(errorMeassge)),
@@ -750,7 +750,7 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessModuleSpec", func() {
 
 			gomock.InOrder(
 				mockWorkerPodManager.EXPECT().GetWorkerPod(ctx, podName, namespace),
-				nm.EXPECT().NodeBecomeReadyAfter(node, status.LastTransitionTime).Return(returnValue),
+				nm.EXPECT().IsNodeRebooted(node, status.BootId).Return(returnValue),
 			)
 
 			if shouldCreate {
@@ -889,7 +889,7 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessUnconfiguredModuleStatus", func
 
 	It("should do nothing , if the node has been rebooted/ready lately", func() {
 		gomock.InOrder(
-			nm.EXPECT().NodeBecomeReadyAfter(&node, status.LastTransitionTime).Return(true),
+			nm.EXPECT().IsNodeRebooted(&node, status.BootId).Return(true),
 			client.EXPECT().Status().Return(sw),
 			sw.EXPECT().Patch(ctx, nmc, gomock.Any()),
 		)
@@ -903,7 +903,7 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessUnconfiguredModuleStatus", func
 
 	It("should create an unloader Pod if no worker Pod exists", func() {
 		gomock.InOrder(
-			nm.EXPECT().NodeBecomeReadyAfter(&node, status.LastTransitionTime).Return(false),
+			nm.EXPECT().IsNodeRebooted(&node, status.BootId).Return(false),
 			mockWorkerPodManager.EXPECT().GetWorkerPod(ctx, podName, namespace),
 			mockWorkerPodManager.EXPECT().CreateUnloaderPod(ctx, nmc, status),
 		)
@@ -924,7 +924,7 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessUnconfiguredModuleStatus", func
 		}
 
 		gomock.InOrder(
-			nm.EXPECT().NodeBecomeReadyAfter(&node, status.LastTransitionTime).Return(false),
+			nm.EXPECT().IsNodeRebooted(&node, status.BootId).Return(false),
 			mockWorkerPodManager.EXPECT().GetWorkerPod(ctx, podName, namespace).Return(&pod, nil),
 			mockWorkerPodManager.EXPECT().IsLoaderPod(&pod).Return(true),
 			mockWorkerPodManager.EXPECT().DeletePod(ctx, &pod),
@@ -946,7 +946,7 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessUnconfiguredModuleStatus", func
 		}
 
 		gomock.InOrder(
-			nm.EXPECT().NodeBecomeReadyAfter(&node, status.LastTransitionTime).Return(false),
+			nm.EXPECT().IsNodeRebooted(&node, status.BootId).Return(false),
 			mockWorkerPodManager.EXPECT().GetWorkerPod(ctx, podName, namespace).Return(&pod, nil),
 			mockWorkerPodManager.EXPECT().IsLoaderPod(&pod).Return(false),
 		)
@@ -975,7 +975,7 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessUnconfiguredModuleStatus", func
 		}
 
 		gomock.InOrder(
-			nm.EXPECT().NodeBecomeReadyAfter(&node, status.LastTransitionTime).Return(false),
+			nm.EXPECT().IsNodeRebooted(&node, status.BootId).Return(false),
 			mockWorkerPodManager.EXPECT().GetWorkerPod(ctx, podName, namespace).Return(&pod, nil),
 			mockWorkerPodManager.EXPECT().IsLoaderPod(&pod).Return(false),
 			mockWorkerPodManager.EXPECT().UnloaderPodTemplate(ctx, nmc, status).Return(nil, errors.New("random error")),
@@ -1007,7 +1007,7 @@ var _ = Describe("nmcReconcilerHelperImpl_ProcessUnconfiguredModuleStatus", func
 		podTemplate := p.DeepCopy()
 
 		gomock.InOrder(
-			nm.EXPECT().NodeBecomeReadyAfter(&node, status.LastTransitionTime).Return(false),
+			nm.EXPECT().IsNodeRebooted(&node, status.BootId).Return(false),
 			mockWorkerPodManager.EXPECT().GetWorkerPod(ctx, podName, namespace).Return(&p, nil),
 			mockWorkerPodManager.EXPECT().IsLoaderPod(&p).Return(false),
 			mockWorkerPodManager.EXPECT().UnloaderPodTemplate(ctx, nmc, status).Return(podTemplate, nil),
@@ -1054,9 +1054,9 @@ var _ = Describe("nmcReconcilerHelperImpl_SyncStatus", func() {
 		nmc := &kmmv1beta1.NodeModulesConfig{
 			ObjectMeta: metav1.ObjectMeta{Name: nmcName},
 		}
-
+		node := v1.Node{}
 		Expect(
-			wh.SyncStatus(ctx, nmc),
+			wh.SyncStatus(ctx, nmc, &node),
 		).NotTo(
 			HaveOccurred(),
 		)
@@ -1109,9 +1109,9 @@ var _ = Describe("nmcReconcilerHelperImpl_SyncStatus", func() {
 			mockWorkerPodManager.EXPECT().DeletePod(ctx, &podWithStatus),
 			mockWorkerPodManager.EXPECT().DeletePod(ctx, &podWithoutStatus),
 		)
-
+		node := v1.Node{}
 		Expect(
-			wh.SyncStatus(ctx, nmc),
+			wh.SyncStatus(ctx, nmc, &node),
 		).NotTo(
 			HaveOccurred(),
 		)
@@ -1156,9 +1156,9 @@ var _ = Describe("nmcReconcilerHelperImpl_SyncStatus", func() {
 			sw.EXPECT().Patch(ctx, nmc, gomock.Any()),
 			mockWorkerPodManager.EXPECT().DeletePod(ctx, &pod),
 		)
-
+		node := v1.Node{}
 		Expect(
-			wh.SyncStatus(ctx, nmc),
+			wh.SyncStatus(ctx, nmc, &node),
 		).NotTo(
 			HaveOccurred(),
 		)
@@ -1240,9 +1240,9 @@ var _ = Describe("nmcReconcilerHelperImpl_SyncStatus", func() {
 			sw.EXPECT().Patch(ctx, nmc, gomock.Any()),
 			mockWorkerPodManager.EXPECT().DeletePod(ctx, &p),
 		)
-
+		node := v1.Node{}
 		Expect(
-			wh.SyncStatus(ctx, nmc),
+			wh.SyncStatus(ctx, nmc, &node),
 		).NotTo(
 			HaveOccurred(),
 		)
@@ -1300,9 +1300,9 @@ var _ = Describe("nmcReconcilerHelperImpl_SyncStatus", func() {
 			kubeClient.EXPECT().Status().Return(sw),
 			sw.EXPECT().Patch(ctx, nmc, gomock.Any()).Return(fmt.Errorf("some error")),
 		)
-
+		node := v1.Node{}
 		Expect(
-			wh.SyncStatus(ctx, nmc),
+			wh.SyncStatus(ctx, nmc, &node),
 		).To(
 			HaveOccurred(),
 		)

--- a/internal/node/mock_node.go
+++ b/internal/node/mock_node.go
@@ -14,7 +14,6 @@ import (
 
 	gomock "go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
-	v10 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // MockNode is a mock of Node interface.
@@ -70,6 +69,20 @@ func (mr *MockNodeMockRecorder) GetNumTargetedNodes(ctx, selector, tolerations a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNumTargetedNodes", reflect.TypeOf((*MockNode)(nil).GetNumTargetedNodes), ctx, selector, tolerations)
 }
 
+// IsNodeRebooted mocks base method.
+func (m *MockNode) IsNodeRebooted(node *v1.Node, statusBootId string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsNodeRebooted", node, statusBootId)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsNodeRebooted indicates an expected call of IsNodeRebooted.
+func (mr *MockNodeMockRecorder) IsNodeRebooted(node, statusBootId any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsNodeRebooted", reflect.TypeOf((*MockNode)(nil).IsNodeRebooted), node, statusBootId)
+}
+
 // IsNodeSchedulable mocks base method.
 func (m *MockNode) IsNodeSchedulable(node *v1.Node, tolerations []v1.Toleration) bool {
 	m.ctrl.T.Helper()
@@ -82,20 +95,6 @@ func (m *MockNode) IsNodeSchedulable(node *v1.Node, tolerations []v1.Toleration)
 func (mr *MockNodeMockRecorder) IsNodeSchedulable(node, tolerations any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsNodeSchedulable", reflect.TypeOf((*MockNode)(nil).IsNodeSchedulable), node, tolerations)
-}
-
-// NodeBecomeReadyAfter mocks base method.
-func (m *MockNode) NodeBecomeReadyAfter(node *v1.Node, checkTime v10.Time) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NodeBecomeReadyAfter", node, checkTime)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// NodeBecomeReadyAfter indicates an expected call of NodeBecomeReadyAfter.
-func (mr *MockNodeMockRecorder) NodeBecomeReadyAfter(node, checkTime any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NodeBecomeReadyAfter", reflect.TypeOf((*MockNode)(nil).NodeBecomeReadyAfter), node, checkTime)
 }
 
 // UpdateLabels mocks base method.

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/meta"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -17,7 +16,7 @@ type Node interface {
 	GetNodesListBySelector(ctx context.Context, selector map[string]string, tolerations []v1.Toleration) ([]v1.Node, error)
 	GetNumTargetedNodes(ctx context.Context, selector map[string]string, tolerations []v1.Toleration) (int, error)
 	UpdateLabels(ctx context.Context, node *v1.Node, toBeAdded, toBeRemoved []string) error
-	NodeBecomeReadyAfter(node *v1.Node, checkTime metav1.Time) bool
+	IsNodeRebooted(node *v1.Node, statusBootId string) bool
 }
 
 type node struct {
@@ -85,11 +84,11 @@ func (n *node) UpdateLabels(ctx context.Context, node *v1.Node, toBeAdded, toBeR
 	return nil
 }
 
-func (n *node) NodeBecomeReadyAfter(node *v1.Node, timestamp metav1.Time) bool {
+func (n *node) IsNodeRebooted(node *v1.Node, statusBootId string) bool {
 	conds := node.Status.Conditions
 	for i := 0; i < len(conds); i++ {
 		c := conds[i]
-		if c.Type == v1.NodeReady && c.Status == v1.ConditionTrue && timestamp.Before(&c.LastTransitionTime) {
+		if c.Type == v1.NodeReady && c.Status == v1.ConditionTrue && (statusBootId != node.Status.NodeInfo.BootID) {
 			return true
 		}
 	}


### PR DESCRIPTION
BootID KMM support:
KMM is checking if a node has rebooted by inspecting the Ready timestamp on the node and check if it newer than the last Ready timestamp recorded.

Kubernetes has a grace period in which if a node stop reporting heartbeats it is then marked by the k8s API server as not ready.

In some cases, the reboot is so fast that the node become Ready again before the k8s API has even noticed it went down, and in those cases we need to make sure KMM catches it and reload the kmod to the node. This is being done by comparing the node's status.nodeInfo.bootID, which is unique per reboot, with the last recorded value.

---

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1471
/assign @yevgeny-shnaidman @TomerNewman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional Boot ID field to module status details for better node state tracking.

- **Bug Fixes**
  - Enhanced node reboot detection by switching from timestamp-based checks to Boot ID comparisons, improving accuracy in module status updates.

- **Tests**
  - Updated test cases to validate node reboot detection using Boot ID instead of readiness timestamps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->