### PR TITLE
Switching KMM to work with the new build/sign flow

### DIFF
--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -63,7 +63,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2025-05-04T10:26:14Z"
+    createdAt: "2025-05-06T07:44:25Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -220,7 +220,18 @@ spec:
         - apiGroups:
           - kmm.sigs.x-k8s.io
           resources:
+          - modulebuildsignconfigs/finalizers
+          - moduleimagesconfigs/finalizers
+          - modules/finalizers
+          - preflightvalidations/finalizers
+          - preflightvalidationsocp/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - kmm.sigs.x-k8s.io
+          resources:
           - modulebuildsignconfigs/status
+          - moduleimagesconfigs/status
           - modules/status
           - preflightvalidationsocp/status
           verbs:
@@ -251,14 +262,6 @@ spec:
           - patch
           - update
           - watch
-        - apiGroups:
-          - kmm.sigs.x-k8s.io
-          resources:
-          - modules/finalizers
-          - preflightvalidations/finalizers
-          - preflightvalidationsocp/finalizers
-          verbs:
-          - update
         - apiGroups:
           - kmm.sigs.x-k8s.io
           resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -98,7 +98,18 @@ rules:
 - apiGroups:
   - kmm.sigs.x-k8s.io
   resources:
+  - modulebuildsignconfigs/finalizers
+  - moduleimagesconfigs/finalizers
+  - modules/finalizers
+  - preflightvalidations/finalizers
+  - preflightvalidationsocp/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - kmm.sigs.x-k8s.io
+  resources:
   - modulebuildsignconfigs/status
+  - moduleimagesconfigs/status
   - modules/status
   - preflightvalidationsocp/status
   verbs:
@@ -129,14 +140,6 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - kmm.sigs.x-k8s.io
-  resources:
-  - modules/finalizers
-  - preflightvalidations/finalizers
-  - preflightvalidationsocp/finalizers
-  verbs:
-  - update
 - apiGroups:
   - kmm.sigs.x-k8s.io
   resources:

--- a/internal/controllers/mbsc_reconciler.go
+++ b/internal/controllers/mbsc_reconciler.go
@@ -53,7 +53,7 @@ func NewMBSCReconciler(
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *mbscReconciler) SetupWithManager(mgr ctrl.Manager, kernelLabel string) error {
+func (r *mbscReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kmmv1beta1.ModuleBuildSignConfig{}).
 		Owns(&buildv1.Build{}).
@@ -65,6 +65,7 @@ func (r *mbscReconciler) SetupWithManager(mgr ctrl.Manager, kernelLabel string) 
 
 //+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modulebuildsignconfigs,verbs=get;list;watch;update;patch;create
 //+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modulebuildsignconfigs/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modulebuildsignconfigs/finalizers,verbs=update
 //+kubebuilder:rbac:groups="core",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups="core",resources=configmaps,verbs=get;list;watch
 //+kubebuilder:rbac:groups="core",resources=pods,verbs=create;list;watch;delete

--- a/internal/controllers/mic_reconciler.go
+++ b/internal/controllers/mic_reconciler.go
@@ -63,6 +63,10 @@ func (r *micReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		)
 }
 
+//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=moduleimagesconfigs,verbs=get;list;watch;patch;create;delete
+//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=moduleimagesconfigs/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=moduleimagesconfigs/finalizers,verbs=update
+
 func (r *micReconciler) Reconcile(ctx context.Context, micObj *kmmv1beta1.ModuleImagesConfig) (ctrl.Result, error) {
 	res := ctrl.Result{}
 	if micObj.GetDeletionTimestamp() != nil {

--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -38,7 +38,6 @@ import (
 //+kubebuilder:rbac:groups="core",resources=nodes,verbs=get;watch
 //+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=nodemodulesconfigs,verbs=get;list;watch;patch;create;delete
 //+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modules/finalizers,verbs=update
-//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=moduleimagesconfigs,verbs=get;list;watch;patch;create;delete
 
 const (
 	ModuleReconcilerName = "ModuleReconciler"


### PR DESCRIPTION
changing the manager's main to use MIC and MBSC reconcilers instead of BuildSignReconciler

---

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded and refined permissions for managing finalizers and status updates on custom resources, improving operator capabilities.

- **Refactor**
  - Simplified controller setup and reorganized permission rules for better maintainability.
  - Updated method signatures for improved clarity and usage.

- **Chores**
  - Consolidated and cleaned up RBAC rules to remove redundancy and ensure consistent permissions across resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->