### PR TITLE
Update nmc node predicate to detect Ready transitions and meaningful changes

### DIFF
--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -2,18 +2,16 @@ package filter
 
 import (
 	"context"
-	"reflect"
-
 	"github.com/go-logr/logr"
 	buildv1 "github.com/openshift/api/build/v1"
 	imagev1 "github.com/openshift/api/image/v1"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/node"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubectl/pkg/util/podutils"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"
+	"reflect"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -151,53 +149,48 @@ func ListModulesForNMC(_ context.Context, obj client.Object) []reconcile.Request
 	return modules.UnsortedList()
 }
 
-func skipNodeHeartbeat() predicate.Predicate {
-
+func filterRelevantNodeUpdates() predicate.Predicate {
 	return predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-
 			oldNode, okOld := e.ObjectOld.(*v1.Node)
 			newNode, okNew := e.ObjectNew.(*v1.Node)
 			if !okOld || !okNew {
 				return false
 			}
 
-			oldNodeCopy := oldNode.DeepCopy()
-			newNodeCopy := newNode.DeepCopy()
-
-			// clear heartbeat timestamp for each condition
-			for i, _ := range oldNodeCopy.Status.Conditions {
-				oldNodeCopy.Status.Conditions[i].LastHeartbeatTime = metav1.Time{}
-			}
-			for i, _ := range newNodeCopy.Status.Conditions {
-				newNodeCopy.Status.Conditions[i].LastHeartbeatTime = metav1.Time{}
+			if !reflect.DeepEqual(oldNode.Spec, newNode.Spec) {
+				return true
 			}
 
-			// clear the resource version as it gets updated with every heartbeat
-			oldNodeCopy.ResourceVersion = ""
-			newNodeCopy.ResourceVersion = ""
-
-			// clear kubelet update managedfields timestamp
-			for i, mf := range oldNodeCopy.ManagedFields {
-				if mf.Manager == "kubelet" {
-					oldNodeCopy.ManagedFields[i].Time = nil
-				}
-			}
-			for i, mf := range newNodeCopy.ManagedFields {
-				if mf.Manager == "kubelet" {
-					newNodeCopy.ManagedFields[i].Time = nil
-				}
+			if !reflect.DeepEqual(oldNode.Labels, newNode.Labels) {
+				return true
 			}
 
-			return !reflect.DeepEqual(oldNodeCopy, newNodeCopy)
+			if !reflect.DeepEqual(oldNode.Status.NodeInfo, newNode.Status.NodeInfo) {
+				return true
+			}
+
+			oldReadyCondition := getNodeReadyConditionStatus(oldNode)
+			newReadyCondition := getNodeReadyConditionStatus(newNode)
+
+			return oldReadyCondition != newReadyCondition
 		},
 	}
+}
+
+func getNodeReadyConditionStatus(node *v1.Node) v1.ConditionStatus {
+	for _, cond := range node.Status.Conditions {
+		if cond.Type == v1.NodeReady {
+			return cond.Status
+		}
+	}
+	return v1.ConditionUnknown
 }
 
 func NMCReconcilerNodePredicate() predicate.Predicate {
 	return predicate.And(
 		skipDeletions,
-		skipNodeHeartbeat(),
+		filterRelevantNodeUpdates(),
 	)
 }
 

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -116,56 +116,133 @@ var _ = Describe("nodeBecomesSchedulable", func() {
 	)
 })
 
