### PR TITLE
removing duplicate imageSpec from MIC

### DIFF
--- a/internal/mic/mic_test.go
+++ b/internal/mic/mic_test.go
@@ -368,3 +368,26 @@ var _ = Describe("DoAllImagesExist", func() {
 		Expect(micAPI.DoAllImagesExist(micObj)).To(BeTrue())
 	})
 })
+
+var _ = Describe("filterDuplicateImages", func() {
+	It("check flow", func() {
+		images := []kmmv1beta1.ModuleImageSpec{
+			{Image: "example.registry.com/org/user/image1:tag"},
+			{Image: "example.registry.com/org/user/image2:tag"},
+			{Image: "example.registry.com/org/user/image3:tag"},
+			{Image: "example.registry.com/org/user/image2:tag"},
+			{Image: "example.registry.com/org/user/image4:tag"},
+			{Image: "example.registry.com/org/user/image1:tag"},
+		}
+
+		expectedRes := []kmmv1beta1.ModuleImageSpec{
+			{Image: "example.registry.com/org/user/image1:tag"},
+			{Image: "example.registry.com/org/user/image2:tag"},
+			{Image: "example.registry.com/org/user/image3:tag"},
+			{Image: "example.registry.com/org/user/image4:tag"},
+		}
+
+		res := filterDuplicateImages(images)
+		Expect(res).To(Equal(expectedRes))
+	})
+})


### PR DESCRIPTION
CreateOrPatch MIC API receives slice of imageSpecs. Since usually the input is created by going over the the target nodes and adding their images to the slice, we need to remove duplicate images, since for most of the cases all the nodes will have the same target image

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of image lists by automatically removing duplicate images before processing.

- **Tests**
  - Added tests to ensure duplicate images are correctly filtered out and only unique images are retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->