### PR TITLE
Removed the `ocpbuildType` consts in the `buildsign` package.

### DIFF
--- a/internal/buildsign/ocpbuild/manager.go
+++ b/internal/buildsign/ocpbuild/manager.go
@@ -39,12 +39,8 @@ func NewManager(client client.Client,
 
 func (m *manager) GetStatus(ctx context.Context, name, namespace, kernelVersion string,
 	action kmmv1beta1.BuildOrSignAction, owner metav1.Object) (kmmv1beta1.BuildOrSignStatus, error) {
-	ocpbuildType := ocpbuildTypeBuild
-	if action == kmmv1beta1.SignImage {
-		ocpbuildType = ocpbuildTypeSign
-	}
 	normalizedKernel := kernel.NormalizeVersion(kernelVersion)
-	foundOCPBuild, err := m.ocpbuildManager.getModuleOCPBuildByKernel(ctx, name, namespace, normalizedKernel, ocpbuildType, owner)
+	foundOCPBuild, err := m.ocpbuildManager.getModuleOCPBuildByKernel(ctx, name, namespace, normalizedKernel, string(action), owner)
 	if err != nil {
 		if !errors.Is(err, ErrNoMatchingBuild) {
 			return kmmv1beta1.BuildOrSignStatus(""), fmt.Errorf("failed to get ocpbuild %s/%s, action %s: %v", namespace, name, action, err)
@@ -70,18 +66,15 @@ func (m *manager) GetStatus(ctx context.Context, name, namespace, kernelVersion 
 func (m *manager) Sync(ctx context.Context, mld *api.ModuleLoaderData, pushImage bool, action kmmv1beta1.BuildOrSignAction, owner metav1.Object) error {
 	logger := log.FromContext(ctx)
 	var (
-		ocpbuildType     string
 		ocpbuildTemplate *buildv1.Build
 		err              error
 	)
 	switch action {
 	case kmmv1beta1.BuildImage:
 		logger.Info("Building in-cluster")
-		ocpbuildType = ocpbuildTypeBuild
 		ocpbuildTemplate, err = m.ocpbuildManager.makeOcpbuildBuildTemplate(ctx, mld, pushImage, owner)
 	case kmmv1beta1.SignImage:
 		logger.Info("Signing in-cluster")
-		ocpbuildType = ocpbuildTypeSign
 		ocpbuildTemplate, err = m.ocpbuildManager.makeOcpbuildSignTemplate(ctx, mld, pushImage, owner)
 	default:
 		return fmt.Errorf("invalid action %s", action)
@@ -92,11 +85,11 @@ func (m *manager) Sync(ctx context.Context, mld *api.ModuleLoaderData, pushImage
 	}
 
 	b, err := m.ocpbuildManager.getModuleOCPBuildByKernel(ctx, mld.Name, mld.Namespace,
-		mld.KernelNormalizedVersion, ocpbuildType, owner)
+		mld.KernelNormalizedVersion, string(action), owner)
 
 	if err != nil {
 		if !errors.Is(err, ErrNoMatchingBuild) {
-			return fmt.Errorf("error getting the %s ocpbuild: %v", ocpbuildType, err)
+			return fmt.Errorf("error getting the %s ocpbuild: %v", action, err)
 		}
 
 		logger.Info("Creating build")
@@ -117,7 +110,7 @@ func (m *manager) Sync(ctx context.Context, mld *api.ModuleLoaderData, pushImage
 		logger.Info("The module's spec has been changed, deleting the current ocpbuild so a new one can be created", "name", b.Name, "action", action)
 		err = m.ocpbuildManager.deleteOCPBuild(ctx, b)
 		if err != nil {
-			logger.Info(utils.WarnString(fmt.Sprintf("failed to delete %s ocpbuild %s: %v", ocpbuildType, b.Name, err)))
+			logger.Info(utils.WarnString(fmt.Sprintf("failed to delete %s ocpbuild %s: %v", action, b.Name, err)))
 		}
 	}
 
@@ -125,13 +118,10 @@ func (m *manager) Sync(ctx context.Context, mld *api.ModuleLoaderData, pushImage
 }
 
 func (m *manager) GarbageCollect(ctx context.Context, name, namespace string, action kmmv1beta1.BuildOrSignAction, owner metav1.Object) ([]string, error) {
-	ocpbuildType := ocpbuildTypeBuild
-	if action == kmmv1beta1.SignImage {
-		ocpbuildType = ocpbuildTypeSign
-	}
-	builds, err := m.ocpbuildManager.getModuleOCPBuilds(ctx, name, namespace, ocpbuildType, owner)
+
+	builds, err := m.ocpbuildManager.getModuleOCPBuilds(ctx, name, namespace, string(action), owner)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get %s buils for mbsc %s/%s: %v", ocpbuildType, namespace, name, err)
+		return nil, fmt.Errorf("failed to get %s buils for mbsc %s/%s: %v", action, namespace, name, err)
 	}
 
 	logger := log.FromContext(ctx)
@@ -142,7 +132,7 @@ func (m *manager) GarbageCollect(ctx context.Context, name, namespace string, ac
 			err = m.ocpbuildManager.deleteOCPBuild(ctx, &build)
 			errs = append(errs, err)
 			if err != nil {
-				logger.Info(utils.WarnString("failed to delete %s build %s in garbage collection: %v"), ocpbuildType, build.Name, err)
+				logger.Info(utils.WarnString("failed to delete %s build %s in garbage collection: %v"), action, build.Name, err)
 				continue
 			}
 			deleteBuildsNames = append(deleteBuildsNames, build.Name)

--- a/internal/buildsign/ocpbuild/manager_test.go
+++ b/internal/buildsign/ocpbuild/manager_test.go
@@ -44,7 +44,8 @@ var _ = Describe("GetStatus", func() {
 
 	It("failed flow, getModuleOCPBuildByKernel fails", func() {
 		normalizedKernel := kernel.NormalizeVersion(kernelVersion)
-		mockOCPBuildManager.EXPECT().getModuleOCPBuildByKernel(ctx, mbscName, mbscNamespace, normalizedKernel, ocpbuildTypeBuild, &testMBSC).
+		mockOCPBuildManager.EXPECT().getModuleOCPBuildByKernel(ctx, mbscName, mbscNamespace, normalizedKernel,
+			string(kmmv1beta1.BuildImage), &testMBSC).
 			Return(nil, fmt.Errorf("some error"))
 
 		status, err := mgr.GetStatus(ctx, mbscName, mbscNamespace, kernelVersion, kmmv1beta1.BuildImage, &testMBSC)
@@ -54,7 +55,8 @@ var _ = Describe("GetStatus", func() {
 
 	It("getModuleOCPBuildByKernel returns pod does not exists", func() {
 		normalizedKernel := kernel.NormalizeVersion(kernelVersion)
-		mockOCPBuildManager.EXPECT().getModuleOCPBuildByKernel(ctx, mbscName, mbscNamespace, normalizedKernel, ocpbuildTypeBuild, &testMBSC).
+		mockOCPBuildManager.EXPECT().getModuleOCPBuildByKernel(ctx, mbscName, mbscNamespace, normalizedKernel,
+			string(kmmv1beta1.BuildImage), &testMBSC).
 			Return(nil, ErrNoMatchingBuild)
 
 		status, err := mgr.GetStatus(ctx, mbscName, mbscNamespace, kernelVersion, kmmv1beta1.BuildImage, &testMBSC)
@@ -66,7 +68,8 @@ var _ = Describe("GetStatus", func() {
 		foundBuild := buildv1.Build{}
 		normalizedKernel := kernel.NormalizeVersion(kernelVersion)
 		gomock.InOrder(
-			mockOCPBuildManager.EXPECT().getModuleOCPBuildByKernel(ctx, mbscName, mbscNamespace, normalizedKernel, ocpbuildTypeBuild, &testMBSC).
+			mockOCPBuildManager.EXPECT().getModuleOCPBuildByKernel(ctx, mbscName, mbscNamespace, normalizedKernel,
+				string(kmmv1beta1.BuildImage), &testMBSC).
 				Return(&foundBuild, nil),
 			mockOCPBuildManager.EXPECT().getOCPBuildStatus(&foundBuild).Return(Status(""), fmt.Errorf("some error")),
 		)
@@ -80,7 +83,8 @@ var _ = Describe("GetStatus", func() {
 		foundBuild := buildv1.Build{}
 		normalizedKernel := kernel.NormalizeVersion(kernelVersion)
 		gomock.InOrder(
-			mockOCPBuildManager.EXPECT().getModuleOCPBuildByKernel(ctx, mbscName, mbscNamespace, normalizedKernel, ocpbuildTypeBuild, &testMBSC).
+			mockOCPBuildManager.EXPECT().getModuleOCPBuildByKernel(ctx, mbscName, mbscNamespace, normalizedKernel,
+				string(kmmv1beta1.BuildImage), &testMBSC).
 				Return(&foundBuild, nil),
 			mockOCPBuildManager.EXPECT().getOCPBuildStatus(&foundBuild).Return(buildStatus, nil),
 		)
@@ -141,7 +145,8 @@ var _ = Describe("Sync", func() {
 	It("GetModulePodByKernel failed", func() {
 		gomock.InOrder(
 			mockOCPBuildManager.EXPECT().makeOcpbuildBuildTemplate(ctx, testMLD, true, &testMBSC).Return(nil, nil),
-			mockOCPBuildManager.EXPECT().getModuleOCPBuildByKernel(ctx, mbscName, mbscNamespace, kernelVersion, ocpbuildTypeBuild, &testMBSC).
+			mockOCPBuildManager.EXPECT().getModuleOCPBuildByKernel(ctx, mbscName, mbscNamespace, kernelVersion,
+				string(kmmv1beta1.BuildImage), &testMBSC).
 				Return(nil, fmt.Errorf("some error")),
 		)
 		err := mgr.Sync(ctx, testMLD, true, kmmv1beta1.BuildImage, &testMBSC)
@@ -152,7 +157,8 @@ var _ = Describe("Sync", func() {
 		testTemplate := buildv1.Build{}
 		gomock.InOrder(
 			mockOCPBuildManager.EXPECT().makeOcpbuildBuildTemplate(ctx, testMLD, true, &testMBSC).Return(&testTemplate, nil),
-			mockOCPBuildManager.EXPECT().getModuleOCPBuildByKernel(ctx, mbscName, mbscNamespace, kernelVersion, ocpbuildTypeBuild, &testMBSC).
+			mockOCPBuildManager.EXPECT().getModuleOCPBuildByKernel(ctx, mbscName, mbscNamespace, kernelVersion,
+				string(kmmv1beta1.BuildImage), &testMBSC).
 				Return(nil, ErrNoMatchingBuild),
 			mockOCPBuildManager.EXPECT().createOCPBuild(ctx, &testTemplate).Return(fmt.Errorf("some error")),
 		)
@@ -165,7 +171,8 @@ var _ = Describe("Sync", func() {
 		testBuild := buildv1.Build{}
 		gomock.InOrder(
 			mockOCPBuildManager.EXPECT().makeOcpbuildBuildTemplate(ctx, testMLD, true, &testMBSC).Return(&testTemplate, nil),
-			mockOCPBuildManager.EXPECT().getModuleOCPBuildByKernel(ctx, mbscName, mbscNamespace, kernelVersion, ocpbuildTypeBuild, &testMBSC).
+			mockOCPBuildManager.EXPECT().getModuleOCPBuildByKernel(ctx, mbscName, mbscNamespace, kernelVersion,
+				string(kmmv1beta1.BuildImage), &testMBSC).
 				Return(&testBuild, nil),
 			mockOCPBuildManager.EXPECT().isOCPBuildChanged(&testBuild, &testTemplate).Return(false, fmt.Errorf("some error")),
 		)
@@ -178,7 +185,8 @@ var _ = Describe("Sync", func() {
 		testBuild := buildv1.Build{}
 		gomock.InOrder(
 			mockOCPBuildManager.EXPECT().makeOcpbuildBuildTemplate(ctx, testMLD, true, &testMBSC).Return(&testTemplate, nil),
-			mockOCPBuildManager.EXPECT().getModuleOCPBuildByKernel(ctx, mbscName, mbscNamespace, kernelVersion, ocpbuildTypeBuild, &testMBSC).
+			mockOCPBuildManager.EXPECT().getModuleOCPBuildByKernel(ctx, mbscName, mbscNamespace, kernelVersion,
+				string(kmmv1beta1.BuildImage), &testMBSC).
 				Return(&testBuild, nil),
 			mockOCPBuildManager.EXPECT().isOCPBuildChanged(&testBuild, &testTemplate).Return(true, nil),
 			mockOCPBuildManager.EXPECT().deleteOCPBuild(ctx, &testBuild).Return(fmt.Errorf("some error")),
@@ -188,12 +196,10 @@ var _ = Describe("Sync", func() {
 	})
 
 	DescribeTable("check good flow", func(buildAction, buildExists, buildChanged, pushImage bool) {
-		testAction := kmmv1beta1.BuildImage
 		testBuildTemplate := buildv1.Build{}
 		existingTestBuild := buildv1.Build{}
-		buildType := ocpbuildTypeBuild
+		testAction := kmmv1beta1.BuildImage
 		if !buildAction {
-			buildType = ocpbuildTypeSign
 			testAction = kmmv1beta1.SignImage
 		}
 
@@ -206,8 +212,8 @@ var _ = Describe("Sync", func() {
 		if !buildExists {
 			getBuildError = ErrNoMatchingBuild
 		}
-		mockOCPBuildManager.EXPECT().getModuleOCPBuildByKernel(ctx, mbscName, mbscNamespace, kernelVersion, buildType, &testMBSC).
-			Return(&existingTestBuild, getBuildError)
+		mockOCPBuildManager.EXPECT().getModuleOCPBuildByKernel(ctx, mbscName, mbscNamespace, kernelVersion, string(testAction),
+			&testMBSC).Return(&existingTestBuild, getBuildError)
 		if !buildExists {
 			mockOCPBuildManager.EXPECT().createOCPBuild(ctx, &testBuildTemplate).Return(nil)
 			goto executeTestFunction
@@ -257,9 +263,10 @@ var _ = Describe("GarbageCollect", func() {
 	testMBSC := kmmv1beta1.ModuleBuildSignConfig{}
 
 	It("failed to get module buildss", func() {
-		mockOCPBuildManager.EXPECT().getModuleOCPBuilds(ctx, mbscName, mbscNamespace, ocpbuildTypeBuild, &testMBSC).Return(nil, fmt.Errorf("some error"))
+		mockOCPBuildManager.EXPECT().getModuleOCPBuilds(ctx, mbscName, mbscNamespace, string(kmmv1beta1.BuildImage),
+			&testMBSC).Return(nil, fmt.Errorf("some error"))
 
-		_, err := mgr.GarbageCollect(ctx, mbscName, mbscNamespace, ocpbuildTypeBuild, &testMBSC)
+		_, err := mgr.GarbageCollect(ctx, mbscName, mbscNamespace, kmmv1beta1.BuildImage, &testMBSC)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -270,12 +277,12 @@ var _ = Describe("GarbageCollect", func() {
 			},
 		}
 		gomock.InOrder(
-			mockOCPBuildManager.EXPECT().getModuleOCPBuilds(ctx, mbscName, mbscNamespace, ocpbuildTypeBuild, &testMBSC).
+			mockOCPBuildManager.EXPECT().getModuleOCPBuilds(ctx, mbscName, mbscNamespace, string(kmmv1beta1.BuildImage), &testMBSC).
 				Return([]buildv1.Build{testBuild}, nil),
 			mockOCPBuildManager.EXPECT().deleteOCPBuild(ctx, &testBuild).Return(fmt.Errorf("some error")),
 		)
 
-		_, err := mgr.GarbageCollect(ctx, mbscName, mbscNamespace, ocpbuildTypeBuild, &testMBSC)
+		_, err := mgr.GarbageCollect(ctx, mbscName, mbscNamespace, kmmv1beta1.BuildImage, &testMBSC)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -302,12 +309,12 @@ var _ = Describe("GarbageCollect", func() {
 		}
 		returnedBuilds := []buildv1.Build{testBuildSuccess, testBuildFailure, testBuildRunning, testBuildError, testBuildPending}
 		gomock.InOrder(
-			mockOCPBuildManager.EXPECT().getModuleOCPBuilds(ctx, mbscName, mbscNamespace, ocpbuildTypeBuild, &testMBSC).
+			mockOCPBuildManager.EXPECT().getModuleOCPBuilds(ctx, mbscName, mbscNamespace, string(kmmv1beta1.BuildImage), &testMBSC).
 				Return(returnedBuilds, nil),
 			mockOCPBuildManager.EXPECT().deleteOCPBuild(ctx, &testBuildSuccess).Return(nil),
 		)
 
-		res, err := mgr.GarbageCollect(ctx, mbscName, mbscNamespace, ocpbuildTypeBuild, &testMBSC)
+		res, err := mgr.GarbageCollect(ctx, mbscName, mbscNamespace, kmmv1beta1.BuildImage, &testMBSC)
 		Expect(err).To(BeNil())
 		Expect(res).To(Equal([]string{"buildSuccess"}))
 	})

--- a/internal/buildsign/ocpbuild/ocpbuildmanager.go
+++ b/internal/buildsign/ocpbuild/ocpbuildmanager.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/module"
@@ -21,9 +22,6 @@ import (
 type Status string
 
 const (
-	ocpbuildTypeBuild = "build"
-	ocpbuildTypeSign  = "sign"
-
 	StatusCompleted  Status = "completed"
 	StatusCreated    Status = "created"
 	StatusInProgress Status = "in progress"
@@ -192,7 +190,7 @@ func (omi *ocpbuildManagerImpl) makeOcpbuildBuildTemplate(ctx context.Context, m
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: mld.Name + "-build-",
 			Namespace:    mld.Namespace,
-			Labels:       omi.ocpbuildLabels(mld.Name, mld.KernelNormalizedVersion, ocpbuildTypeBuild),
+			Labels:       omi.ocpbuildLabels(mld.Name, mld.KernelNormalizedVersion, string(kmmv1beta1.BuildImage)),
 			Annotations:  omi.ocpbuildAnnotations(sourceConfigHash),
 			Finalizers:   []string{constants.GCDelayFinalizer, constants.JobEventFinalizer},
 		},
@@ -246,7 +244,7 @@ func (omi *ocpbuildManagerImpl) makeOcpbuildSignTemplate(ctx context.Context, ml
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: mld.Name + "-sign-",
 			Namespace:    mld.Namespace,
-			Labels:       omi.ocpbuildLabels(mld.Name, mld.KernelNormalizedVersion, ocpbuildTypeSign),
+			Labels:       omi.ocpbuildLabels(mld.Name, mld.KernelNormalizedVersion, string(kmmv1beta1.SignImage)),
 			Annotations:  omi.ocpbuildAnnotations(buildSpecHash),
 			Finalizers:   []string{constants.GCDelayFinalizer, constants.JobEventFinalizer},
 		},

--- a/internal/controllers/build_sign_events_reconciler.go
+++ b/internal/controllers/build_sign_events_reconciler.go
@@ -6,10 +6,9 @@ import (
 	"fmt"
 
 	buildv1 "github.com/openshift/api/build/v1"
-	ocpbuildbuild "github.com/rh-ecosystem-edge/kernel-module-management/internal/build/ocpbuild"
+	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/meta"
-	ocpbuildsign "github.com/rh-ecosystem-edge/kernel-module-management/internal/sign/ocpbuild"
 	"golang.org/x/exp/maps"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -178,7 +177,7 @@ func (r *JobEventReconciler) Reconcile(ctx context.Context, build *buildv1.Build
 var jobEventPredicate = predicate.NewPredicateFuncs(func(obj client.Object) bool {
 	label := obj.GetLabels()[constants.BuildTypeLabel]
 
-	return (label == ocpbuildbuild.BuildType || label == ocpbuildsign.BuildType) &&
+	return (label == string(kmmv1beta1.BuildImage) || label == string(kmmv1beta1.SignImage)) &&
 		controllerutil.ContainsFinalizer(obj, constants.JobEventFinalizer)
 })
 

--- a/internal/controllers/job_gc_reconciler.go
+++ b/internal/controllers/job_gc_reconciler.go
@@ -5,9 +5,8 @@ import (
 	"time"
 
 	buildv1 "github.com/openshift/api/build/v1"
-	buildocpbuild "github.com/rh-ecosystem-edge/kernel-module-management/internal/build/ocpbuild"
+	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
-	signocpbuild "github.com/rh-ecosystem-edge/kernel-module-management/internal/sign/ocpbuild"
 	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -59,7 +58,7 @@ func (r *JobGCReconciler) Reconcile(ctx context.Context, build *buildv1.Build) (
 }
 
 func (r *JobGCReconciler) SetupWithManager(mgr manager.Manager) error {
-	podTypes := sets.New(buildocpbuild.BuildType, signocpbuild.BuildType)
+	podTypes := sets.New(string(kmmv1beta1.BuildImage), string(kmmv1beta1.SignImage))
 
 	p := predicate.NewPredicateFuncs(func(object client.Object) bool {
 		return podTypes.Has(


### PR DESCRIPTION
We can directly use the API's `BuildImage` and `SignImage`. No need to use local consts and do the translation.

---

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1507
/assign @TomerNewman @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized build and sign type labels throughout the application to use consistent string values from the public API, improving label consistency and maintainability.
  - Updated internal logic and tests to use these standardized labels, removing reliance on local or internal constants.

- **Tests**
  - Adjusted test cases to match the new label conventions and ensure continued accuracy of build and sign event filtering and processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->