### PR TITLE
Skip waiting for missing image in case the flag is set

### DIFF
--- a/internal/controllers/mic_reconciler.go
+++ b/internal/controllers/mic_reconciler.go
@@ -154,6 +154,9 @@ func (mrhi *micReconcilerHelperImpl) updateStatusByPullPods(ctx context.Context,
 			case imageSpec.Sign != nil:
 				logger.Info("pull pod failed, build does not exist, sign exists, setting status to kmmv1beta1.ImageNeedsSigning")
 				mrhi.micHelper.SetImageStatus(micObj, image, kmmv1beta1.ImageNeedsSigning)
+			case imageSpec.SkipWaitMissingImage:
+				logger.Info("pull pod failed, SkipWaitMissingImage was set, setting status to kmmv1beta1.ImageDoesNotExist")
+				mrhi.micHelper.SetImageStatus(micObj, image, kmmv1beta1.ImageDoesNotExist)
 			default:
 				logger.Info(utils.WarnString("failed pod without build or sign spec, shoud not have happened"))
 			}
@@ -238,11 +241,12 @@ func (mrhi *micReconcilerHelperImpl) processImagesSpecs(ctx context.Context, mic
 			// image State is not set: either new image or pull pod is still running
 			if mrhi.imagePullerAPI.GetPullPodForImage(pullPods, imageSpec.Image) == nil {
 				// no pull pod- create it, otherwise we wait for it to finish
+				oneTimePod := imageSpec.Build != nil || imageSpec.Sign != nil || imageSpec.SkipWaitMissingImage
 				err := mrhi.imagePullerAPI.CreatePullPod(ctx,
 					micObj.Name,
 					micObj.Namespace,
 					imageSpec.Image,
-					(imageSpec.Build != nil || imageSpec.Sign != nil),
+					oneTimePod,
 					micObj.Spec.ImageRepoSecret,
 					micObj)
 				errs = append(errs, err)


### PR DESCRIPTION
This commit implements skipping waiting for missing image using image puller pod in case the SkipWaitMissingImage is set in MIC The changes are:
1. In case SkipWaitMissingImage is set, the image puller pod is created with pullPodTypeLabel set to "one-time-pull"
2. The when the pod is in pending state due to a missing image, GetPullPodStatus will return PodFailed, since pullPodTypeLabel is set to "one-time-pull"
3. When updating image status in MIC based on puller pod, in case the puller pod status is failed and the SkipWaitMissingImage is set, then the status is set to ImageDoesNotExists