### PR TITLE
Updating imagepuller pod to use ImagePullPolicy

### DIFF
--- a/internal/controllers/mic_reconciler.go
+++ b/internal/controllers/mic_reconciler.go
@@ -244,6 +244,7 @@ func (mrhi *micReconcilerHelperImpl) processImagesSpecs(ctx context.Context, mic
 					imageSpec.Image,
 					oneTimePod,
 					micObj.Spec.ImageRepoSecret,
+					micObj.Spec.ImagePullPolicy,
 					micObj)
 				errs = append(errs, err)
 			}

--- a/internal/controllers/mic_reconciler_test.go
+++ b/internal/controllers/mic_reconciler_test.go
@@ -359,7 +359,8 @@ var _ = Describe("processImagesSpecs", func() {
 			gomock.InOrder(
 				micHelper.EXPECT().GetImageState(&testMic, "image 1").Return(kmmv1beta1.ImageState("")),
 				mockImagePuller.EXPECT().GetPullPodForImage(pullPods, "image 1").Return(nil),
-				mockImagePuller.EXPECT().CreatePullPod(ctx, "some name", "some namespace", "image 1", expectedOneTimePodFlag, nil, &testMic).Return(nil),
+				mockImagePuller.EXPECT().CreatePullPod(ctx, "some name", "some namespace", "image 1", expectedOneTimePodFlag,
+					nil, v1.PullPolicy(""), &testMic).Return(nil),
 			)
 			err := mrh.processImagesSpecs(ctx, &testMic, pullPods)
 			Expect(err).To(BeNil())

--- a/internal/pod/imagepuller.go
+++ b/internal/pod/imagepuller.go
@@ -35,7 +35,7 @@ const (
 
 type ImagePuller interface {
 	CreatePullPod(ctx context.Context, name, namespace, imageToPull string, oneTimePod bool,
-		imageRepoSecret *v1.LocalObjectReference, owner metav1.Object) error
+		imageRepoSecret *v1.LocalObjectReference, pullPolicy v1.PullPolicy, owner metav1.Object) error
 	DeletePod(ctx context.Context, pod *v1.Pod) error
 	ListPullPods(ctx context.Context, name, namespace string) ([]v1.Pod, error)
 	GetPullPodForImage(pods []v1.Pod, image string) *v1.Pod
@@ -56,7 +56,7 @@ func NewImagePuller(client client.Client, scheme *runtime.Scheme) ImagePuller {
 }
 
 func (ipi *imagePullerImpl) CreatePullPod(ctx context.Context, name, namespace, imageToPull string, oneTimePod bool,
-	imageRepoSecret *v1.LocalObjectReference, owner metav1.Object) error {
+	imageRepoSecret *v1.LocalObjectReference, pullPolicy v1.PullPolicy, owner metav1.Object) error {
 
 	pullPodTypeLabelValue := pullPodUntilSuccess
 	if oneTimePod {
@@ -80,9 +80,10 @@ func (ipi *imagePullerImpl) CreatePullPod(ctx context.Context, name, namespace, 
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				{
-					Name:    pullerContainerName,
-					Image:   imageToPull,
-					Command: []string{"/bin/sh", "-c", "exit 0"},
+					Name:            pullerContainerName,
+					Image:           imageToPull,
+					Command:         []string{"/bin/sh", "-c", "exit 0"},
+					ImagePullPolicy: pullPolicy,
 				},
 			},
 			RestartPolicy:    v1.RestartPolicyNever,

--- a/internal/pod/imagepuller_test.go
+++ b/internal/pod/imagepuller_test.go
@@ -162,6 +162,7 @@ var _ = Describe("CreatePullPod", func() {
 	testImage := "some image"
 	testMic := kmmv1beta1.ModuleImagesConfig{}
 	testRepoSecret := v1.LocalObjectReference{}
+	imagePullPolicy := v1.PullAlways
 
 	It("check the pod fields", func() {
 		expectedPod := v1.Pod{
@@ -176,9 +177,10 @@ var _ = Describe("CreatePullPod", func() {
 			Spec: v1.PodSpec{
 				Containers: []v1.Container{
 					{
-						Name:    pullerContainerName,
-						Image:   testImage,
-						Command: []string{"/bin/sh", "-c", "exit 0"},
+						Name:            pullerContainerName,
+						Image:           testImage,
+						Command:         []string{"/bin/sh", "-c", "exit 0"},
+						ImagePullPolicy: imagePullPolicy,
 					},
 				},
 				RestartPolicy:    v1.RestartPolicyNever,
@@ -198,7 +200,7 @@ var _ = Describe("CreatePullPod", func() {
 				}
 				return nil
 			})
-		err := ip.CreatePullPod(ctx, testName, testNamespace, testImage, false, &testRepoSecret, &testMic)
+		err := ip.CreatePullPod(ctx, testName, testNamespace, testImage, false, &testRepoSecret, imagePullPolicy, &testMic)
 		Expect(err).To(BeNil())
 	})
 })

--- a/internal/pod/mock_imagepuller.go
+++ b/internal/pod/mock_imagepuller.go
@@ -41,17 +41,17 @@ func (m *MockImagePuller) EXPECT() *MockImagePullerMockRecorder {
 }
 
 // CreatePullPod mocks base method.
-func (m *MockImagePuller) CreatePullPod(ctx context.Context, name, namespace, imageToPull string, oneTimePod bool, imageRepoSecret *v1.LocalObjectReference, owner v10.Object) error {
+func (m *MockImagePuller) CreatePullPod(ctx context.Context, name, namespace, imageToPull string, oneTimePod bool, imageRepoSecret *v1.LocalObjectReference, pullPolicy v1.PullPolicy, owner v10.Object) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreatePullPod", ctx, name, namespace, imageToPull, oneTimePod, imageRepoSecret, owner)
+	ret := m.ctrl.Call(m, "CreatePullPod", ctx, name, namespace, imageToPull, oneTimePod, imageRepoSecret, pullPolicy, owner)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreatePullPod indicates an expected call of CreatePullPod.
-func (mr *MockImagePullerMockRecorder) CreatePullPod(ctx, name, namespace, imageToPull, oneTimePod, imageRepoSecret, owner any) *gomock.Call {
+func (mr *MockImagePullerMockRecorder) CreatePullPod(ctx, name, namespace, imageToPull, oneTimePod, imageRepoSecret, pullPolicy, owner any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePullPod", reflect.TypeOf((*MockImagePuller)(nil).CreatePullPod), ctx, name, namespace, imageToPull, oneTimePod, imageRepoSecret, owner)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePullPod", reflect.TypeOf((*MockImagePuller)(nil).CreatePullPod), ctx, name, namespace, imageToPull, oneTimePod, imageRepoSecret, pullPolicy, owner)
 }
 
 // DeletePod mocks base method.


### PR DESCRIPTION
Since imagepuller pod must use the same pull policy as worker pod, this commit updates the imagepuller interface to use the pull policy from the MIC object. This commit also updates the unit tests and the mic controller to pass the pull policy from MIC object to the imagepuller interface