### PR TITLE
Adding pull policy specification to the MIC CRD

### DIFF
--- a/api/v1beta1/moduleimagesconfig_types.go
+++ b/api/v1beta1/moduleimagesconfig_types.go
@@ -67,6 +67,11 @@ type ModuleImagesConfigSpec struct {
 	// ImageRepoSecret contains pull secret for the image's repo, if needed
 	// +optional
 	ImageRepoSecret *v1.LocalObjectReference `json:"imageRepoSecret,omitempty"`
+
+	// +kubebuilder:default=IfNotPresent
+	// ImagePullPolicy defines the pull policy used for verifying the presence of the image
+	//+optional
+	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy"`
 }
 
 type ModuleImageState struct {

--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2025-06-04T19:43:18Z"
+    createdAt: "2025-06-05T10:08:33Z"
     operatorframework.io/suggested-namespace: openshift-kmm-hub
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -47,7 +47,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2025-06-04T19:43:16Z"
+    createdAt: "2025-06-05T10:08:31Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/bundle/manifests/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -48,6 +48,11 @@ spec:
               ModuleImagesConfigSpec describes the images of the Module whose status needs to be verified
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
             properties:
+              imagePullPolicy:
+                default: IfNotPresent
+                description: ImagePullPolicy defines the pull policy used for verifying
+                  the presence of the image
+                type: string
               imageRepoSecret:
                 description: ImageRepoSecret contains pull secret for the image's
                   repo, if needed

--- a/config/crd/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -44,6 +44,11 @@ spec:
               ModuleImagesConfigSpec describes the images of the Module whose status needs to be verified
               More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
             properties:
+              imagePullPolicy:
+                default: IfNotPresent
+                description: ImagePullPolicy defines the pull policy used for verifying
+                  the presence of the image
+                type: string
               imageRepoSecret:
                 description: ImageRepoSecret contains pull secret for the image's
                   repo, if needed


### PR DESCRIPTION
This policy will be used by the image puller pod. Currently image puller pod uses IfNotPresent, which may create a discrepance with worker pod whcih uses the pull policy of the KMM Module. So, image may be present on the node, but not in repo, and in that case , image puller will be successful, while worker will fail with pull policy Always

---

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1566
/assign @yevgeny-shnaidman @TomerNewman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an optional field to specify the image pull policy for ModuleImagesConfig resources, defaulting to "IfNotPresent".
- **Chores**
  - Updated metadata timestamps in service version manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->