### PR TITLE
Allow KMM to be installed on worker nodes if there is no better choice.

### DIFF
--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2025-05-14T05:51:10Z"
+    createdAt: "2025-05-21T13:45:02Z"
     operatorframework.io/suggested-namespace: openshift-kmm-hub
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -313,17 +313,17 @@ spec:
             spec:
               affinity:
                 nodeAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    nodeSelectorTerms:
-                    - matchExpressions:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - preference:
+                      matchExpressions:
                       - key: node-role.kubernetes.io/control-plane
                         operator: Exists
-                    - matchExpressions:
+                    weight: 1
+                  - preference:
+                      matchExpressions:
                       - key: node-role.kubernetes.io/master
                         operator: Exists
-                    - matchExpressions:
-                      - key: kmm.node.kubernetes.io/control-plane
-                        operator: Exists
+                    weight: 1
               containers:
               - args:
                 - --config=controller_config.yaml

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -63,7 +63,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2025-05-14T05:51:08Z"
+    createdAt: "2025-05-21T13:45:01Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -444,17 +444,17 @@ spec:
             spec:
               affinity:
                 nodeAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
-                    nodeSelectorTerms:
-                    - matchExpressions:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - preference:
+                      matchExpressions:
                       - key: node-role.kubernetes.io/control-plane
                         operator: Exists
-                    - matchExpressions:
+                    weight: 1
+                  - preference:
+                      matchExpressions:
                       - key: node-role.kubernetes.io/master
                         operator: Exists
-                    - matchExpressions:
-                      - key: kmm.node.kubernetes.io/control-plane
-                        operator: Exists
+                    weight: 1
               containers:
               - args:
                 - --config=controller_config.yaml

--- a/config/manager-base/manager.yaml
+++ b/config/manager-base/manager.yaml
@@ -28,16 +28,16 @@ spec:
     spec:
       affinity:
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
               - key: node-role.kubernetes.io/control-plane
                 operator: Exists
-            - matchExpressions:
+          - weight: 1
+            preference:
+              matchExpressions:
               - key: node-role.kubernetes.io/master
-                operator: Exists
-            - matchExpressions:
-              - key: kmm.node.kubernetes.io/control-plane
                 operator: Exists
       securityContext:
         runAsNonRoot: true

--- a/config/webhook-server/deployment.yaml
+++ b/config/webhook-server/deployment.yaml
@@ -20,17 +20,17 @@ spec:
     spec:
       affinity:
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: node-role.kubernetes.io/control-plane
-                    operator: Exists
-              - matchExpressions:
-                  - key: node-role.kubernetes.io/master
-                    operator: Exists
-              - matchExpressions:
-                  - key: kmm.node.kubernetes.io/control-plane
-                    operator: Exists
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       securityContext:
         runAsNonRoot: true
       containers:


### PR DESCRIPTION
Some installations of k8s doesn't allow deploying workloads on the control-plane nodes or the control-plane isn't accessible at all.

In these installs, the worker nodes do not have the node-role.kubernetes.io/control-plane or node-role.kubernetes.io/master labels. Because the worker nodes do not have these labels the Kernel Module Management operator will not run out of the box.

This commit changes the nodeAffinity to
preferredDuringSchedulingIgnoredDuringExecution to solve this issue.

Signed-off-by: brucejcong

---

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1518 
Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1438
/assign @yevgeny-shnaidman @TomerNewman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
  - Updated node scheduling rules for deployments to prefer, rather than require, specific node roles. Pods now prefer to run on nodes labeled as control-plane or master, but can be scheduled elsewhere if necessary. This change increases flexibility and resilience in pod placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->