### PR TITLE
Fixing logging warnings format.

### DIFF
--- a/internal/buildsign/manager.go
+++ b/internal/buildsign/manager.go
@@ -135,7 +135,9 @@ func (m *manager) GarbageCollect(ctx context.Context, name, namespace string, ac
 			err = m.resourceManager.DeleteResource(ctx, obj)
 			errs = append(errs, err)
 			if err != nil {
-				logger.Info(utils.WarnString("failed to delete %s resource %s in garbage collection: %v"), action, obj.GetName(), err)
+				logger.Info(utils.WarnString(
+					fmt.Sprintf("failed to delete %s resource %s in garbage collection: %v", action, obj.GetName(), err),
+				))
 				continue
 			}
 			deleteResourceNames = append(deleteResourceNames, obj.GetName())

--- a/internal/controllers/hub/managedclustermodule_reconciler.go
+++ b/internal/controllers/hub/managedclustermodule_reconciler.go
@@ -122,17 +122,13 @@ func (r *ManagedClusterModuleReconciler) Reconcile(ctx context.Context, mcm *hub
 
 		err = r.reconHelper.setMicAsDesired(ctx, mcm, cluster.Name, kernelVersions)
 		if err != nil {
-			logger.Info(utils.WarnString(
-				fmt.Sprintf("Failed to set MIC as desired: %v", err),
-			))
+			logger.Info(utils.WarnString(fmt.Sprintf("Failed to set MIC as desired: %v", err)))
 			continue
 		}
 
 		allImagesReady, err := r.reconHelper.areImagesReady(ctx, mcm.Name, cluster.Name)
 		if err != nil {
-			logger.Info(utils.WarnString(
-				fmt.Sprintf("Failed to check if MIC is ready: %v", err),
-			))
+			logger.Info(utils.WarnString(fmt.Sprintf("Failed to check if MIC is ready: %v", err)))
 			continue
 		}
 		if !allImagesReady {
@@ -151,9 +147,7 @@ func (r *ManagedClusterModuleReconciler) Reconcile(ctx context.Context, mcm *hub
 			return r.manifestAPI.SetManifestWorkAsDesired(ctx, mw, *mcm, kernelVersions)
 		})
 		if err != nil {
-			logger.Info(utils.WarnString(
-				fmt.Sprintf("failed to create/patch ManifestWork for managed cluster: %v", err),
-			))
+			logger.Info(utils.WarnString(fmt.Sprintf("failed to create/patch ManifestWork for managed cluster: %v", err)))
 			continue
 		}
 

--- a/internal/controllers/mbsc_reconciler.go
+++ b/internal/controllers/mbsc_reconciler.go
@@ -147,7 +147,7 @@ func (mrh *mbscReconcilerHelper) processImagesSpecs(ctx context.Context, mbscObj
 		err := mrh.buildSignAPI.Sync(ctx, mld, true, imageSpec.Action, mbscObj)
 		if err != nil {
 			errs = append(errs, err)
-			logger.Info(utils.WarnString("sync for image %s, action %s failed: %v"), imageSpec.Image, imageSpec.Action, err)
+			logger.Info(utils.WarnString(fmt.Sprintf("sync for image %s, action %s failed: %v", imageSpec.Image, imageSpec.Action, err)))
 		}
 	}
 	return errors.Join(errs...)

--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -357,7 +357,9 @@ func (mrh *moduleReconcilerHelper) prepareSchedulingData(ctx context.Context,
 		if err != nil && !errors.Is(err, module.ErrNoMatchingKernelMapping) {
 			// deleting earlier, so as not to change NMC in case we failed to determine mld
 			currentNMCs.Delete(node.Name)
-			logger.Info(utils.WarnString(fmt.Sprintf("internal errors while fetching kernel mapping for version %s: %v", kernelVersion, err)))
+			logger.Info(utils.WarnString(
+				fmt.Sprintf("internal errors while fetching kernel mapping for version %s: %v", kernelVersion, err),
+			))
 			errs = append(errs, err)
 			continue
 		}
@@ -389,8 +391,9 @@ func (mrh *moduleReconcilerHelper) handleMIC(ctx context.Context, mod *kmmv1beta
 		mld, err := mrh.kernelAPI.GetModuleLoaderDataForKernel(mod, kernelVersion)
 		if err != nil {
 			if !errors.Is(err, module.ErrNoMatchingKernelMapping) {
-				logger.Info(utils.WarnString(fmt.Sprintf("internal errors while fetching kernel mapping for kernel %s: %v",
-					kernelVersion, err)))
+				logger.Info(utils.WarnString(
+					fmt.Sprintf("internal errors while fetching kernel mapping for kernel %s: %v", kernelVersion, err),
+				))
 				errs = append(errs, fmt.Errorf("failed to get moduleLoaderData for kernel %s: %v", kernelVersion, err))
 			}
 			// node is not targeted by module
@@ -504,7 +507,9 @@ func (mrh *moduleReconcilerHelper) moduleUpdateWorkerPodsStatus(ctx context.Cont
 		modSpec, _ := mrh.nmcHelper.GetModuleSpecEntry(&nmc, mod.Namespace, mod.Name)
 		if modSpec == nil {
 			logger.Info(utils.WarnString(
-				fmt.Sprintf("module %s/%s spec is missing in NMC %s although config label is present", mod.Namespace, mod.Name, nmc.Name)))
+				fmt.Sprintf("module %s/%s spec is missing in NMC %s although config label is present", mod.Namespace,
+					mod.Name, nmc.Name),
+			))
 			continue
 		}
 		modStatus := mrh.nmcHelper.GetModuleStatusEntry(&nmc, mod.Namespace, mod.Name)

--- a/internal/controllers/node_label_module_version_reconciler.go
+++ b/internal/controllers/node_label_module_version_reconciler.go
@@ -95,7 +95,9 @@ func (nlmvha *nodeLabelModuleVersionHelper) getLabelsPerModules(ctx context.Cont
 		if utils.IsVersionLabel(key) {
 			namespace, name, err := utils.GetNamespaceNameFromVersionLabel(key)
 			if err != nil {
-				logger.Info(utils.WarnString("failed to extract namespace and name from version label"), "label", key, "labelValue", value)
+				logger.Info(
+					utils.WarnString("failed to extract namespace and name from version label"), "label", key, "labelValue", value,
+				)
 				continue
 			}
 			mapKey := namespace + "-" + name

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -51,7 +51,8 @@ func (w *worker) LoadKmod(ctx context.Context, cfg *kmmv1beta1.ModuleConfig, fir
 		for _, module := range inTreeModulesToRemove {
 			exists, err := w.fh.FileExists("/lib/modules", fmt.Sprintf("^%s.ko", module))
 			if err != nil {
-				w.logger.Info(utils.WarnString(fmt.Sprintf("failed to check if module file %s present on the host:", module)), "error", err)
+				w.logger.Info(utils.WarnString(
+					fmt.Sprintf("failed to check if module file %s present on the host", module)), "error", err)
 				continue
 			}
 			if !exists {


### PR DESCRIPTION
In some cases, we were using the args of the formatting string outside of the `fmt.Sprintf()` function which will create a slightly different log than expected.

---

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1541
/assign @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved formatting and readability of log messages throughout the application. No changes to functionality or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->