### PR TITLE
Adding a preflight package

### DIFF
--- a/internal/preflight/preflight.go
+++ b/internal/preflight/preflight.go
@@ -1,0 +1,67 @@
+package preflight
+
+import (
+	"github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta2"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const VerificationStatusReasonVerified = "Verification successful (%s), this Module will not be verified again in this Preflight CR"
+
+//go:generate mockgen -source=preflight.go -package=preflight -destination=mock_preflight.go
+
+type PreflightAPI interface {
+	SetModuleStatus(pv *v1beta2.PreflightValidation, namespace, name, status, reason string)
+	GetModuleStatus(pv *v1beta2.PreflightValidation, namespace, name string) string
+	AllModulesVerified(pv *v1beta2.PreflightValidation) bool
+}
+
+func NewPreflightAPI() PreflightAPI {
+	return &preflight{}
+}
+
+type preflight struct {
+}
+
+func (p *preflight) SetModuleStatus(pv *v1beta2.PreflightValidation, namespace, name, status, reason string) {
+	stage := v1beta2.VerificationStageImage
+	if status == v1beta2.VerificationSuccess || status == v1beta2.VerificationFailure {
+		stage = v1beta2.VerificationStageDone
+	}
+	newStatus := v1beta2.PreflightValidationModuleStatus{
+		Name:      name,
+		Namespace: namespace,
+		CRBaseStatus: v1beta2.CRBaseStatus{
+			VerificationStatus: status,
+			StatusReason:       reason,
+			VerificationStage:  stage,
+			LastTransitionTime: metav1.Now(),
+		},
+	}
+	for i, moduleStatus := range pv.Status.Modules {
+		if moduleStatus.Name == name && moduleStatus.Namespace == namespace {
+			pv.Status.Modules[i] = newStatus
+			return
+		}
+	}
+
+	pv.Status.Modules = append(pv.Status.Modules, newStatus)
+}
+
+func (p *preflight) GetModuleStatus(pv *v1beta2.PreflightValidation, namespace, name string) string {
+	for _, moduleStatus := range pv.Status.Modules {
+		if moduleStatus.Name == name && moduleStatus.Namespace == namespace {
+			return moduleStatus.VerificationStatus
+		}
+	}
+	return ""
+}
+
+func (p *preflight) AllModulesVerified(pv *v1beta2.PreflightValidation) bool {
+	for _, moduleStatus := range pv.Status.Modules {
+		if !(moduleStatus.VerificationStatus == v1beta2.VerificationSuccess || moduleStatus.VerificationStatus == v1beta2.VerificationFailure) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/preflight/preflight_test.go
+++ b/internal/preflight/preflight_test.go
@@ -1,0 +1,120 @@
+package preflight
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta2"
+)
+
+var _ = Describe("SetModuleStatus", func() {
+	var (
+		preflightAPI PreflightAPI
+		pv           *v1beta2.PreflightValidation
+	)
+
+	BeforeEach(func() {
+		preflightAPI = NewPreflightAPI()
+		pv = &v1beta2.PreflightValidation{
+			Status: v1beta2.PreflightValidationStatus{
+				Modules: []v1beta2.PreflightValidationModuleStatus{
+					{
+						Name:      "test-name",
+						Namespace: "test-namespace",
+						CRBaseStatus: v1beta2.CRBaseStatus{
+							VerificationStatus: "original status",
+							StatusReason:       "original reason",
+						},
+					},
+				},
+			},
+		}
+	})
+
+	It("should set the existing module status correctly", func() {
+		preflightAPI.SetModuleStatus(pv, "test-namespace", "test-name", "some status", "some reason")
+		Expect(pv.Status.Modules).To(HaveLen(1))
+		Expect(pv.Status.Modules[0].VerificationStatus).To(Equal("some status"))
+		Expect(pv.Status.Modules[0].StatusReason).To(Equal("some reason"))
+	})
+
+	It("should set the new module status correctly", func() {
+		preflightAPI.SetModuleStatus(pv, "test-namespace", "new-name", "new status", "new reason")
+		Expect(pv.Status.Modules).To(HaveLen(2))
+		Expect(pv.Status.Modules[1].Name).To(Equal("new-name"))
+		Expect(pv.Status.Modules[1].VerificationStatus).To(Equal("new status"))
+		Expect(pv.Status.Modules[1].StatusReason).To(Equal("new reason"))
+	})
+})
+
+var _ = Describe("GetModuleStatus", func() {
+	var (
+		preflightAPI PreflightAPI
+		pv           *v1beta2.PreflightValidation
+	)
+
+	BeforeEach(func() {
+		preflightAPI = NewPreflightAPI()
+		pv = &v1beta2.PreflightValidation{
+			Status: v1beta2.PreflightValidationStatus{
+				Modules: []v1beta2.PreflightValidationModuleStatus{
+					{
+						Name:      "test-name",
+						Namespace: "test-namespace",
+						CRBaseStatus: v1beta2.CRBaseStatus{
+							VerificationStatus: "original status",
+							StatusReason:       "original reason",
+						},
+					},
+				},
+			},
+		}
+	})
+
+	It("should return the status of existing module", func() {
+		res := preflightAPI.GetModuleStatus(pv, "test-namespace", "test-name")
+		Expect(res).To(Equal("original status"))
+	})
+
+	It("should return empty string for non-existing module", func() {
+		res := preflightAPI.GetModuleStatus(pv, "test-namespace", "non-existing-name")
+		Expect(res).To(Equal(""))
+	})
+})
+
+var _ = Describe("AllModulesVerified", func() {
+	var (
+		preflightAPI PreflightAPI
+		pv           *v1beta2.PreflightValidation
+	)
+
+	BeforeEach(func() {
+		preflightAPI = NewPreflightAPI()
+		pv = &v1beta2.PreflightValidation{
+			Status: v1beta2.PreflightValidationStatus{
+				Modules: []v1beta2.PreflightValidationModuleStatus{
+					{
+						Name:      "test-name1",
+						Namespace: "test-namespace1",
+					},
+					{
+						Name:      "test-name2",
+						Namespace: "test-namespace2",
+					},
+				},
+			},
+		}
+	})
+
+	It("should return true if all modules are verified", func() {
+		pv.Status.Modules[0].VerificationStatus = v1beta2.VerificationSuccess
+		pv.Status.Modules[1].VerificationStatus = v1beta2.VerificationFailure
+		Expect(preflightAPI.AllModulesVerified(pv)).To(BeTrue())
+
+	})
+
+	It("should return false if any module is not verified", func() {
+		pv.Status.Modules[0].VerificationStatus = v1beta2.VerificationInProgress
+		pv.Status.Modules[1].VerificationStatus = v1beta2.VerificationFailure
+		Expect(preflightAPI.AllModulesVerified(pv)).To(BeFalse())
+	})
+})

--- a/internal/preflight/suite_test.go
+++ b/internal/preflight/suite_test.go
@@ -1,0 +1,22 @@
+package preflight
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/test"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var scheme *runtime.Scheme
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	var err error
+	scheme, err = test.TestScheme()
+	Expect(err).NotTo(HaveOccurred())
+
+	RunSpecs(t, "Preflight Suite")
+}


### PR DESCRIPTION
This package is going to be used by the Preflight controller to perform manipulation on the in-memory PreflightValidation object. The main functionalities: setting the status of the veirfied module, checking the status of veirfied module, and checking if all the modules in the cluster has already been verified