### PR TITLE
adding gpu perses dashboard metrics

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -184,7 +184,7 @@ func main() {
 
 	workerPodManagerAPI := pod.NewWorkerPodManager(client, workerImage, scheme, &cfg.Worker)
 	if err = controllers.NewNMCReconciler(client, scheme, workerImage, caHelper, &cfg.Worker, eventRecorder, nodeAPI,
-		workerPodManagerAPI).SetupWithManager(ctx, mgr); err != nil {
+		workerPodManagerAPI, metricsAPI).SetupWithManager(ctx, mgr); err != nil {
 		cmd.FatalError(setupLogger, err, "unable to create controller", "name", controllers.NodeModulesConfigReconcilerName)
 	}
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -9,8 +9,8 @@ patches:
 
 images:
 - name: controller
-  newName: quay.io/edge-infrastructure/kernel-module-management-operator
-  newTag: latest
+  newName: quay.io/yshnaidm/kmmo
+  newTag: simulate-metrics
 - name: worker
   newName: quay.io/edge-infrastructure/kernel-module-management-worker
   newTag: latest


### PR DESCRIPTION
using KMM operator to simulate the accelerator gpu metrics for common accelerators Perses dashboard. NMC reconciler just send the metrcis over and over again, with random values, each one with nvidia or amd label

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new Prometheus metrics for accelerator hardware, including GPU utilization, memory usage, power consumption, temperature, and clock frequencies, with support for multiple vendors (e.g., AMD and NVIDIA).
- **Chores**
  - Updated the controller image reference and tag in configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->