### PR TITLE
Remove non KMM related tolerations from the NMC status

### DIFF
--- a/internal/controllers/nmc_reconciler.go
+++ b/internal/controllers/nmc_reconciler.go
@@ -567,7 +567,14 @@ func (h *nmcReconcilerHelperImpl) SyncStatus(ctx context.Context, nmcObj *kmmv1b
 					errs,
 					fmt.Errorf("%s: could not unmarshal the ModuleConfig from YAML: %v", podNSN, err),
 				)
-
+				continue
+			}
+			tolerationsAnnotation := h.podManager.GetTolerationsAnnotation(&p)
+			if err = yaml.UnmarshalStrict([]byte(tolerationsAnnotation), &status.Tolerations); err != nil {
+				errs = append(
+					errs,
+					fmt.Errorf("%s: could not unmarshal the ModuleConfig from YAML: %v", podNSN, err),
+				)
 				continue
 			}
 
@@ -575,7 +582,6 @@ func (h *nmcReconcilerHelperImpl) SyncStatus(ctx context.Context, nmcObj *kmmv1b
 				status.ImageRepoSecret = &p.Spec.ImagePullSecrets[0]
 			}
 			status.ServiceAccountName = p.Spec.ServiceAccountName
-			status.Tolerations = p.Spec.Tolerations
 
 			status.BootId = node.Status.NodeInfo.BootID
 

--- a/internal/controllers/nmc_reconciler_test.go
+++ b/internal/controllers/nmc_reconciler_test.go
@@ -1228,10 +1228,14 @@ var _ = Describe("nmcReconcilerHelperImpl_SyncStatus", func() {
 		b, err := yaml.Marshal(cfg)
 		Expect(err).NotTo(HaveOccurred())
 
+		tolerations, err := yaml.Marshal(p.Spec.Tolerations)
+		Expect(err).NotTo(HaveOccurred())
+
 		gomock.InOrder(
 			mockWorkerPodManager.EXPECT().ListWorkerPodsOnNode(ctx, nmcName).Return([]v1.Pod{p}, nil),
 			mockWorkerPodManager.EXPECT().IsUnloaderPod(&p).Return(false),
 			mockWorkerPodManager.EXPECT().GetConfigAnnotation(&p).Return(string(b)),
+			mockWorkerPodManager.EXPECT().GetTolerationsAnnotation(&p).Return(string(tolerations)),
 			kubeClient.EXPECT().Status().Return(sw),
 			sw.EXPECT().Patch(ctx, nmc, gomock.Any()),
 			mockWorkerPodManager.EXPECT().DeletePod(ctx, &p),

--- a/internal/pod/mock_workerpodmanager.go
+++ b/internal/pod/mock_workerpodmanager.go
@@ -97,6 +97,20 @@ func (mr *MockWorkerPodManagerMockRecorder) GetConfigAnnotation(p any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigAnnotation", reflect.TypeOf((*MockWorkerPodManager)(nil).GetConfigAnnotation), p)
 }
 
+// GetTolerationsAnnotation mocks base method.
+func (m *MockWorkerPodManager) GetTolerationsAnnotation(p *v1.Pod) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTolerationsAnnotation", p)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetTolerationsAnnotation indicates an expected call of GetTolerationsAnnotation.
+func (mr *MockWorkerPodManagerMockRecorder) GetTolerationsAnnotation(p any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTolerationsAnnotation", reflect.TypeOf((*MockWorkerPodManager)(nil).GetTolerationsAnnotation), p)
+}
+
 // GetWorkerPod mocks base method.
 func (m *MockWorkerPodManager) GetWorkerPod(ctx context.Context, podName, namespace string) (*v1.Pod, error) {
 	m.ctrl.T.Helper()

--- a/internal/pod/workerpodmanager_test.go
+++ b/internal/pod/workerpodmanager_test.go
@@ -485,6 +485,7 @@ cp -R /firmware-path/* /tmp/firmware-path;
 	} else {
 		configAnnotationValue = strings.ReplaceAll(configAnnotationValue, "firmwarePath: /firmware-path\n  ", "")
 	}
+	tolerationAnotationValue := "- effect: NoExecute\n  key: test-key\n  value: test-value\n"
 	pod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      WorkerPodName(nmcName, moduleName),
@@ -497,8 +498,9 @@ cp -R /firmware-path/* /tmp/firmware-path;
 				constants.ModuleNameLabel:     moduleName,
 			},
 			Annotations: map[string]string{
-				configAnnotationKey: configAnnotationValue,
-				modulesOrderKey:     modulesOrderValue,
+				configAnnotationKey:      configAnnotationValue,
+				modulesOrderKey:          modulesOrderValue,
+				tolerationsAnnotationKey: tolerationAnotationValue,
 			},
 		},
 		Spec: v1.PodSpec{


### PR DESCRIPTION
Until now, the  nmc status reflected all pod tolerations, including those unrelated to KMM.

This commit updates the behavior to source tolerations from a dedicated annotation instead,
ensuring only KMM-specific tolerations appear in the status.


---

/cc @yevgeny-shnaidman @ybettan 
fixes #1504


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tolerations are now stored and retrieved as annotations on pods, improving how tolerations are managed and synchronized in status displays.

- **Bug Fixes**
  - Enhanced error handling when reading tolerations from pod annotations, ensuring more robust status updates.

- **Tests**
  - Updated and extended tests to verify tolerations annotation handling and synchronization logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->