### PR TITLE
Fixing the `GCDelay` configuration option default value documentation.

### DIFF
--- a/docs/mkdocs/documentation/configure.md
+++ b/docs/mkdocs/documentation/configure.md
@@ -40,7 +40,7 @@ Default value: `:8081`.
 Defines the duration for which successful build pods should be preserved before they are deleted.  
 Refer to the Go [`ParseDuration`](https://pkg.go.dev/time#ParseDuration) function documentation to understand valid
 values for this setting.  
-Default value: `0`.
+Default value: `0s`.
 
 #### `leaderElection.enabled`
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -186,6 +186,7 @@ func (ch *configHelper) decodeStrictYAMLIntoConfig(yamlData []byte, config *Conf
 
 func (ch *configHelper) newDefaultConfig(isHubConfig bool) *Config {
 	leaderElectionResourceID := "kmm.sigs.x-k8s.io"
+	gcDelay, _ := time.ParseDuration("0s")
 	if isHubConfig {
 		leaderElectionResourceID = "kmm-hub.sigs.x-k8s.io"
 	}
@@ -209,6 +210,9 @@ func (ch *configHelper) newDefaultConfig(isHubConfig bool) *Config {
 		Webhook: Webhook{
 			DisableHTTP2: true,
 			Port:         9443,
+		},
+		Job: Job{
+			GCDelay: gcDelay,
 		},
 	}
 }


### PR DESCRIPTION
Setting it to `0s` instead of `0` to emphasise the `time.Duration` type instead of a normal `int` which will result in a user error.

Also, explicitly set the `GCDelay` default value so we have all default values in a single place for clarity.

---

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1578
/assign @yevgeny-shnaidman @TomerNewman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the default value format for the job garbage collection delay setting, specifying it as "0s" (zero seconds) instead of "0".
- **Chores**
  - Updated the default configuration to explicitly set the job garbage collection delay to "0s".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->