### PR TITLE
Adding support for Modules with no OOT kmod

### DIFF
--- a/api/v1beta1/module_types.go
+++ b/api/v1beta1/module_types.go
@@ -319,7 +319,8 @@ type ModuleSpec struct {
 
 	// ModuleLoader allows overriding some properties of the container that loads the kernel module on the node.
 	// Name and image are ignored and are set automatically by the KMM Operator.
-	ModuleLoader ModuleLoaderSpec `json:"moduleLoader"`
+	// +optional
+	ModuleLoader *ModuleLoaderSpec `json:"moduleLoader,omitempty"`
 
 	// ImageRepoSecret is an optional secret that is used to pull both the module loader and the device plugin, and
 	// to push the resulting image from the module loader build, if enabled.
@@ -351,7 +352,7 @@ type ModuleStatus struct {
 	// if it was deployed during reconciliation
 	DevicePlugin DaemonSetStatus `json:"devicePlugin,omitempty"`
 	// ModuleLoader contains the status of the ModuleLoader daemonset
-	ModuleLoader DaemonSetStatus `json:"moduleLoader"`
+	ModuleLoader DaemonSetStatus `json:"moduleLoader,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -730,7 +730,11 @@ func (in *ModuleSpec) DeepCopyInto(out *ModuleSpec) {
 		*out = new(DevicePluginSpec)
 		(*in).DeepCopyInto(*out)
 	}
-	in.ModuleLoader.DeepCopyInto(&out.ModuleLoader)
+	if in.ModuleLoader != nil {
+		in, out := &in.ModuleLoader, &out.ModuleLoader
+		*out = new(ModuleLoaderSpec)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ImageRepoSecret != nil {
 		in, out := &in.ImageRepoSecret, &out.ImageRepoSecret
 		*out = new(v1.LocalObjectReference)

--- a/bundle-hub/manifests/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
+++ b/bundle-hub/manifests/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
@@ -2732,7 +2732,6 @@ spec:
                       type: object
                     type: array
                 required:
-                - moduleLoader
                 - selector
                 type: object
               selector:

--- a/bundle/manifests/kmm.sigs.x-k8s.io_modules.yaml
+++ b/bundle/manifests/kmm.sigs.x-k8s.io_modules.yaml
@@ -2708,7 +2708,6 @@ spec:
                   type: object
                 type: array
             required:
-            - moduleLoader
             - selector
             type: object
           status:
@@ -2749,8 +2748,6 @@ spec:
                     format: int32
                     type: integer
                 type: object
-            required:
-            - moduleLoader
             type: object
         type: object
     served: true

--- a/config/crd-hub/bases/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
+++ b/config/crd-hub/bases/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
@@ -2728,7 +2728,6 @@ spec:
                       type: object
                     type: array
                 required:
-                - moduleLoader
                 - selector
                 type: object
               selector:

--- a/config/crd/bases/kmm.sigs.x-k8s.io_modules.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_modules.yaml
@@ -2704,7 +2704,6 @@ spec:
                   type: object
                 type: array
             required:
-            - moduleLoader
             - selector
             type: object
           status:
@@ -2745,8 +2744,6 @@ spec:
                     format: int32
                     type: integer
                 type: object
-            required:
-            - moduleLoader
             type: object
         type: object
     served: true

--- a/internal/controllers/device_plugin_reconciler.go
+++ b/internal/controllers/device_plugin_reconciler.go
@@ -184,9 +184,10 @@ func (dprh *devicePluginReconcilerHelper) handleDevicePlugin(ctx context.Context
 	}
 
 	logger := log.FromContext(ctx)
-	ds := getExistingDS(existingDevicePluginDS, mod.Namespace, mod.Name, mod.Spec.ModuleLoader.Container.Version)
+
+	ds, version := getExistingDSFromVersion(existingDevicePluginDS, mod.Namespace, mod.Name, mod.Spec.ModuleLoader)
 	if ds == nil {
-		logger.Info("creating new device plugin DS", "version", mod.Spec.ModuleLoader.Container.Version)
+		logger.Info("creating new device plugin DS", "version", version)
 		ds = &appsv1.DaemonSet{
 			ObjectMeta: metav1.ObjectMeta{Namespace: mod.Namespace, GenerateName: mod.Name + "-device-plugin-"},
 		}
@@ -205,6 +206,11 @@ func (dprh *devicePluginReconcilerHelper) handleDevicePlugin(ctx context.Context
 func (dprh *devicePluginReconcilerHelper) garbageCollect(ctx context.Context,
 	mod *kmmv1beta1.Module,
 	existingDS []appsv1.DaemonSet) error {
+	if mod.Spec.ModuleLoader == nil {
+		// If ModuleLoader is not exist, Ordered Upgrade is not relevant
+		// so there is no need to delete older-versioned Deamonsets
+		return nil
+	}
 
 	logger := log.FromContext(ctx)
 	deleted := make([]string, 0)
@@ -250,21 +256,22 @@ func (dprh *devicePluginReconcilerHelper) setKMMOMetrics(ctx context.Context) {
 		if mod.Spec.DevicePlugin != nil {
 			numModulesWithDevicePlugin += 1
 		}
-		buildCapable, signCapable := isModuleBuildAndSignCapable(&mod)
-		if buildCapable {
-			numModulesWithBuild += 1
-		}
-		if signCapable {
-			numModulesWithSign += 1
-		}
-
-		if mod.Spec.ModuleLoader.Container.Modprobe.Args != nil {
-			modprobeArgs := strings.Join(mod.Spec.ModuleLoader.Container.Modprobe.Args.Load, ",")
-			dprh.metricsAPI.SetKMMModprobeArgs(mod.Name, mod.Namespace, modprobeArgs)
-		}
-		if mod.Spec.ModuleLoader.Container.Modprobe.RawArgs != nil {
-			modprobeRawArgs := strings.Join(mod.Spec.ModuleLoader.Container.Modprobe.RawArgs.Load, ",")
-			dprh.metricsAPI.SetKMMModprobeRawArgs(mod.Name, mod.Namespace, modprobeRawArgs)
+		if mod.Spec.ModuleLoader != nil {
+			buildCapable, signCapable := isModuleBuildAndSignCapable(&mod)
+			if buildCapable {
+				numModulesWithBuild += 1
+			}
+			if signCapable {
+				numModulesWithSign += 1
+			}
+			if mod.Spec.ModuleLoader.Container.Modprobe.Args != nil {
+				modprobeArgs := strings.Join(mod.Spec.ModuleLoader.Container.Modprobe.Args.Load, ",")
+				dprh.metricsAPI.SetKMMModprobeArgs(mod.Name, mod.Namespace, modprobeArgs)
+			}
+			if mod.Spec.ModuleLoader.Container.Modprobe.RawArgs != nil {
+				modprobeRawArgs := strings.Join(mod.Spec.ModuleLoader.Container.Modprobe.RawArgs.Load, ",")
+				dprh.metricsAPI.SetKMMModprobeRawArgs(mod.Name, mod.Namespace, modprobeRawArgs)
+			}
 		}
 	}
 	dprh.metricsAPI.SetKMMModulesNum(numModules)
@@ -352,14 +359,8 @@ func (dsci *daemonSetCreatorImpl) setDevicePluginAsDesired(
 			},
 		},
 	}
-	standardLabels := map[string]string{constants.ModuleNameLabel: mod.Name}
-	nodeSelector := map[string]string{utils.GetKernelModuleReadyNodeLabel(mod.Namespace, mod.Name): ""}
 
-	if mod.Spec.ModuleLoader.Container.Version != "" {
-		versionLabel := utils.GetDevicePluginVersionLabelName(mod.Namespace, mod.Name)
-		standardLabels[versionLabel] = mod.Spec.ModuleLoader.Container.Version
-		nodeSelector[versionLabel] = mod.Spec.ModuleLoader.Container.Version
-	}
+	standardLabels, nodeSelector := generateDevicePluginLabelsAndSelector(mod)
 
 	ds.SetLabels(
 		overrideLabels(ds.GetLabels(), standardLabels),
@@ -408,6 +409,21 @@ func (dsci *daemonSetCreatorImpl) setDevicePluginAsDesired(
 	return controllerutil.SetControllerReference(mod, ds, dsci.scheme)
 }
 
+func generateDevicePluginLabelsAndSelector(mod *kmmv1beta1.Module) (map[string]string, map[string]string) {
+	labels := map[string]string{constants.ModuleNameLabel: mod.Name}
+	nodeSelector := map[string]string{utils.GetKernelModuleReadyNodeLabel(mod.Namespace, mod.Name): ""}
+
+	if mod.Spec.ModuleLoader != nil && mod.Spec.ModuleLoader.Container.Version != "" {
+		versionLabel := utils.GetDevicePluginVersionLabelName(mod.Namespace, mod.Name)
+		labels[versionLabel] = mod.Spec.ModuleLoader.Container.Version
+		nodeSelector[versionLabel] = mod.Spec.ModuleLoader.Container.Version
+	} else if mod.Spec.ModuleLoader == nil {
+		nodeSelector = mod.Spec.Selector
+	}
+
+	return labels, nodeSelector
+}
+
 func isModuleBuildAndSignCapable(mod *kmmv1beta1.Module) (bool, bool) {
 	buildCapable := mod.Spec.ModuleLoader.Container.Build != nil
 	signCapable := mod.Spec.ModuleLoader.Container.Sign != nil
@@ -425,19 +441,23 @@ func isModuleBuildAndSignCapable(mod *kmmv1beta1.Module) (bool, bool) {
 	return buildCapable, signCapable
 }
 
-func getExistingDS(existingDS []appsv1.DaemonSet,
+func getExistingDSFromVersion(existingDS []appsv1.DaemonSet,
 	moduleNamespace string,
 	moduleName string,
-	moduleVersion string) *appsv1.DaemonSet {
+	moduleLoader *kmmv1beta1.ModuleLoaderSpec) (*appsv1.DaemonSet, string) {
+	version := ""
+	if moduleLoader != nil {
+		version = moduleLoader.Container.Version
+	}
 
 	versionLabel := utils.GetDevicePluginVersionLabelName(moduleNamespace, moduleName)
 	for _, ds := range existingDS {
 		dsModuleVersion := ds.GetLabels()[versionLabel]
-		if dsModuleVersion == moduleVersion {
-			return &ds
+		if dsModuleVersion == version {
+			return &ds, version
 		}
 	}
-	return nil
+	return nil, version
 }
 
 func isOlderVersionUnusedDevicePluginDaemonset(ds *appsv1.DaemonSet, moduleVersion string) bool {

--- a/internal/controllers/device_plugin_reconciler_test.go
+++ b/internal/controllers/device_plugin_reconciler_test.go
@@ -240,7 +240,7 @@ var _ = Describe("DevicePluginReconciler_garbageCollect", func() {
 			Namespace: "namespace",
 		},
 		Spec: kmmv1beta1.ModuleSpec{
-			ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+			ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{
 				Container: kmmv1beta1.ModuleLoaderContainerSpec{
 					Version: currentModuleVersion,
 				},
@@ -297,6 +297,23 @@ var _ = Describe("DevicePluginReconciler_garbageCollect", func() {
 
 		err := dprh.garbageCollect(context.Background(), mod, existingDS)
 		Expect(err).To(HaveOccurred())
+	})
+
+	It("should pass if moduleLoader is not defined", func() {
+		modWithoutModuleLoader := mod
+		modWithoutModuleLoader.Spec.ModuleLoader = nil
+		deleteDS := appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "devicePlugin",
+				Namespace: "namespace",
+				Labels:    map[string]string{constants.ModuleNameLabel: mod.Name, devicePluginVersionLabel: "formerVersion"},
+			},
+		}
+
+		existingDS := []appsv1.DaemonSet{deleteDS}
+
+		err := dprh.garbageCollect(context.Background(), modWithoutModuleLoader, existingDS)
+		Expect(err).ToNot(HaveOccurred())
 	})
 })
 
@@ -365,9 +382,20 @@ var _ = Describe("DevicePluginReconciler_setKMMOMetrics", func() {
 				Name:      "moduleName",
 				Namespace: "namespace",
 			},
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{},
+			},
 		}
-		mod2 := kmmv1beta1.Module{}
-		mod3 := kmmv1beta1.Module{}
+		mod2 := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{},
+			},
+		}
+		mod3 := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{},
+			},
+		}
 		numBuild := 0
 		numSign := 0
 		numDevicePlugin := 0
@@ -453,7 +481,11 @@ var _ = Describe("DevicePluginReconciler_moduleUpdateDevicePluginStatus", func()
 	ctx := context.Background()
 
 	It("device plugin not defined in the module", func() {
-		mod := kmmv1beta1.Module{}
+		mod := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{},
+			},
+		}
 		err := dprh.moduleUpdateDevicePluginStatus(ctx, &mod, nil)
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -528,8 +560,13 @@ var _ = Describe("DevicePluginReconciler_setDevicePluginAsDesired", func() {
 
 	It("should return an error if DevicePlugin not set in the Spec", func() {
 		ds := appsv1.DaemonSet{}
+		mod := kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{},
+			},
+		}
 		Expect(
-			dsc.setDevicePluginAsDesired(context.Background(), &ds, &kmmv1beta1.Module{}),
+			dsc.setDevicePluginAsDesired(context.Background(), &ds, &mod),
 		).To(
 			HaveOccurred(),
 		)
@@ -589,7 +626,7 @@ var _ = Describe("DevicePluginReconciler_setDevicePluginAsDesired", func() {
 				Namespace: namespace,
 			},
 			Spec: kmmv1beta1.ModuleSpec{
-				ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+				ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{
 					Container: kmmv1beta1.ModuleLoaderContainerSpec{
 						Version: "some version",
 					},
@@ -615,7 +652,7 @@ var _ = Describe("DevicePluginReconciler_setDevicePluginAsDesired", func() {
 		Expect(ds.GetLabels()).Should(HaveKeyWithValue(versionLabel, "some version"))
 	})
 
-	It("should work as expected", func() {
+	DescribeTable("should work as expected", func(moduleLoader *kmmv1beta1.ModuleLoaderSpec, expectedNodeSelector map[string]string) {
 		const (
 			dsName             = "ds-name"
 			serviceAccountName = "some-service-account"
@@ -672,6 +709,7 @@ var _ = Describe("DevicePluginReconciler_setDevicePluginAsDesired", func() {
 				Namespace: namespace,
 			},
 			Spec: kmmv1beta1.ModuleSpec{
+				ModuleLoader: moduleLoader,
 				DevicePlugin: &kmmv1beta1.DevicePluginSpec{
 					Container: kmmv1beta1.DevicePluginContainerSpec{
 						Args:            args,
@@ -748,10 +786,8 @@ var _ = Describe("DevicePluginReconciler_setDevicePluginAsDesired", func() {
 								},
 							},
 						},
-						ImagePullSecrets: []v1.LocalObjectReference{repoSecret},
-						NodeSelector: map[string]string{
-							utils.GetKernelModuleReadyNodeLabel(mod.Namespace, mod.Name): "",
-						},
+						ImagePullSecrets:   []v1.LocalObjectReference{repoSecret},
+						NodeSelector:       expectedNodeSelector,
 						PriorityClassName:  "system-node-critical",
 						ServiceAccountName: serviceAccountName,
 						Volumes: []v1.Volume{
@@ -776,10 +812,19 @@ var _ = Describe("DevicePluginReconciler_setDevicePluginAsDesired", func() {
 		).To(
 			BeTrue(), cmp.Diff(expected, ds),
 		)
-	})
+	},
+		Entry("moduleLoader is nil",
+			nil,
+			map[string]string{"has-feature-x": "true"},
+		),
+		Entry("moduleLoader is defined",
+			&kmmv1beta1.ModuleLoaderSpec{},
+			map[string]string{utils.GetKernelModuleReadyNodeLabel(namespace, moduleName): ""},
+		),
+	)
 })
 
-var _ = Describe("DevicePluginReconciler_getExistingDS", func() {
+var _ = Describe("DevicePluginReconciler_getExistingDSFromVersion", func() {
 	const (
 		moduleName      = "moduleName"
 		moduleNamespace = "moduleNamespace"
@@ -797,22 +842,26 @@ var _ = Describe("DevicePluginReconciler_getExistingDS", func() {
 
 	It("various scenarios", func() {
 		By("empty daemonset list")
-		res := getExistingDS(nil, moduleNamespace, moduleName, moduleVersion)
+		res, version := getExistingDSFromVersion(nil, moduleNamespace, moduleName, &kmmv1beta1.ModuleLoaderSpec{Container: kmmv1beta1.ModuleLoaderContainerSpec{Version: moduleVersion}})
 		Expect(res).To(BeNil())
+		Expect(version).To(Equal(moduleVersion))
 
 		By("device plugin, module version equal")
 		ds.SetLabels(devicePluginLabels)
-		res = getExistingDS([]appsv1.DaemonSet{ds}, moduleNamespace, moduleName, moduleVersion)
+		res, version = getExistingDSFromVersion([]appsv1.DaemonSet{ds}, moduleNamespace, moduleName, &kmmv1beta1.ModuleLoaderSpec{Container: kmmv1beta1.ModuleLoaderContainerSpec{Version: moduleVersion}})
 		Expect(res).To(Equal(&ds))
+		Expect(version).To(Equal(moduleVersion))
 
 		By("device plugin, module version not equal")
-		res = getExistingDS([]appsv1.DaemonSet{ds}, moduleNamespace, moduleName, "some version")
+		res, version = getExistingDSFromVersion([]appsv1.DaemonSet{ds}, moduleNamespace, moduleName, &kmmv1beta1.ModuleLoaderSpec{Container: kmmv1beta1.ModuleLoaderContainerSpec{Version: "some-version"}})
 		Expect(res).To(BeNil())
+		Expect(version).To(Equal("some-version"))
 
 		By("device plugin, module version label missing, and module version parameter is empty")
 		ds.SetLabels(map[string]string{})
-		res = getExistingDS([]appsv1.DaemonSet{ds}, moduleNamespace, moduleName, "")
+		res, version = getExistingDSFromVersion([]appsv1.DaemonSet{ds}, moduleNamespace, moduleName, &kmmv1beta1.ModuleLoaderSpec{Container: kmmv1beta1.ModuleLoaderContainerSpec{Version: ""}})
 		Expect(res).To(Equal(&ds))
+		Expect(version).To(Equal(""))
 	})
 })
 

--- a/internal/controllers/hub/managedclustermodule_reconciler_test.go
+++ b/internal/controllers/hub/managedclustermodule_reconciler_test.go
@@ -329,7 +329,7 @@ var _ = Describe("ManagedClusterModuleReconciler_Reconcile", func() {
 			},
 			Spec: v1beta1.ManagedClusterModuleSpec{
 				ModuleSpec: kmmv1beta1.ModuleSpec{
-					ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{
 						Container: kmmv1beta1.ModuleLoaderContainerSpec{
 							Build: &kmmv1beta1.Build{},
 						},

--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -115,6 +115,11 @@ func (mr *ModuleReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.Modul
 		return ctrl.Result{}, fmt.Errorf("failed to set finalizer on Module %s/%s: %v", mod.Namespace, mod.Name, err)
 	}
 
+	if mod.Spec.ModuleLoader == nil {
+		logger.Info("ModuleLoader is not defined, skipping loading kernel module")
+		return ctrl.Result{}, nil
+	}
+
 	// get nodes targeted by selector
 	targetedNodes, err := mr.nodeAPI.GetNodesListBySelector(ctx, mod.Spec.Selector, mod.Spec.Tolerations)
 	if err != nil {

--- a/internal/manifestwork/manifestwork_test.go
+++ b/internal/manifestwork/manifestwork_test.go
@@ -188,7 +188,7 @@ var _ = Describe("SetManifestWorkAsDesired", func() {
 			Spec: hubv1beta1.ManagedClusterModuleSpec{
 				SpokeNamespace: spokeNamespace,
 				ModuleSpec: kmmv1beta1.ModuleSpec{
-					ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+					ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{
 						Container: kmmv1beta1.ModuleLoaderContainerSpec{
 							Build: &kmmv1beta1.Build{},
 							Sign:  &kmmv1beta1.Sign{},
@@ -251,7 +251,7 @@ var _ = Describe("SetManifestWorkAsDesired", func() {
 		}
 
 		expectedModuleSpec := kmmv1beta1.ModuleSpec{
-			ModuleLoader: kmmv1beta1.ModuleLoaderSpec{
+			ModuleLoader: &kmmv1beta1.ModuleLoaderSpec{
 				Container: kmmv1beta1.ModuleLoaderContainerSpec{
 					Build: nil,
 					Sign:  nil,

--- a/internal/module/kernelmapper_test.go
+++ b/internal/module/kernelmapper_test.go
@@ -29,6 +29,7 @@ var _ = Describe("GetModuleLoaderDataForKernel", func() {
 		kh = NewMockkernelMapperHelperAPI(ctrl)
 		km = &kernelMapper{helper: kh}
 		mod = kmmv1beta1.Module{}
+		mod.Spec.ModuleLoader = &kmmv1beta1.ModuleLoaderSpec{}
 	})
 
 	AfterEach(func() {
@@ -164,8 +165,8 @@ var _ = Describe("prepareModuleLoaderData", func() {
 		mockCombiner = NewMockCombiner(ctrl)
 		kh = newKernelMapperHelper(mockCombiner)
 		mod = kmmv1beta1.Module{}
-		mod.Spec.ModuleLoader.Container.ContainerImage = "spec container image"
-		mod.Spec.ModuleLoader.Container.ImagePullPolicy = "Always"
+		ModuleLoader := kmmv1beta1.ModuleLoaderSpec{Container: kmmv1beta1.ModuleLoaderContainerSpec{ContainerImage: "spec container image", ImagePullPolicy: "Always"}}
+		mod.Spec.ModuleLoader = &ModuleLoader
 		mapping = kmmv1beta1.KernelMapping{}
 	})
 

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -52,7 +52,7 @@ func TestPreflight(t *testing.T) {
 				Name: moduleName,
 			},
 			Spec: v1beta1.ModuleSpec{
-				ModuleLoader: v1beta1.ModuleLoaderSpec{
+				ModuleLoader: &v1beta1.ModuleLoaderSpec{
 					Container: v1beta1.ModuleLoaderContainerSpec{
 						Modprobe: v1beta1.ModprobeSpec{
 							ModuleName: "simple-kmod",


### PR DESCRIPTION
When KMM is used by 3rd party vendor operators, they need an option to configure KMM Module not to load OOT kernel driver, but use the in-tree one, and just run the device-plugin.
This commit makes moduleLoader in Module cr a pointer, hence making it an optional field.

---

fixes #1509
/cc @ybettan @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The ModuleLoader field is now optional in Module and ManagedClusterModule resources, allowing these resources to be created without specifying a ModuleLoader.

- **Bug Fixes**
  - Improved handling and validation to prevent errors when ModuleLoader is not defined.
  - Added safeguards to avoid nil pointer dereferences related to ModuleLoader.

- **Tests**
  - Enhanced test coverage for scenarios where ModuleLoader is omitted or set to nil.

- **Documentation**
  - Updated resource schema to reflect that ModuleLoader is no longer a required field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->