### PR TITLE
Refactoring the way we get the hash annotation for build/sign.

### DIFF
--- a/internal/buildsign/ocpbuild/common.go
+++ b/internal/buildsign/ocpbuild/common.go
@@ -9,7 +9,9 @@ import (
 	"github.com/mitchellh/hashstructure/v2"
 	buildv1 "github.com/openshift/api/build/v1"
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 )
@@ -73,44 +75,106 @@ func buildVolumesFromBuildSecrets(secrets []v1.LocalObjectReference) []buildv1.B
 	return vols
 }
 
-func (omi *ocpbuildManagerImpl) hash(ctx context.Context, buildSpec *buildv1.BuildSpec, namespace, keySecretName,
-	certSecretName string) (uint64, error) {
+func (omi *ocpbuildManagerImpl) getSecretData(ctx context.Context, secretName, secretDataKey, namespace string) ([]byte, error) {
+
+	secret := v1.Secret{}
+	namespacedName := types.NamespacedName{Name: secretName, Namespace: namespace}
+
+	if err := omi.client.Get(ctx, namespacedName, &secret); err != nil {
+		return nil, fmt.Errorf("error while getting secret %s: %v", namespacedName, err)
+	}
+
+	data, ok := secret.Data[secretDataKey]
+	if !ok {
+		return nil, fmt.Errorf("invalid Secret %s format, %s key is missing", namespacedName, secretDataKey)
+	}
+
+	return data, nil
+}
+
+func filterOCPBuildsByOwner(builds []buildv1.Build, owner metav1.Object) []buildv1.Build {
+	ownedBuilds := []buildv1.Build{}
+	for _, build := range builds {
+		if metav1.IsControlledBy(&build, owner) {
+			ownedBuilds = append(ownedBuilds, build)
+		}
+	}
+	return ownedBuilds
+}
+
+func moduleKernelLabels(modName, kernelVersion, ocpbuildType string) map[string]string {
+	labels := moduleLabels(modName, ocpbuildType)
+	labels[constants.TargetKernelTarget] = kernelVersion
+	return labels
+}
+
+func moduleLabels(modName, ocpbuildType string) map[string]string {
+	return map[string]string{
+		constants.ModuleNameLabel: modName,
+		constants.BuildTypeLabel:  ocpbuildType,
+	}
+}
+
+func (omi *ocpbuildManagerImpl) getDockerfileData(ctx context.Context, buildConfig *kmmv1beta1.Build, namespace string) (string, error) {
+	dockerfileCM := &v1.ConfigMap{}
+	namespacedName := types.NamespacedName{Name: buildConfig.DockerfileConfigMap.Name, Namespace: namespace}
+	err := omi.client.Get(ctx, namespacedName, dockerfileCM)
+	if err != nil {
+		return "", fmt.Errorf("failed to get dockerfile ConfigMap %s: %v", namespacedName, err)
+	}
+	data, ok := dockerfileCM.Data[constants.DockerfileCMKey]
+	if !ok {
+		return "", fmt.Errorf("invalid Dockerfile ConfigMap %s format, %s key is missing", namespacedName, constants.DockerfileCMKey)
+	}
+	return data, nil
+}
+
+func (omi *ocpbuildManagerImpl) ocpbuildAnnotations(hash uint64) map[string]string {
+	return map[string]string{constants.HashAnnotation: fmt.Sprintf("%d", hash)}
+}
+
+func (omi *ocpbuildManagerImpl) getBuildHashAnnotationValue(ctx context.Context, dockerfileData string) (uint64, error) {
+
+	sourceConfig := buildv1.BuildSource{
+		Dockerfile: &dockerfileData,
+		Type:       buildv1.BuildSourceDockerfile,
+	}
+
+	sourceConfigHash, err := hashstructure.Hash(sourceConfig, hashstructure.FormatV2, nil)
+	if err != nil {
+		return 0, fmt.Errorf("could not hash Build's Buildsource template: %v", err)
+	}
+
+	return sourceConfigHash, nil
+}
+
+func (omi *ocpbuildManagerImpl) getSignHashAnnotationValue(ctx context.Context, privateSecret, publicSecret, namespace string,
+	buildSpec *buildv1.BuildSpec) (uint64, error) {
+
+	publicKeyData, err := omi.getSecretData(ctx, publicSecret, constants.PublicSignDataKey, namespace)
+	if err != nil {
+		return 0, fmt.Errorf("could not get cert bytes: %v", err)
+	}
+
+	privateKeyData, err := omi.getSecretData(ctx, privateSecret, constants.PrivateSignDataKey, namespace)
+	if err != nil {
+		return 0, fmt.Errorf("could not get key bytes: %v", err)
+	}
 
 	dataToHash := struct {
 		BuildSpec      *buildv1.BuildSpec
 		PrivateKeyData []byte
 		PublicKeyData  []byte
 	}{
-		BuildSpec: buildSpec,
-	}
-
-	var err error
-
-	dataToHash.PublicKeyData, err = omi.getSecretBytes(ctx, types.NamespacedName{Namespace: namespace, Name: certSecretName}, "cert.pem")
-	if err != nil {
-		return 0, fmt.Errorf("could not get cert bytes: %v", err)
-	}
-
-	dataToHash.PrivateKeyData, err = omi.getSecretBytes(ctx, types.NamespacedName{Namespace: namespace, Name: keySecretName}, "key.pem")
-	if err != nil {
-		return 0, fmt.Errorf("could not get key bytes: %v", err)
+		BuildSpec:      buildSpec,
+		PrivateKeyData: privateKeyData,
+		PublicKeyData:  publicKeyData,
 	}
 
 	hashValue, err := hashstructure.Hash(dataToHash, hashstructure.FormatV2, nil)
 	if err != nil {
-		return 0, fmt.Errorf("could not hash build spec and secrets: %v", err)
+		return 0, fmt.Errorf("could not hash Build's spec and signing keys: %v", err)
 	}
+
 	return hashValue, nil
-}
-
-func (omi *ocpbuildManagerImpl) getSecretBytes(ctx context.Context, secretObjectKey types.NamespacedName,
-	keyName string) ([]byte, error) {
-
-	secret := v1.Secret{}
-
-	if err := omi.client.Get(ctx, secretObjectKey, &secret); err != nil {
-		return nil, fmt.Errorf("error while getting secret %s: %v", secretObjectKey, err)
-	}
-
-	return secret.Data[keyName], nil
 }

--- a/internal/buildsign/ocpbuild/mock_ocbuildmanager.go
+++ b/internal/buildsign/ocpbuild/mock_ocbuildmanager.go
@@ -159,20 +159,6 @@ func (mr *MockocpbuildManagerMockRecorder) makeOcpbuildSignTemplate(ctx, mld, pu
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "makeOcpbuildSignTemplate", reflect.TypeOf((*MockocpbuildManager)(nil).makeOcpbuildSignTemplate), ctx, mld, pushImage, owner)
 }
 