-var _ = Describe("skipNodeHeartbeat", func() {
+var _ = Describe("filterRelevantNodeUpdates", func() {
 
-	It("should return false if the only diff is the heartbeat", func() {
-
+	It("should return false if there's no relevant change", func() {
 		oldNode := v1.Node{
-			Status: v1.NodeStatus{
-				Conditions: []v1.NodeCondition{
-					{
-						LastHeartbeatTime: metav1.NewTime(time.Unix(1, 0)),
-					},
-				},
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"node-role.kubernetes.io/worker": "true"},
 			},
-		}
-
-		newNode := v1.Node{
-			Status: v1.NodeStatus{
-				Conditions: []v1.NodeCondition{
-					{
-						LastHeartbeatTime: metav1.NewTime(time.Unix(2, 0)),
-					},
-				},
+			Spec: v1.NodeSpec{
+				Unschedulable: false,
 			},
-		}
-
-		res := skipNodeHeartbeat().Update(event.UpdateEvent{ObjectOld: &oldNode, ObjectNew: &newNode})
-		Expect(res).To(BeFalse())
-
-	})
-
-	It("should return true if there is a non heartbeat diff", func() {
-
-		oldNode := v1.Node{
 			Status: v1.NodeStatus{
 				NodeInfo: v1.NodeSystemInfo{
 					KernelVersion: "v1",
 				},
-			},
-		}
-
-		newNode := v1.Node{
-			Status: v1.NodeStatus{
-				NodeInfo: v1.NodeSystemInfo{
-					KernelVersion: "v2",
+				Conditions: []v1.NodeCondition{
+					{
+						Type:   v1.NodeReady,
+						Status: v1.ConditionTrue,
+					},
 				},
 			},
 		}
 
-		res := skipNodeHeartbeat().Update(event.UpdateEvent{ObjectOld: &oldNode, ObjectNew: &newNode})
-		Expect(res).To(BeTrue())
+		// New node with just a heartbeat difference (which is ignored now)
+		newNode := oldNode.DeepCopy()
+		newNode.Status.Conditions[0].LastHeartbeatTime = metav1.NewTime(time.Now())
 
+		res := filterRelevantNodeUpdates().Update(event.UpdateEvent{ObjectOld: &oldNode, ObjectNew: newNode})
+		Expect(res).To(BeFalse())
+	})
+
+	It("should return true if spec changed", func() {
+		oldNode := v1.Node{}
+		newNode := v1.Node{
+			Spec: v1.NodeSpec{
+				Unschedulable: true,
+			},
+		}
+
+		res := filterRelevantNodeUpdates().Update(event.UpdateEvent{ObjectOld: &oldNode, ObjectNew: &newNode})
+		Expect(res).To(BeTrue())
+	})
+
+	It("should return true if labels changed", func() {
+		oldNode := v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"a": "1"},
+			},
+		}
+		newNode := v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{"a": "2"},
+			},
+		}
+
+		res := filterRelevantNodeUpdates().Update(event.UpdateEvent{ObjectOld: &oldNode, ObjectNew: &newNode})
+		Expect(res).To(BeTrue())
+	})
+
+	It("should return true if NodeInfo changed", func() {
+		oldNode := v1.Node{
+			Status: v1.NodeStatus{
+				NodeInfo: v1.NodeSystemInfo{KernelVersion: "1"},
+			},
+		}
+		newNode := v1.Node{
+			Status: v1.NodeStatus{
+				NodeInfo: v1.NodeSystemInfo{KernelVersion: "2"},
+			},
+		}
+
+		res := filterRelevantNodeUpdates().Update(event.UpdateEvent{ObjectOld: &oldNode, ObjectNew: &newNode})
+		Expect(res).To(BeTrue())
+	})
+
+	It("should return true if Ready condition transitioned from NotReady to Ready", func() {
+		oldNode := v1.Node{
+			Status: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					{
+						Type:   v1.NodeReady,
+						Status: v1.ConditionFalse,
+					},
+				},
+			},
+		}
+		newNode := v1.Node{
+			Status: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					{
+						Type:   v1.NodeReady,
+						Status: v1.ConditionTrue,
+					},
+				},
+			},
+		}
+
+		res := filterRelevantNodeUpdates().Update(event.UpdateEvent{ObjectOld: &oldNode, ObjectNew: &newNode})
+		Expect(res).To(BeTrue())
+	})
+
+	It("should return false if Ready condition stays True", func() {
+		oldNode := v1.Node{
+			Status: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					{
+						Type:   v1.NodeReady,
+						Status: v1.ConditionTrue,
+					},
+				},
+			},
+		}
+		newNode := v1.Node{
+			Status: v1.NodeStatus{
+				Conditions: []v1.NodeCondition{
+					{
+						Type:               v1.NodeReady,
+						Status:             v1.ConditionTrue,
+						LastHeartbeatTime:  metav1.NewTime(time.Now()),
+						LastTransitionTime: metav1.NewTime(time.Now()),
+					},
+				},
+			},
+		}
+
+		res := filterRelevantNodeUpdates().Update(event.UpdateEvent{ObjectOld: &oldNode, ObjectNew: &newNode})
+		Expect(res).To(BeFalse())
 	})
 })
 


### PR DESCRIPTION
Previously, nmc controller filtered out all heartbeat-related updates by ignoring changes to node status.conditions[*].lastHeartbeatTime.

With this change:
- We now trigger reconciliation when:
  - node.Spec changes
  - node metadata.labels change
  - node.Status.NodeInfo changes
  - The Node condition status transitions.
  
 ---
 fix #1513
 /cc @ybettan @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved node update filtering to ignore irrelevant heartbeat-only changes and accurately detect meaningful updates such as changes to node spec, labels, NodeInfo, or NodeReady condition status.
- **Tests**
	- Expanded and refined test coverage to ensure correct behavior for various node update scenarios, including distinguishing between relevant and irrelevant changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->