### PR TITLE
Start using `MIC` status to check if an image exists.

### DIFF
--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -397,17 +397,19 @@ func (mrh *moduleReconcilerHelper) handleMIC(ctx context.Context, mod *kmmv1beta
 }
 
 func (mrh *moduleReconcilerHelper) enableModuleOnNode(ctx context.Context, mld *api.ModuleLoaderData, node *v1.Node) error {
+
 	logger := log.FromContext(ctx)
-	if module.ShouldBeBuilt(mld) || module.ShouldBeSigned(mld) {
-		exists, err := module.ImageExists(ctx, mrh.authFactory, mrh.registryAPI, mld, mld.ContainerImage)
-		if err != nil {
-			return fmt.Errorf("failed to verify that image %s exists: %v", mld.ContainerImage, err)
-		}
-		if !exists {
-			// skip updating NMC, reconciliation will kick in once the build pod is completed
-			logger.V(1).Info("Image does not exist, not adding to NMC", "nmc name", node.Name, "container image", mld.ContainerImage)
-			return nil
-		}
+
+	micObj, err := mrh.micAPI.Get(ctx, mld.Name, mld.Namespace)
+	if err != nil {
+		return fmt.Errorf("failed to get moduleImagesConfig %s: %v", mld.Name, err)
+	}
+
+	imageStatus := mrh.micAPI.GetImageState(micObj, mld.ContainerImage)
+	if imageStatus != kmmv1beta1.ImageExists {
+		// skip updating NMC, reconciliation will kick in once the build pod is completed
+		logger.V(1).Info("Image does not exist, not adding to NMC", "nmc name", node.Name, "container image", mld.ContainerImage)
+		return nil
 	}
 
 	moduleConfig := kmmv1beta1.ModuleConfig{

--- a/internal/mic/mock_mic.go
+++ b/internal/mic/mock_mic.go
@@ -55,6 +55,21 @@ func (mr *MockMICMockRecorder) CreateOrPatch(ctx, name, ns, images, imageRepoSec
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrPatch", reflect.TypeOf((*MockMIC)(nil).CreateOrPatch), ctx, name, ns, images, imageRepoSecret, owner)
 }
 
+// Get mocks base method.
+func (m *MockMIC) Get(ctx context.Context, name, ns string) (*v1beta1.ModuleImagesConfig, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", ctx, name, ns)
+	ret0, _ := ret[0].(*v1beta1.ModuleImagesConfig)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockMICMockRecorder) Get(ctx, name, ns any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockMIC)(nil).Get), ctx, name, ns)
+}
+
 // GetImageState mocks base method.
 func (m *MockMIC) GetImageState(micObj *v1beta1.ModuleImagesConfig, image string) v1beta1.ImageState {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Now that the MIC object is being reconciled correctly then we can start using the MIC.status in order to check if an image exists instead of using an explicit HTTP request from the controller container.

---

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1479
/assign @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved reliability by verifying container image existence through a new configuration resource rather than direct registry checks.
- **Bug Fixes**
  - Enhanced error handling when retrieving image configuration data.
- **Tests**
  - Updated and expanded tests to reflect the new image existence verification approach and to cover additional error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->