-// ocpbuildAnnotations mocks base method.
-func (m *MockocpbuildManager) ocpbuildAnnotations(hash uint64) map[string]string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ocpbuildAnnotations", hash)
-	ret0, _ := ret[0].(map[string]string)
-	return ret0
-}
-
-// ocpbuildAnnotations indicates an expected call of ocpbuildAnnotations.
-func (mr *MockocpbuildManagerMockRecorder) ocpbuildAnnotations(hash any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ocpbuildAnnotations", reflect.TypeOf((*MockocpbuildManager)(nil).ocpbuildAnnotations), hash)
-}
-
 // ocpbuildLabels mocks base method.
 func (m *MockocpbuildManager) ocpbuildLabels(modName, kernelVersion, ocpbuildType string) map[string]string {
 	m.ctrl.T.Helper()

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -9,6 +9,7 @@ const (
 	TargetKernelTarget   = "kmm.node.kubernetes.io/target-kernel"
 	KernelLabel          = "kmm.node.kubernetes.io/kernel-version.full"
 	BuildTypeLabel       = "kmm.openshift.io/build.type"
+	HashAnnotation       = "kmm.node.kubernetes.io/last-hash"
 	NamespaceLabelKey    = "kmm.node.k8s.io/contains-modules"
 
 	WorkerPodVersionLabelPrefix    = "beta.kmm.node.kubernetes.io/version-worker-pod"


### PR DESCRIPTION
Reducing the diff between the 2 flows and re-use code.

---

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1489
Some cosmetic changes were made to make the code a bit more like the u/s code

/assign @TomerNewman @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved separation of logic for handling secrets, build filtering, labeling, and hashing, resulting in more modular and maintainable code.
	- Standardized annotation keys across the application for consistency.
- **Tests**
	- Enhanced test reliability by improving secret data mocking and updating tests to use the standardized annotation key.
- **Chores**
	- Removed unused methods and updated internal references to streamline the codebase.
- **New Features**
	- Added a new annotation key for tracking the last hash related to modules or nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->