### PR TITLE
Split the build's and sign's specs creation for ocpbuild templates.

### DIFF
--- a/internal/buildsign/ocpbuild/common.go
+++ b/internal/buildsign/ocpbuild/common.go
@@ -245,7 +245,8 @@ func (omi *ocpbuildManagerImpl) signSpec(mld *api.ModuleLoaderData, dockerfileDa
 			Strategy: buildv1.BuildStrategy{
 				Type: buildv1.DockerBuildStrategyType,
 				DockerStrategy: &buildv1.DockerBuildStrategy{
-					Volumes: volumes,
+					Volumes:    volumes,
+					PullSecret: mld.ImageRepoSecret,
 				},
 			},
 			Output:         buildTarget,


### PR DESCRIPTION
To be simpler.

---

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1501
/assign @TomerNewman @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined and simplified the process for building and signing kernel module container images, resulting in a more maintainable and consistent experience for users.
- **Chores**
  - Removed unused internal components to improve system efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->