### PR TITLE
Changing ImagePuller interface to more elaborate parameters

### DIFF
--- a/internal/controllers/mic_reconciler.go
+++ b/internal/controllers/mic_reconciler.go
@@ -74,7 +74,7 @@ func (r *micReconciler) Reconcile(ctx context.Context, micObj *kmmv1beta1.Module
 		return res, nil
 	}
 
-	pods, err := r.imagePullerAPI.ListPullPods(ctx, micObj)
+	pods, err := r.imagePullerAPI.ListPullPods(ctx, micObj.Name, micObj.Namespace)
 	if err != nil {
 		return res, fmt.Errorf("failed to get the image pods for mic %s: %v", micObj.Name, err)
 	}
@@ -238,7 +238,13 @@ func (mrhi *micReconcilerHelperImpl) processImagesSpecs(ctx context.Context, mic
 			// image State is not set: either new image or pull pod is still running
 			if mrhi.imagePullerAPI.GetPullPodForImage(pullPods, imageSpec.Image) == nil {
 				// no pull pod- create it, otherwise we wait for it to finish
-				err := mrhi.imagePullerAPI.CreatePullPod(ctx, &imageSpec, micObj)
+				err := mrhi.imagePullerAPI.CreatePullPod(ctx,
+					micObj.Name,
+					micObj.Namespace,
+					imageSpec.Image,
+					(imageSpec.Build != nil || imageSpec.Sign != nil),
+					micObj.Spec.ImageRepoSecret,
+					micObj)
 				errs = append(errs, err)
 			}
 		case kmmv1beta1.ImageDoesNotExist:

--- a/internal/pod/imagepuller.go
+++ b/internal/pod/imagepuller.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,7 +22,7 @@ const (
 	imagePullBackOffReason = "ImagePullBackOff"
 	errImagePullReason     = "ErrImagePull"
 
-	moduleImageLabelKey = "kmm.node.kubernetes.io/module-image-config"
+	imageOwnerLabelKey  = "kmm.node.kubernetes.io/image-owner"
 	pullPodTypeLabelKey = "kmm.node.kubernetes.io/pull-pod-type"
 
 	pullerContainerName = "puller"
@@ -35,9 +34,10 @@ const (
 //go:generate mockgen -source=imagepuller.go -package=pod -destination=mock_imagepuller.go
 
 type ImagePuller interface {
-	CreatePullPod(ctx context.Context, imageSpec *kmmv1beta1.ModuleImageSpec, micObj *kmmv1beta1.ModuleImagesConfig) error
+	CreatePullPod(ctx context.Context, name, namespace, imageToPull string, oneTimePod bool,
+		imageRepoSecret *v1.LocalObjectReference, owner metav1.Object) error
 	DeletePod(ctx context.Context, pod *v1.Pod) error
-	ListPullPods(ctx context.Context, micObj *kmmv1beta1.ModuleImagesConfig) ([]v1.Pod, error)
+	ListPullPods(ctx context.Context, name, namespace string) ([]v1.Pod, error)
 	GetPullPodForImage(pods []v1.Pod, image string) *v1.Pod
 	GetPullPodImage(pod v1.Pod) string
 	GetPullPodStatus(pod *v1.Pod) PullPodStatus
@@ -55,33 +55,33 @@ func NewImagePuller(client client.Client, scheme *runtime.Scheme) ImagePuller {
 	}
 }
 
-func (ipi *imagePullerImpl) CreatePullPod(ctx context.Context, imageSpec *kmmv1beta1.ModuleImageSpec,
-	micObj *kmmv1beta1.ModuleImagesConfig) error {
+func (ipi *imagePullerImpl) CreatePullPod(ctx context.Context, name, namespace, imageToPull string, oneTimePod bool,
+	imageRepoSecret *v1.LocalObjectReference, owner metav1.Object) error {
 
-	pullPodTypeLabeValue := pullPodUntilSuccess
-	if imageSpec.Build != nil || imageSpec.Sign != nil {
-		pullPodTypeLabeValue = pullPodTypeOneTime
+	pullPodTypeLabelValue := pullPodUntilSuccess
+	if oneTimePod {
+		pullPodTypeLabelValue = pullPodTypeOneTime
 	}
 
 	imagePullSecrets := []v1.LocalObjectReference{}
-	if micObj.Spec.ImageRepoSecret != nil {
-		imagePullSecrets = []v1.LocalObjectReference{*micObj.Spec.ImageRepoSecret}
+	if imageRepoSecret != nil {
+		imagePullSecrets = []v1.LocalObjectReference{*imageRepoSecret}
 	}
 
 	pullPod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: micObj.Name + "-pull-pod-",
-			Namespace:    micObj.Namespace,
+			GenerateName: name + "-pull-pod-",
+			Namespace:    namespace,
 			Labels: map[string]string{
-				moduleImageLabelKey: micObj.Name,
-				pullPodTypeLabelKey: pullPodTypeLabeValue,
+				imageOwnerLabelKey:  name,
+				pullPodTypeLabelKey: pullPodTypeLabelValue,
 			},
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				{
 					Name:    pullerContainerName,
-					Image:   imageSpec.Image,
+					Image:   imageToPull,
 					Command: []string{"/bin/sh", "-c", "exit 0"},
 				},
 			},
@@ -90,9 +90,9 @@ func (ipi *imagePullerImpl) CreatePullPod(ctx context.Context, imageSpec *kmmv1b
 		},
 	}
 
-	err := ctrl.SetControllerReference(micObj, &pullPod, ipi.scheme)
+	err := ctrl.SetControllerReference(owner, &pullPod, ipi.scheme)
 	if err != nil {
-		return fmt.Errorf("failed to set MIC object %s as owner on pullPod for image %s: %v", micObj.Name, imageSpec.Image, err)
+		return fmt.Errorf("failed to set owner for pullPod for image %s: %v", imageToPull, err)
 	}
 
 	return ipi.client.Create(ctx, &pullPod)
@@ -103,17 +103,17 @@ func (ipi *imagePullerImpl) DeletePod(ctx context.Context, pod *v1.Pod) error {
 	return deletePod(ipi.client, ctx, pod)
 }
 
-func (ipi *imagePullerImpl) ListPullPods(ctx context.Context, micObj *kmmv1beta1.ModuleImagesConfig) ([]v1.Pod, error) {
+func (ipi *imagePullerImpl) ListPullPods(ctx context.Context, name, namespace string) ([]v1.Pod, error) {
 
 	pl := v1.PodList{}
 
 	hl := client.HasLabels{pullPodTypeLabelKey}
-	ml := client.MatchingLabels{moduleImageLabelKey: micObj.Name}
+	ml := client.MatchingLabels{imageOwnerLabelKey: name}
 
-	ctrl.LoggerFrom(ctx).WithValues("mic name", micObj.Name).V(1).Info("Listing mic image Pods")
+	ctrl.LoggerFrom(ctx).WithValues("module name", name).V(1).Info("Listing module image Pods")
 
-	if err := ipi.client.List(ctx, &pl, client.InNamespace(micObj.Namespace), hl, ml); err != nil {
-		return nil, fmt.Errorf("could not list mic image pods for mic %s: %v", micObj.Name, err)
+	if err := ipi.client.List(ctx, &pl, client.InNamespace(namespace), hl, ml); err != nil {
+		return nil, fmt.Errorf("could not list module image pods for module %s: %v", name, err)
 	}
 
 	return pl.Items, nil

--- a/internal/pod/mock_imagepuller.go
+++ b/internal/pod/mock_imagepuller.go
@@ -12,9 +12,9 @@ import (
 	context "context"
 	reflect "reflect"
 
-	v1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	gomock "go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
+	v10 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // MockImagePuller is a mock of ImagePuller interface.
@@ -41,17 +41,17 @@ func (m *MockImagePuller) EXPECT() *MockImagePullerMockRecorder {
 }
 
 // CreatePullPod mocks base method.
-func (m *MockImagePuller) CreatePullPod(ctx context.Context, imageSpec *v1beta1.ModuleImageSpec, micObj *v1beta1.ModuleImagesConfig) error {
+func (m *MockImagePuller) CreatePullPod(ctx context.Context, name, namespace, imageToPull string, oneTimePod bool, imageRepoSecret *v1.LocalObjectReference, owner v10.Object) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreatePullPod", ctx, imageSpec, micObj)
+	ret := m.ctrl.Call(m, "CreatePullPod", ctx, name, namespace, imageToPull, oneTimePod, imageRepoSecret, owner)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreatePullPod indicates an expected call of CreatePullPod.
-func (mr *MockImagePullerMockRecorder) CreatePullPod(ctx, imageSpec, micObj any) *gomock.Call {
+func (mr *MockImagePullerMockRecorder) CreatePullPod(ctx, name, namespace, imageToPull, oneTimePod, imageRepoSecret, owner any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePullPod", reflect.TypeOf((*MockImagePuller)(nil).CreatePullPod), ctx, imageSpec, micObj)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePullPod", reflect.TypeOf((*MockImagePuller)(nil).CreatePullPod), ctx, name, namespace, imageToPull, oneTimePod, imageRepoSecret, owner)
 }
 
 // DeletePod mocks base method.
@@ -111,16 +111,16 @@ func (mr *MockImagePullerMockRecorder) GetPullPodStatus(pod any) *gomock.Call {
 }
 
 // ListPullPods mocks base method.
-func (m *MockImagePuller) ListPullPods(ctx context.Context, micObj *v1beta1.ModuleImagesConfig) ([]v1.Pod, error) {
+func (m *MockImagePuller) ListPullPods(ctx context.Context, name, namespace string) ([]v1.Pod, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListPullPods", ctx, micObj)
+	ret := m.ctrl.Call(m, "ListPullPods", ctx, name, namespace)
 	ret0, _ := ret[0].([]v1.Pod)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListPullPods indicates an expected call of ListPullPods.
-func (mr *MockImagePullerMockRecorder) ListPullPods(ctx, micObj any) *gomock.Call {
+func (mr *MockImagePullerMockRecorder) ListPullPods(ctx, name, namespace any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPullPods", reflect.TypeOf((*MockImagePuller)(nil).ListPullPods), ctx, micObj)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPullPods", reflect.TypeOf((*MockImagePuller)(nil).ListPullPods), ctx, name, namespace)
 }


### PR DESCRIPTION
Since ImagePuller interface is going to be used not only by MIC, but also by Preflight controller, the APIs should be changed to receive specific parameters, and not use ModuleImagesConfig or ImageSpec structures, that are alient to Preflight

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined pod management logic by generalizing parameters for pod creation and listing, reducing dependencies on specific object types.
  - Updated pod labeling for ownership to improve clarity and flexibility.
- **Tests**
  - Adjusted test cases to align with the new parameter structure and updated label keys for better consistency.
- **Chores**
  - Updated mock interfaces and method signatures to match the refactored implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->