### PR TITLE
Adding all KMM CRDs generated files to KMM-hub.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,6 +111,7 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 	$(CONTROLLER_GEN) webhook paths="./internal/webhook" output:webhook:artifacts:config=config/webhook
 	$(CONTROLLER_GEN) rbac:roleName=manager-role paths="./internal/controllers" output:rbac:artifacts:config=config/rbac
 	# Hub
+	$(CONTROLLER_GEN) crd paths="./api/..." output:crd:artifacts:config=config/crd-hub/bases
 	$(CONTROLLER_GEN) crd paths="./api-hub/..." output:crd:artifacts:config=config/crd-hub/bases
 	$(CONTROLLER_GEN) webhook paths="./internal/webhook/hub" output:webhook:artifacts:config=config/webhook-hub
 	$(CONTROLLER_GEN) \

--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2025-06-05T10:08:33Z"
+    createdAt: "2025-06-12T13:41:07Z"
     operatorframework.io/suggested-namespace: openshift-kmm-hub
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -57,6 +57,12 @@ spec:
       displayName: Managed Cluster Module
       kind: ManagedClusterModule
       name: managedclustermodules.hub.kmm.sigs.x-k8s.io
+      version: v1beta1
+    - kind: ModuleBuildSignConfig
+      name: modulebuildsignconfigs.kmm.sigs.x-k8s.io
+      version: v1beta1
+    - kind: ModuleImagesConfig
+      name: moduleimagesconfigs.kmm.sigs.x-k8s.io
       version: v1beta1
   description: Hub component for Kernel Module Management
   displayName: Kernel Module Management (Hub)

--- a/bundle-hub/manifests/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
+++ b/bundle-hub/manifests/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
@@ -1,0 +1,301 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kmm-hub
+    app.kubernetes.io/name: kmm-hub
+    app.kubernetes.io/part-of: kmm
+  name: modulebuildsignconfigs.kmm.sigs.x-k8s.io
+spec:
+  group: kmm.sigs.x-k8s.io
+  names:
+    kind: ModuleBuildSignConfig
+    listKind: ModuleBuildSignConfigList
+    plural: modulebuildsignconfigs
+    shortNames:
+    - mbsc
+    singular: modulebuildsignconfig
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ModuleBuildSignConfig keeps the request for images' build/sign
+          for a KMM Module.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              ModuleBuildSignConfigSpec describes the images that need to be built/signed
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              imageRepoSecret:
+                description: ImageRepoSecret contains pull secret for the image's
+                  repo, if needed
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              images:
+                items:
+                  description: ModuleBuildSignSpec describes the image whose state
+                    needs to be queried
+                  properties:
+                    action:
+                      enum:
+                      - BuildImage
+                      - SignImage
+                      type: string
+                    build:
+                      description: Build contains build instructions, in case image
+                        needs building
+                      properties:
+                        baseImageRegistryTLS:
+                          description: BaseImageRegistryTLS contains settings determining
+                            how to access registries of the base images in the build-process'
+                            Dockerfile.
+                          properties:
+                            insecure:
+                              description: If Insecure is true, the operator will
+                                be able to access a registry in an insecure (plain
+                                HTTP) protocol.
+                              type: boolean
+                            insecureSkipTLSVerify:
+                              description: If InsecureSkipTLSVerify, the operator
+                                will accept any certificate provided by the registry.
+                              type: boolean
+                          type: object
+                        buildArgs:
+                          description: BuildArgs is an array of build variables that
+                            are provided to the image building backend.
+                          items:
+                            description: BuildArg represents a build argument used
+                              when building a container image.
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        dockerfileConfigMap:
+                          description: ConfigMap that holds Dockerfile contents
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        kanikoParams:
+                          description: KanikoParams is used to customize the building
+                            process of the image.
+                          properties:
+                            tag:
+                              description: Kaniko image tag to use when creating the
+                                build Job
+                              type: string
+                          type: object
+                        secrets:
+                          description: |-
+                            Secrets is an optional list of secrets to be made available to the build system.
+                            Those secrets should be used for private resources such as a private Github repo.
+                            For container registries auth use module.spec.imagePullSecret instead.
+                          items:
+                            description: |-
+                              LocalObjectReference contains enough information to let you locate the
+                              referenced object inside the same namespace.
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                        selector:
+                          additionalProperties:
+                            type: string
+                          description: Selector describes on which nodes will run
+                            the building process.
+                          type: object
+                      required:
+                      - dockerfileConfigMap
+                      type: object
+                    image:
+                      description: image
+                      type: string
+                    kernelVersion:
+                      description: kernel version for which this image is targeted
+                      type: string
+                    registryTLS:
+                      description: RegistryTLS set the TLS configs for accessing the
+                        registry of the image.
+                      properties:
+                        insecure:
+                          description: If Insecure is true, the operator will be able
+                            to access a registry in an insecure (plain HTTP) protocol.
+                          type: boolean
+                        insecureSkipTLSVerify:
+                          description: If InsecureSkipTLSVerify, the operator will
+                            accept any certificate provided by the registry.
+                          type: boolean
+                      type: object
+                    sign:
+                      description: Sign contains sign instructions, in case image
+                        needs signing
+                      properties:
+                        certSecret:
+                          description: a secret containing the public key used to
+                            sign kernel modules for secureboot
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        filesToSign:
+                          description: paths inside the image for the kernel modules
+                            to sign (if ommited all kmods are signed)
+                          items:
+                            type: string
+                          type: array
+                        keySecret:
+                          description: a secret containing the private key used to
+                            sign kernel modules for secureboot
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        unsignedImage:
+                          description: Image to sign, ignored if a Build is present,
+                            required otherwise
+                          type: string
+                        unsignedImageRegistryTLS:
+                          description: UnsignedImageRegistryTLS contains settings
+                            determining how to access registries of the unsigned image.
+                          properties:
+                            insecure:
+                              description: If Insecure is true, the operator will
+                                be able to access a registry in an insecure (plain
+                                HTTP) protocol.
+                              type: boolean
+                            insecureSkipTLSVerify:
+                              description: If InsecureSkipTLSVerify, the operator
+                                will accept any certificate provided by the registry.
+                              type: boolean
+                          type: object
+                      required:
+                      - certSecret
+                      - keySecret
+                      type: object
+                    skipWaitMissingImage:
+                      description: |-
+                        SkipWaitMissingImage signals to MIC to stop waiting for image to be present
+                        in case Build andSign not define, and report the image as DoesNotExist
+                      type: boolean
+                  required:
+                  - action
+                  - image
+                  - kernelVersion
+                  type: object
+                type: array
+            required:
+            - images
+            type: object
+          status:
+            description: |-
+              ModuleBuildSignConfigStatus describes the status of the images that needed to be built/signed
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              images:
+                items:
+                  description: BuildSignImageState contains the status of the image
+                    that was requested to be built/signed
+                  properties:
+                    action:
+                      enum:
+                      - BuildImage
+                      - SignImage
+                      type: string
+                    image:
+                      type: string
+                    status:
+                      enum:
+                      - Success
+                      - Failure
+                      type: string
+                  required:
+                  - action
+                  - image
+                  - status
+                  type: object
+                type: array
+            required:
+            - images
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/bundle-hub/manifests/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/bundle-hub/manifests/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -1,0 +1,291 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: kmm-hub
+    app.kubernetes.io/name: kmm-hub
+    app.kubernetes.io/part-of: kmm
+  name: moduleimagesconfigs.kmm.sigs.x-k8s.io
+spec:
+  group: kmm.sigs.x-k8s.io
+  names:
+    kind: ModuleImagesConfig
+    listKind: ModuleImagesConfigList
+    plural: moduleimagesconfigs
+    shortNames:
+    - mic
+    singular: moduleimagesconfig
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ModuleImagesConfig keeps the request for images' state for a
+          KMM Module.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              ModuleImagesConfigSpec describes the images of the Module whose status needs to be verified
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              imagePullPolicy:
+                default: IfNotPresent
+                description: ImagePullPolicy defines the pull policy used for verifying
+                  the presence of the image
+                type: string
+              imageRepoSecret:
+                description: ImageRepoSecret contains pull secret for the image's
+                  repo, if needed
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              images:
+                items:
+                  description: ModuleImageSpec describes the image whose state needs
+                    to be queried
+                  properties:
+                    build:
+                      description: Build contains build instructions, in case image
+                        needs building
+                      properties:
+                        baseImageRegistryTLS:
+                          description: BaseImageRegistryTLS contains settings determining
+                            how to access registries of the base images in the build-process'
+                            Dockerfile.
+                          properties:
+                            insecure:
+                              description: If Insecure is true, the operator will
+                                be able to access a registry in an insecure (plain
+                                HTTP) protocol.
+                              type: boolean
+                            insecureSkipTLSVerify:
+                              description: If InsecureSkipTLSVerify, the operator
+                                will accept any certificate provided by the registry.
+                              type: boolean
+                          type: object
+                        buildArgs:
+                          description: BuildArgs is an array of build variables that
+                            are provided to the image building backend.
+                          items:
+                            description: BuildArg represents a build argument used
+                              when building a container image.
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        dockerfileConfigMap:
+                          description: ConfigMap that holds Dockerfile contents
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        kanikoParams:
+                          description: KanikoParams is used to customize the building
+                            process of the image.
+                          properties:
+                            tag:
+                              description: Kaniko image tag to use when creating the
+                                build Job
+                              type: string
+                          type: object
+                        secrets:
+                          description: |-
+                            Secrets is an optional list of secrets to be made available to the build system.
+                            Those secrets should be used for private resources such as a private Github repo.
+                            For container registries auth use module.spec.imagePullSecret instead.
+                          items:
+                            description: |-
+                              LocalObjectReference contains enough information to let you locate the
+                              referenced object inside the same namespace.
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                        selector:
+                          additionalProperties:
+                            type: string
+                          description: Selector describes on which nodes will run
+                            the building process.
+                          type: object
+                      required:
+                      - dockerfileConfigMap
+                      type: object
+                    image:
+                      description: image
+                      type: string
+                    kernelVersion:
+                      description: kernel version for which this image is targeted
+                      type: string
+                    registryTLS:
+                      description: RegistryTLS set the TLS configs for accessing the
+                        registry of the image.
+                      properties:
+                        insecure:
+                          description: If Insecure is true, the operator will be able
+                            to access a registry in an insecure (plain HTTP) protocol.
+                          type: boolean
+                        insecureSkipTLSVerify:
+                          description: If InsecureSkipTLSVerify, the operator will
+                            accept any certificate provided by the registry.
+                          type: boolean
+                      type: object
+                    sign:
+                      description: Sign contains sign instructions, in case image
+                        needs signing
+                      properties:
+                        certSecret:
+                          description: a secret containing the public key used to
+                            sign kernel modules for secureboot
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        filesToSign:
+                          description: paths inside the image for the kernel modules
+                            to sign (if ommited all kmods are signed)
+                          items:
+                            type: string
+                          type: array
+                        keySecret:
+                          description: a secret containing the private key used to
+                            sign kernel modules for secureboot
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        unsignedImage:
+                          description: Image to sign, ignored if a Build is present,
+                            required otherwise
+                          type: string
+                        unsignedImageRegistryTLS:
+                          description: UnsignedImageRegistryTLS contains settings
+                            determining how to access registries of the unsigned image.
+                          properties:
+                            insecure:
+                              description: If Insecure is true, the operator will
+                                be able to access a registry in an insecure (plain
+                                HTTP) protocol.
+                              type: boolean
+                            insecureSkipTLSVerify:
+                              description: If InsecureSkipTLSVerify, the operator
+                                will accept any certificate provided by the registry.
+                              type: boolean
+                          type: object
+                      required:
+                      - certSecret
+                      - keySecret
+                      type: object
+                    skipWaitMissingImage:
+                      description: |-
+                        SkipWaitMissingImage signals to MIC to stop waiting for image to be present
+                        in case Build andSign not define, and report the image as DoesNotExist
+                      type: boolean
+                  required:
+                  - image
+                  - kernelVersion
+                  type: object
+                type: array
+            type: object
+          status:
+            description: |-
+              ModuleImagesConfigStatus describes the status of the images that need to be verified (defined in the spec)
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              imagesStates:
+                items:
+                  properties:
+                    image:
+                      description: image
+                      type: string
+                    status:
+                      description: |-
+                        status of the image
+                        one of: Exists, notExists
+                      type: string
+                  required:
+                  - image
+                  - status
+                  type: object
+                type: array
+            required:
+            - imagesStates
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -47,7 +47,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2025-06-05T10:08:31Z"
+    createdAt: "2025-06-12T13:41:06Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/config/crd-hub/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
+++ b/config/crd-hub/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
@@ -1,0 +1,291 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  name: modulebuildsignconfigs.kmm.sigs.x-k8s.io
+spec:
+  group: kmm.sigs.x-k8s.io
+  names:
+    kind: ModuleBuildSignConfig
+    listKind: ModuleBuildSignConfigList
+    plural: modulebuildsignconfigs
+    shortNames:
+    - mbsc
+    singular: modulebuildsignconfig
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ModuleBuildSignConfig keeps the request for images' build/sign
+          for a KMM Module.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              ModuleBuildSignConfigSpec describes the images that need to be built/signed
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              imageRepoSecret:
+                description: ImageRepoSecret contains pull secret for the image's
+                  repo, if needed
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              images:
+                items:
+                  description: ModuleBuildSignSpec describes the image whose state
+                    needs to be queried
+                  properties:
+                    action:
+                      enum:
+                      - BuildImage
+                      - SignImage
+                      type: string
+                    build:
+                      description: Build contains build instructions, in case image
+                        needs building
+                      properties:
+                        baseImageRegistryTLS:
+                          description: BaseImageRegistryTLS contains settings determining
+                            how to access registries of the base images in the build-process'
+                            Dockerfile.
+                          properties:
+                            insecure:
+                              description: If Insecure is true, the operator will
+                                be able to access a registry in an insecure (plain
+                                HTTP) protocol.
+                              type: boolean
+                            insecureSkipTLSVerify:
+                              description: If InsecureSkipTLSVerify, the operator
+                                will accept any certificate provided by the registry.
+                              type: boolean
+                          type: object
+                        buildArgs:
+                          description: BuildArgs is an array of build variables that
+                            are provided to the image building backend.
+                          items:
+                            description: BuildArg represents a build argument used
+                              when building a container image.
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        dockerfileConfigMap:
+                          description: ConfigMap that holds Dockerfile contents
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        kanikoParams:
+                          description: KanikoParams is used to customize the building
+                            process of the image.
+                          properties:
+                            tag:
+                              description: Kaniko image tag to use when creating the
+                                build Job
+                              type: string
+                          type: object
+                        secrets:
+                          description: |-
+                            Secrets is an optional list of secrets to be made available to the build system.
+                            Those secrets should be used for private resources such as a private Github repo.
+                            For container registries auth use module.spec.imagePullSecret instead.
+                          items:
+                            description: |-
+                              LocalObjectReference contains enough information to let you locate the
+                              referenced object inside the same namespace.
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                        selector:
+                          additionalProperties:
+                            type: string
+                          description: Selector describes on which nodes will run
+                            the building process.
+                          type: object
+                      required:
+                      - dockerfileConfigMap
+                      type: object
+                    image:
+                      description: image
+                      type: string
+                    kernelVersion:
+                      description: kernel version for which this image is targeted
+                      type: string
+                    registryTLS:
+                      description: RegistryTLS set the TLS configs for accessing the
+                        registry of the image.
+                      properties:
+                        insecure:
+                          description: If Insecure is true, the operator will be able
+                            to access a registry in an insecure (plain HTTP) protocol.
+                          type: boolean
+                        insecureSkipTLSVerify:
+                          description: If InsecureSkipTLSVerify, the operator will
+                            accept any certificate provided by the registry.
+                          type: boolean
+                      type: object
+                    sign:
+                      description: Sign contains sign instructions, in case image
+                        needs signing
+                      properties:
+                        certSecret:
+                          description: a secret containing the public key used to
+                            sign kernel modules for secureboot
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        filesToSign:
+                          description: paths inside the image for the kernel modules
+                            to sign (if ommited all kmods are signed)
+                          items:
+                            type: string
+                          type: array
+                        keySecret:
+                          description: a secret containing the private key used to
+                            sign kernel modules for secureboot
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        unsignedImage:
+                          description: Image to sign, ignored if a Build is present,
+                            required otherwise
+                          type: string
+                        unsignedImageRegistryTLS:
+                          description: UnsignedImageRegistryTLS contains settings
+                            determining how to access registries of the unsigned image.
+                          properties:
+                            insecure:
+                              description: If Insecure is true, the operator will
+                                be able to access a registry in an insecure (plain
+                                HTTP) protocol.
+                              type: boolean
+                            insecureSkipTLSVerify:
+                              description: If InsecureSkipTLSVerify, the operator
+                                will accept any certificate provided by the registry.
+                              type: boolean
+                          type: object
+                      required:
+                      - certSecret
+                      - keySecret
+                      type: object
+                    skipWaitMissingImage:
+                      description: |-
+                        SkipWaitMissingImage signals to MIC to stop waiting for image to be present
+                        in case Build andSign not define, and report the image as DoesNotExist
+                      type: boolean
+                  required:
+                  - action
+                  - image
+                  - kernelVersion
+                  type: object
+                type: array
+            required:
+            - images
+            type: object
+          status:
+            description: |-
+              ModuleBuildSignConfigStatus describes the status of the images that needed to be built/signed
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              images:
+                items:
+                  description: BuildSignImageState contains the status of the image
+                    that was requested to be built/signed
+                  properties:
+                    action:
+                      enum:
+                      - BuildImage
+                      - SignImage
+                      type: string
+                    image:
+                      type: string
+                    status:
+                      enum:
+                      - Success
+                      - Failure
+                      type: string
+                  required:
+                  - action
+                  - image
+                  - status
+                  type: object
+                type: array
+            required:
+            - images
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd-hub/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/config/crd-hub/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -1,0 +1,281 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  name: moduleimagesconfigs.kmm.sigs.x-k8s.io
+spec:
+  group: kmm.sigs.x-k8s.io
+  names:
+    kind: ModuleImagesConfig
+    listKind: ModuleImagesConfigList
+    plural: moduleimagesconfigs
+    shortNames:
+    - mic
+    singular: moduleimagesconfig
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: ModuleImagesConfig keeps the request for images' state for a
+          KMM Module.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              ModuleImagesConfigSpec describes the images of the Module whose status needs to be verified
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              imagePullPolicy:
+                default: IfNotPresent
+                description: ImagePullPolicy defines the pull policy used for verifying
+                  the presence of the image
+                type: string
+              imageRepoSecret:
+                description: ImageRepoSecret contains pull secret for the image's
+                  repo, if needed
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              images:
+                items:
+                  description: ModuleImageSpec describes the image whose state needs
+                    to be queried
+                  properties:
+                    build:
+                      description: Build contains build instructions, in case image
+                        needs building
+                      properties:
+                        baseImageRegistryTLS:
+                          description: BaseImageRegistryTLS contains settings determining
+                            how to access registries of the base images in the build-process'
+                            Dockerfile.
+                          properties:
+                            insecure:
+                              description: If Insecure is true, the operator will
+                                be able to access a registry in an insecure (plain
+                                HTTP) protocol.
+                              type: boolean
+                            insecureSkipTLSVerify:
+                              description: If InsecureSkipTLSVerify, the operator
+                                will accept any certificate provided by the registry.
+                              type: boolean
+                          type: object
+                        buildArgs:
+                          description: BuildArgs is an array of build variables that
+                            are provided to the image building backend.
+                          items:
+                            description: BuildArg represents a build argument used
+                              when building a container image.
+                            properties:
+                              name:
+                                type: string
+                              value:
+                                type: string
+                            required:
+                            - name
+                            - value
+                            type: object
+                          type: array
+                        dockerfileConfigMap:
+                          description: ConfigMap that holds Dockerfile contents
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        kanikoParams:
+                          description: KanikoParams is used to customize the building
+                            process of the image.
+                          properties:
+                            tag:
+                              description: Kaniko image tag to use when creating the
+                                build Job
+                              type: string
+                          type: object
+                        secrets:
+                          description: |-
+                            Secrets is an optional list of secrets to be made available to the build system.
+                            Those secrets should be used for private resources such as a private Github repo.
+                            For container registries auth use module.spec.imagePullSecret instead.
+                          items:
+                            description: |-
+                              LocalObjectReference contains enough information to let you locate the
+                              referenced object inside the same namespace.
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          type: array
+                        selector:
+                          additionalProperties:
+                            type: string
+                          description: Selector describes on which nodes will run
+                            the building process.
+                          type: object
+                      required:
+                      - dockerfileConfigMap
+                      type: object
+                    image:
+                      description: image
+                      type: string
+                    kernelVersion:
+                      description: kernel version for which this image is targeted
+                      type: string
+                    registryTLS:
+                      description: RegistryTLS set the TLS configs for accessing the
+                        registry of the image.
+                      properties:
+                        insecure:
+                          description: If Insecure is true, the operator will be able
+                            to access a registry in an insecure (plain HTTP) protocol.
+                          type: boolean
+                        insecureSkipTLSVerify:
+                          description: If InsecureSkipTLSVerify, the operator will
+                            accept any certificate provided by the registry.
+                          type: boolean
+                      type: object
+                    sign:
+                      description: Sign contains sign instructions, in case image
+                        needs signing
+                      properties:
+                        certSecret:
+                          description: a secret containing the public key used to
+                            sign kernel modules for secureboot
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        filesToSign:
+                          description: paths inside the image for the kernel modules
+                            to sign (if ommited all kmods are signed)
+                          items:
+                            type: string
+                          type: array
+                        keySecret:
+                          description: a secret containing the private key used to
+                            sign kernel modules for secureboot
+                          properties:
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        unsignedImage:
+                          description: Image to sign, ignored if a Build is present,
+                            required otherwise
+                          type: string
+                        unsignedImageRegistryTLS:
+                          description: UnsignedImageRegistryTLS contains settings
+                            determining how to access registries of the unsigned image.
+                          properties:
+                            insecure:
+                              description: If Insecure is true, the operator will
+                                be able to access a registry in an insecure (plain
+                                HTTP) protocol.
+                              type: boolean
+                            insecureSkipTLSVerify:
+                              description: If InsecureSkipTLSVerify, the operator
+                                will accept any certificate provided by the registry.
+                              type: boolean
+                          type: object
+                      required:
+                      - certSecret
+                      - keySecret
+                      type: object
+                    skipWaitMissingImage:
+                      description: |-
+                        SkipWaitMissingImage signals to MIC to stop waiting for image to be present
+                        in case Build andSign not define, and report the image as DoesNotExist
+                      type: boolean
+                  required:
+                  - image
+                  - kernelVersion
+                  type: object
+                type: array
+            type: object
+          status:
+            description: |-
+              ModuleImagesConfigStatus describes the status of the images that need to be verified (defined in the spec)
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              imagesStates:
+                items:
+                  properties:
+                    image:
+                      description: image
+                      type: string
+                    status:
+                      description: |-
+                        status of the image
+                        one of: Exists, notExists
+                      type: string
+                  required:
+                  - image
+                  - status
+                  type: object
+                type: array
+            required:
+            - imagesStates
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd-hub/bases/kmm.sigs.x-k8s.io_modules.yaml
+++ b/config/crd-hub/bases/kmm.sigs.x-k8s.io_modules.yaml
@@ -1,0 +1,3046 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  name: modules.kmm.sigs.x-k8s.io
+spec:
+  group: kmm.sigs.x-k8s.io
+  names:
+    kind: Module
+    listKind: ModuleList
+    plural: modules
+    singular: module
+  scope: Namespaced
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: Module describes how to load a module on different kernel versions
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ModuleSpec describes how the KMM operator should deploy a
+              Module on those nodes that need it.
+            properties:
+              devicePlugin:
+                description: |-
+                  DevicePlugin allows overriding some properties of the container that deploys the device plugin on the node.
+                  Name is ignored and is set automatically by the KMM Operator.
+                properties:
+                  container:
+                    properties:
+                      args:
+                        description: |-
+                          Arguments to the entrypoint.
+                          The container image's CMD is used if this is not provided.
+                          Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                          cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                          produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                          of whether the variable exists or not. Cannot be updated.
+                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                        items:
+                          type: string
+                        type: array
+                      command:
+                        description: |-
+                          Entrypoint array. Not executed within a shell.
+                          The container image's ENTRYPOINT is used if this is not provided.
+                          Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                          cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                          produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                          of whether the variable exists or not. Cannot be updated.
+                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                        items:
+                          type: string
+                        type: array
+                      env:
+                        description: |-
+                          List of environment variables to set in the container.
+                          Cannot be updated.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      image:
+                        description: Image is the name of the container image that
+                          the device plugin container will run.
+                        type: string
+                      imagePullPolicy:
+                        description: |-
+                          Image pull policy.
+                          One of Always, Never, IfNotPresent.
+                          Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                        type: string
+                      resources:
+                        description: |-
+                          Compute Resources required by this container.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                      volumeMounts:
+                        description: VolumeMounts is a list of volume mounts that
+                          are appended to the default ones.
+                        items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
+                          properties:
+                            mountPath:
+                              description: |-
+                                Path within the container at which the volume should be mounted.  Must
+                                not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: |-
+                                mountPropagation determines how mounts are propagated from the host
+                                to container and the other way around.
+                                When not set, MountPropagationNone is used.
+                                This field is beta in 1.10.
+                                When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                (which defaults to None).
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: |-
+                                Mounted read-only if true, read-write otherwise (false or unspecified).
+                                Defaults to false.
+                              type: boolean
+                            recursiveReadOnly:
+                              description: |-
+                                RecursiveReadOnly specifies whether read-only mounts should be handled
+                                recursively.
+
+                                If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                recursively read-only.  If this field is set to IfPossible, the mount is made
+                                recursively read-only, if it is supported by the container runtime.  If this
+                                field is set to Enabled, the mount is made recursively read-only if it is
+                                supported by the container runtime, otherwise the pod will not be started and
+                                an error will be generated to indicate the reason.
+
+                                If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                None (or be unspecified, which defaults to None).
+
+                                If this field is not specified, it is treated as an equivalent of Disabled.
+                              type: string
+                            subPath:
+                              description: |-
+                                Path within the volume from which the container's volume should be mounted.
+                                Defaults to "" (volume's root).
+                              type: string
+                            subPathExpr:
+                              description: |-
+                                Expanded path within the volume from which the container's volume should be mounted.
+                                Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                Defaults to "" (volume's root).
+                                SubPathExpr and SubPath are mutually exclusive.
+                              type: string
+                          required:
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                    required:
+                    - image
+                    type: object
+                  initContainer:
+                    description: InitContainer allows defines the init container that
+                      will be used by the device plugin
+                    properties:
+                      args:
+                        description: |-
+                          Arguments to the entrypoint.
+                          The container image's CMD is used if this is not provided.
+                          Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                          cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                          produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                          of whether the variable exists or not. Cannot be updated.
+                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                        items:
+                          type: string
+                        type: array
+                      command:
+                        description: |-
+                          Entrypoint array. Not executed within a shell.
+                          The container image's ENTRYPOINT is used if this is not provided.
+                          Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                          cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                          produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                          of whether the variable exists or not. Cannot be updated.
+                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
+                        items:
+                          type: string
+                        type: array
+                      env:
+                        description: |-
+                          List of environment variables to set in the container.
+                          Cannot be updated.
+                        items:
+                          description: EnvVar represents an environment variable present
+                            in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must
+                                be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value.
+                                Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or
+                                        its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                fieldRef:
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath
+                                        is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in
+                                        the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                resourceFieldRef:
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes,
+                                        optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of
+                                        the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's
+                                    namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select
+                                        from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its
+                                        key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      image:
+                        description: Image is the name of the container image that
+                          the device plugin container will run.
+                        type: string
+                      imagePullPolicy:
+                        description: |-
+                          Image pull policy.
+                          One of Always, Never, IfNotPresent.
+                          Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                        type: string
+                      resources:
+                        description: |-
+                          Compute Resources required by this container.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                        properties:
+                          claims:
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+
+                              This field is immutable. It can only be set for containers.
+                            items:
+                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                              properties:
+                                name:
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
+                                    inside a container.
+                                  type: string
+                                request:
+                                  description: |-
+                                    Request is the name chosen for a request in the referenced claim.
+                                    If empty, everything from the claim is made available, otherwise
+                                    only the result of this request.
+                                  type: string
+                              required:
+                              - name
+                              type: object
+                            type: array
+                            x-kubernetes-list-map-keys:
+                            - name
+                            x-kubernetes-list-type: map
+                          limits:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                          requests:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                            type: object
+                        type: object
+                      volumeMounts:
+                        description: VolumeMounts is a list of volume mounts that
+                          are appended to the default ones.
+                        items:
+                          description: VolumeMount describes a mounting of a Volume
+                            within a container.
+                          properties:
+                            mountPath:
+                              description: |-
+                                Path within the container at which the volume should be mounted.  Must
+                                not contain ':'.
+                              type: string
+                            mountPropagation:
+                              description: |-
+                                mountPropagation determines how mounts are propagated from the host
+                                to container and the other way around.
+                                When not set, MountPropagationNone is used.
+                                This field is beta in 1.10.
+                                When RecursiveReadOnly is set to IfPossible or to Enabled, MountPropagation must be None or unspecified
+                                (which defaults to None).
+                              type: string
+                            name:
+                              description: This must match the Name of a Volume.
+                              type: string
+                            readOnly:
+                              description: |-
+                                Mounted read-only if true, read-write otherwise (false or unspecified).
+                                Defaults to false.
+                              type: boolean
+                            recursiveReadOnly:
+                              description: |-
+                                RecursiveReadOnly specifies whether read-only mounts should be handled
+                                recursively.
+
+                                If ReadOnly is false, this field has no meaning and must be unspecified.
+
+                                If ReadOnly is true, and this field is set to Disabled, the mount is not made
+                                recursively read-only.  If this field is set to IfPossible, the mount is made
+                                recursively read-only, if it is supported by the container runtime.  If this
+                                field is set to Enabled, the mount is made recursively read-only if it is
+                                supported by the container runtime, otherwise the pod will not be started and
+                                an error will be generated to indicate the reason.
+
+                                If this field is set to IfPossible or Enabled, MountPropagation must be set to
+                                None (or be unspecified, which defaults to None).
+
+                                If this field is not specified, it is treated as an equivalent of Disabled.
+                              type: string
+                            subPath:
+                              description: |-
+                                Path within the volume from which the container's volume should be mounted.
+                                Defaults to "" (volume's root).
+                              type: string
+                            subPathExpr:
+                              description: |-
+                                Expanded path within the volume from which the container's volume should be mounted.
+                                Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                Defaults to "" (volume's root).
+                                SubPathExpr and SubPath are mutually exclusive.
+                              type: string
+                          required:
+                          - mountPath
+                          - name
+                          type: object
+                        type: array
+                    required:
+                    - image
+                    type: object
+                  serviceAccountName:
+                    description: |-
+                      ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+                    type: string
+                  volumes:
+                    items:
+                      description: Volume represents a named volume in a pod that
+                        may be accessed by any container in the pod.
+                      properties:
+                        awsElasticBlockStore:
+                          description: |-
+                            awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                            kubelet's host machine and then exposed to the pod.
+                            Deprecated: AWSElasticBlockStore is deprecated. All operations for the in-tree
+                            awsElasticBlockStore type are redirected to the ebs.csi.aws.com CSI driver.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type of the volume that you want to mount.
+                                Tip: Ensure that the filesystem type is supported by the host operating system.
+                                Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                              type: string
+                            partition:
+                              description: |-
+                                partition is the partition in the volume that you want to mount.
+                                If omitted, the default is to mount by volume name.
+                                Examples: For volume /dev/sda1, you specify the partition as "1".
+                                Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                              format: int32
+                              type: integer
+                            readOnly:
+                              description: |-
+                                readOnly value true will force the readOnly setting in VolumeMounts.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                              type: boolean
+                            volumeID:
+                              description: |-
+                                volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        azureDisk:
+                          description: |-
+                            azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                            Deprecated: AzureDisk is deprecated. All operations for the in-tree azureDisk type
+                            are redirected to the disk.csi.azure.com CSI driver.
+                          properties:
+                            cachingMode:
+                              description: 'cachingMode is the Host Caching mode:
+                                None, Read Only, Read Write.'
+                              type: string
+                            diskName:
+                              description: diskName is the Name of the data disk in
+                                the blob storage
+                              type: string
+                            diskURI:
+                              description: diskURI is the URI of data disk in the
+                                blob storage
+                              type: string
+                            fsType:
+                              default: ext4
+                              description: |-
+                                fsType is Filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            kind:
+                              description: 'kind expected values are Shared: multiple
+                                blob disks per storage account  Dedicated: single
+                                blob disk per storage account  Managed: azure managed
+                                data disk (only in managed availability set). defaults
+                                to shared'
+                              type: string
+                            readOnly:
+                              default: false
+                              description: |-
+                                readOnly Defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                          required:
+                          - diskName
+                          - diskURI
+                          type: object
+                        azureFile:
+                          description: |-
+                            azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                            Deprecated: AzureFile is deprecated. All operations for the in-tree azureFile type
+                            are redirected to the file.csi.azure.com CSI driver.
+                          properties:
+                            readOnly:
+                              description: |-
+                                readOnly defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretName:
+                              description: secretName is the  name of secret that
+                                contains Azure Storage Account Name and Key
+                              type: string
+                            shareName:
+                              description: shareName is the azure share Name
+                              type: string
+                          required:
+                          - secretName
+                          - shareName
+                          type: object
+                        cephfs:
+                          description: |-
+                            cephFS represents a Ceph FS mount on the host that shares a pod's lifetime.
+                            Deprecated: CephFS is deprecated and the in-tree cephfs type is no longer supported.
+                          properties:
+                            monitors:
+                              description: |-
+                                monitors is Required: Monitors is a collection of Ceph monitors
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            path:
+                              description: 'path is Optional: Used as the mounted
+                                root, rather than the full Ceph tree, default is /'
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                              type: boolean
+                            secretFile:
+                              description: |-
+                                secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                              type: string
+                            secretRef:
+                              description: |-
+                                secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            user:
+                              description: |-
+                                user is optional: User is the rados user name, default is admin
+                                More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
+                              type: string
+                          required:
+                          - monitors
+                          type: object
+                        cinder:
+                          description: |-
+                            cinder represents a cinder volume attached and mounted on kubelets host machine.
+                            Deprecated: Cinder is deprecated. All operations for the in-tree cinder type
+                            are redirected to the cinder.csi.openstack.org CSI driver.
+                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                              type: boolean
+                            secretRef:
+                              description: |-
+                                secretRef is optional: points to a secret object containing parameters used to connect
+                                to OpenStack.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            volumeID:
+                              description: |-
+                                volumeID used to identify the volume in cinder.
+                                More info: https://examples.k8s.io/mysql-cinder-pd/README.md
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        configMap:
+                          description: configMap represents a configMap that should
+                            populate this volume
+                          properties:
+                            defaultMode:
+                              description: |-
+                                defaultMode is optional: mode bits used to set permissions on created files by default.
+                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                Defaults to 0644.
+                                Directories within the path are not affected by this setting.
+                                This might be in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode bits set.
+                              format: int32
+                              type: integer
+                            items:
+                              description: |-
+                                items if unspecified, each key-value pair in the Data field of the referenced
+                                ConfigMap will be projected into the volume as a file whose name is the
+                                key and content is the value. If specified, the listed keys will be
+                                projected into the specified paths, and unlisted keys will not be
+                                present. If a key is specified which is not present in the ConfigMap,
+                                the volume setup will error unless it is marked optional. Paths must be
+                                relative and may not contain the '..' path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: |-
+                                      mode is Optional: mode bits used to set permissions on this file.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      If not specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: |-
+                                      path is the relative path of the file to map the key to.
+                                      May not be an absolute path.
+                                      May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            name:
+                              default: ""
+                              description: |-
+                                Name of the referent.
+                                This field is effectively required, but due to backwards compatibility is
+                                allowed to be empty. Instances of this type with an empty value here are
+                                almost certainly wrong.
+                                More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              type: string
+                            optional:
+                              description: optional specify whether the ConfigMap
+                                or its keys must be defined
+                              type: boolean
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        csi:
+                          description: csi (Container Storage Interface) represents
+                            ephemeral storage that is handled by certain external
+                            CSI drivers.
+                          properties:
+                            driver:
+                              description: |-
+                                driver is the name of the CSI driver that handles this volume.
+                                Consult with your admin for the correct name as registered in the cluster.
+                              type: string
+                            fsType:
+                              description: |-
+                                fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                If not provided, the empty value is passed to the associated CSI driver
+                                which will determine the default filesystem to apply.
+                              type: string
+                            nodePublishSecretRef:
+                              description: |-
+                                nodePublishSecretRef is a reference to the secret object containing
+                                sensitive information to pass to the CSI driver to complete the CSI
+                                NodePublishVolume and NodeUnpublishVolume calls.
+                                This field is optional, and  may be empty if no secret is required. If the
+                                secret object contains more than one secret, all secret references are passed.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            readOnly:
+                              description: |-
+                                readOnly specifies a read-only configuration for the volume.
+                                Defaults to false (read/write).
+                              type: boolean
+                            volumeAttributes:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                volumeAttributes stores driver-specific properties that are passed to the CSI
+                                driver. Consult your driver's documentation for supported values.
+                              type: object
+                          required:
+                          - driver
+                          type: object
+                        downwardAPI:
+                          description: downwardAPI represents downward API about the
+                            pod that should populate this volume
+                          properties:
+                            defaultMode:
+                              description: |-
+                                Optional: mode bits to use on created files by default. Must be a
+                                Optional: mode bits used to set permissions on created files by default.
+                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                Defaults to 0644.
+                                Directories within the path are not affected by this setting.
+                                This might be in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode bits set.
+                              format: int32
+                              type: integer
+                            items:
+                              description: Items is a list of downward API volume
+                                file
+                              items:
+                                description: DownwardAPIVolumeFile represents information
+                                  to create the file containing the pod field
+                                properties:
+                                  fieldRef:
+                                    description: 'Required: Selects a field of the
+                                      pod: only annotations, labels, name, namespace
+                                      and uid are supported.'
+                                    properties:
+                                      apiVersion:
+                                        description: Version of the schema the FieldPath
+                                          is written in terms of, defaults to "v1".
+                                        type: string
+                                      fieldPath:
+                                        description: Path of the field to select in
+                                          the specified API version.
+                                        type: string
+                                    required:
+                                    - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  mode:
+                                    description: |-
+                                      Optional: mode bits used to set permissions on this file, must be an octal value
+                                      between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      If not specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: 'Required: Path is  the relative
+                                      path name of the file to be created. Must not
+                                      be absolute or contain the ''..'' path. Must
+                                      be utf-8 encoded. The first item of the relative
+                                      path must not start with ''..'''
+                                    type: string
+                                  resourceFieldRef:
+                                    description: |-
+                                      Selects a resource of the container: only resources limits and requests
+                                      (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                    properties:
+                                      containerName:
+                                        description: 'Container name: required for
+                                          volumes, optional for env vars'
+                                        type: string
+                                      divisor:
+                                        anyOf:
+                                        - type: integer
+                                        - type: string
+                                        description: Specifies the output format of
+                                          the exposed resources, defaults to "1"
+                                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                        x-kubernetes-int-or-string: true
+                                      resource:
+                                        description: 'Required: resource to select'
+                                        type: string
+                                    required:
+                                    - resource
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                required:
+                                - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        emptyDir:
+                          description: |-
+                            emptyDir represents a temporary directory that shares a pod's lifetime.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                          properties:
+                            medium:
+                              description: |-
+                                medium represents what type of storage medium should back this directory.
+                                The default is "" which means to use the node's default medium.
+                                Must be an empty string (default) or Memory.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                              type: string
+                            sizeLimit:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: |-
+                                sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                The size limit is also applicable for memory medium.
+                                The maximum usage on memory medium EmptyDir would be the minimum value between
+                                the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                The default is nil which means that the limit is undefined.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                          type: object
+                        ephemeral:
+                          description: |-
+                            ephemeral represents a volume that is handled by a cluster storage driver.
+                            The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                            and deleted when the pod is removed.
+
+                            Use this if:
+                            a) the volume is only needed while the pod runs,
+                            b) features of normal volumes like restoring from snapshot or capacity
+                               tracking are needed,
+                            c) the storage driver is specified through a storage class, and
+                            d) the storage driver supports dynamic volume provisioning through
+                               a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                               information on the connection between this volume type
+                               and PersistentVolumeClaim).
+
+                            Use PersistentVolumeClaim or one of the vendor-specific
+                            APIs for volumes that persist for longer than the lifecycle
+                            of an individual pod.
+
+                            Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                            be used that way - see the documentation of the driver for
+                            more information.
+
+                            A pod can use both types of ephemeral volumes and
+                            persistent volumes at the same time.
+                          properties:
+                            volumeClaimTemplate:
+                              description: |-
+                                Will be used to create a stand-alone PVC to provision the volume.
+                                The pod in which this EphemeralVolumeSource is embedded will be the
+                                owner of the PVC, i.e. the PVC will be deleted together with the
+                                pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                `<volume name>` is the name from the `PodSpec.Volumes` array
+                                entry. Pod validation will reject the pod if the concatenated name
+                                is not valid for a PVC (for example, too long).
+
+                                An existing PVC with that name that is not owned by the pod
+                                will *not* be used for the pod to avoid using an unrelated
+                                volume by mistake. Starting the pod is then blocked until
+                                the unrelated PVC is removed. If such a pre-created PVC is
+                                meant to be used by the pod, the PVC has to updated with an
+                                owner reference to the pod once the pod exists. Normally
+                                this should not be necessary, but it may be useful when
+                                manually reconstructing a broken cluster.
+
+                                This field is read-only and no changes will be made by Kubernetes
+                                to the PVC after it has been created.
+
+                                Required, must not be nil.
+                              properties:
+                                metadata:
+                                  description: |-
+                                    May contain labels and annotations that will be copied into the PVC
+                                    when creating it. No other fields are allowed and will be rejected during
+                                    validation.
+                                  type: object
+                                spec:
+                                  description: |-
+                                    The specification for the PersistentVolumeClaim. The entire content is
+                                    copied unchanged into the PVC that gets created from this
+                                    template. The same fields as in a PersistentVolumeClaim
+                                    are also valid here.
+                                  properties:
+                                    accessModes:
+                                      description: |-
+                                        accessModes contains the desired access modes the volume should have.
+                                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    dataSource:
+                                      description: |-
+                                        dataSource field can be used to specify either:
+                                        * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                        * An existing PVC (PersistentVolumeClaim)
+                                        If the provisioner or an external controller can support the specified data source,
+                                        it will create a new volume based on the contents of the specified data source.
+                                        When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                        and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                        If the namespace is specified, then dataSourceRef will not be copied to dataSource.
+                                      properties:
+                                        apiGroup:
+                                          description: |-
+                                            APIGroup is the group for the resource being referenced.
+                                            If APIGroup is not specified, the specified Kind must be in the core API group.
+                                            For any other third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource
+                                            being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource
+                                            being referenced
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    dataSourceRef:
+                                      description: |-
+                                        dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                        volume is desired. This may be any object from a non-empty API group (non
+                                        core object) or a PersistentVolumeClaim object.
+                                        When this field is specified, volume binding will only succeed if the type of
+                                        the specified object matches some installed volume populator or dynamic
+                                        provisioner.
+                                        This field will replace the functionality of the dataSource field and as such
+                                        if both fields are non-empty, they must have the same value. For backwards
+                                        compatibility, when namespace isn't specified in dataSourceRef,
+                                        both fields (dataSource and dataSourceRef) will be set to the same
+                                        value automatically if one of them is empty and the other is non-empty.
+                                        When namespace is specified in dataSourceRef,
+                                        dataSource isn't set to the same value and must be empty.
+                                        There are three important differences between dataSource and dataSourceRef:
+                                        * While dataSource only allows two specific types of objects, dataSourceRef
+                                          allows any non-core object, as well as PersistentVolumeClaim objects.
+                                        * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                          preserves all values, and generates an error if a disallowed value is
+                                          specified.
+                                        * While dataSource only allows local objects, dataSourceRef allows objects
+                                          in any namespaces.
+                                        (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                        (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                      properties:
+                                        apiGroup:
+                                          description: |-
+                                            APIGroup is the group for the resource being referenced.
+                                            If APIGroup is not specified, the specified Kind must be in the core API group.
+                                            For any other third-party types, APIGroup is required.
+                                          type: string
+                                        kind:
+                                          description: Kind is the type of resource
+                                            being referenced
+                                          type: string
+                                        name:
+                                          description: Name is the name of resource
+                                            being referenced
+                                          type: string
+                                        namespace:
+                                          description: |-
+                                            Namespace is the namespace of resource being referenced
+                                            Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                            (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                          type: string
+                                      required:
+                                      - kind
+                                      - name
+                                      type: object
+                                    resources:
+                                      description: |-
+                                        resources represents the minimum resources the volume should have.
+                                        If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                        that are lower than previous value but must still be higher than capacity recorded in the
+                                        status field of the claim.
+                                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
+                                      properties:
+                                        limits:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Limits describes the maximum amount of compute resources allowed.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                        requests:
+                                          additionalProperties:
+                                            anyOf:
+                                            - type: integer
+                                            - type: string
+                                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                            x-kubernetes-int-or-string: true
+                                          description: |-
+                                            Requests describes the minimum amount of compute resources required.
+                                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                                          type: object
+                                      type: object
+                                    selector:
+                                      description: selector is a label query over
+                                        volumes to consider for binding.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                    storageClassName:
+                                      description: |-
+                                        storageClassName is the name of the StorageClass required by the claim.
+                                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
+                                      type: string
+                                    volumeAttributesClassName:
+                                      description: |-
+                                        volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                        If specified, the CSI driver will create or update the volume with the attributes defined
+                                        in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                        it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                        will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                        If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                        will be set by the persistentvolume controller if it exists.
+                                        If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                        set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                        exists.
+                                        More info: https://kubernetes.io/docs/concepts/storage/volume-attributes-classes/
+                                        (Beta) Using this field requires the VolumeAttributesClass feature gate to be enabled (off by default).
+                                      type: string
+                                    volumeMode:
+                                      description: |-
+                                        volumeMode defines what type of volume is required by the claim.
+                                        Value of Filesystem is implied when not included in claim spec.
+                                      type: string
+                                    volumeName:
+                                      description: volumeName is the binding reference
+                                        to the PersistentVolume backing this claim.
+                                      type: string
+                                  type: object
+                              required:
+                              - spec
+                              type: object
+                          type: object
+                        fc:
+                          description: fc represents a Fibre Channel resource that
+                            is attached to a kubelet's host machine and then exposed
+                            to the pod.
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            lun:
+                              description: 'lun is Optional: FC target lun number'
+                              format: int32
+                              type: integer
+                            readOnly:
+                              description: |-
+                                readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            targetWWNs:
+                              description: 'targetWWNs is Optional: FC target worldwide
+                                names (WWNs)'
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            wwids:
+                              description: |-
+                                wwids Optional: FC volume world wide identifiers (wwids)
+                                Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        flexVolume:
+                          description: |-
+                            flexVolume represents a generic volume resource that is
+                            provisioned/attached using an exec based plugin.
+                            Deprecated: FlexVolume is deprecated. Consider using a CSIDriver instead.
+                          properties:
+                            driver:
+                              description: driver is the name of the driver to use
+                                for this volume.
+                              type: string
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                              type: string
+                            options:
+                              additionalProperties:
+                                type: string
+                              description: 'options is Optional: this field holds
+                                extra command options if any.'
+                              type: object
+                            readOnly:
+                              description: |-
+                                readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: |-
+                                secretRef is Optional: secretRef is reference to the secret object containing
+                                sensitive information to pass to the plugin scripts. This may be
+                                empty if no secret object is specified. If the secret object
+                                contains more than one secret, all secrets are passed to the plugin
+                                scripts.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          required:
+                          - driver
+                          type: object
+                        flocker:
+                          description: |-
+                            flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running.
+                            Deprecated: Flocker is deprecated and the in-tree flocker type is no longer supported.
+                          properties:
+                            datasetName:
+                              description: |-
+                                datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                should be considered as deprecated
+                              type: string
+                            datasetUUID:
+                              description: datasetUUID is the UUID of the dataset.
+                                This is unique identifier of a Flocker dataset
+                              type: string
+                          type: object
+                        gcePersistentDisk:
+                          description: |-
+                            gcePersistentDisk represents a GCE Disk resource that is attached to a
+                            kubelet's host machine and then exposed to the pod.
+                            Deprecated: GCEPersistentDisk is deprecated. All operations for the in-tree
+                            gcePersistentDisk type are redirected to the pd.csi.storage.gke.io CSI driver.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is filesystem type of the volume that you want to mount.
+                                Tip: Ensure that the filesystem type is supported by the host operating system.
+                                Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                              type: string
+                            partition:
+                              description: |-
+                                partition is the partition in the volume that you want to mount.
+                                If omitted, the default is to mount by volume name.
+                                Examples: For volume /dev/sda1, you specify the partition as "1".
+                                Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                              format: int32
+                              type: integer
+                            pdName:
+                              description: |-
+                                pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly here will force the ReadOnly setting in VolumeMounts.
+                                Defaults to false.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                              type: boolean
+                          required:
+                          - pdName
+                          type: object
+                        gitRepo:
+                          description: |-
+                            gitRepo represents a git repository at a particular revision.
+                            Deprecated: GitRepo is deprecated. To provision a container with a git repo, mount an
+                            EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                            into the Pod's container.
+                          properties:
+                            directory:
+                              description: |-
+                                directory is the target directory name.
+                                Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                git repository.  Otherwise, if specified, the volume will contain the git repository in
+                                the subdirectory with the given name.
+                              type: string
+                            repository:
+                              description: repository is the URL
+                              type: string
+                            revision:
+                              description: revision is the commit hash for the specified
+                                revision.
+                              type: string
+                          required:
+                          - repository
+                          type: object
+                        glusterfs:
+                          description: |-
+                            glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                            Deprecated: Glusterfs is deprecated and the in-tree glusterfs type is no longer supported.
+                            More info: https://examples.k8s.io/volumes/glusterfs/README.md
+                          properties:
+                            endpoints:
+                              description: |-
+                                endpoints is the endpoint name that details Glusterfs topology.
+                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                              type: string
+                            path:
+                              description: |-
+                                path is the Glusterfs volume path.
+                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                Defaults to false.
+                                More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
+                              type: boolean
+                          required:
+                          - endpoints
+                          - path
+                          type: object
+                        hostPath:
+                          description: |-
+                            hostPath represents a pre-existing file or directory on the host
+                            machine that is directly exposed to the container. This is generally
+                            used for system agents or other privileged things that are allowed
+                            to see the host machine. Most containers will NOT need this.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                          properties:
+                            path:
+                              description: |-
+                                path of the directory on the host.
+                                If the path is a symlink, it will follow the link to the real path.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                              type: string
+                            type:
+                              description: |-
+                                type for HostPath Volume
+                                Defaults to ""
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                              type: string
+                          required:
+                          - path
+                          type: object
+                        image:
+                          description: |-
+                            image represents an OCI object (a container image or artifact) pulled and mounted on the kubelet's host machine.
+                            The volume is resolved at pod startup depending on which PullPolicy value is provided:
+
+                            - Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                            - Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                            - IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+
+                            The volume gets re-resolved if the pod gets deleted and recreated, which means that new remote content will become available on pod recreation.
+                            A failure to resolve or pull the image during pod startup will block containers from starting and may add significant latency. Failures will be retried using normal volume backoff and will be reported on the pod reason and message.
+                            The types of objects that may be mounted by this volume are defined by the container runtime implementation on a host machine and at minimum must include all valid types supported by the container image field.
+                            The OCI object gets mounted in a single directory (spec.containers[*].volumeMounts.mountPath) by merging the manifest layers in the same way as for container images.
+                            The volume will be mounted read-only (ro) and non-executable files (noexec).
+                            Sub path mounts for containers are not supported (spec.containers[*].volumeMounts.subpath).
+                            The field spec.securityContext.fsGroupChangePolicy has no effect on this volume type.
+                          properties:
+                            pullPolicy:
+                              description: |-
+                                Policy for pulling OCI objects. Possible values are:
+                                Always: the kubelet always attempts to pull the reference. Container creation will fail If the pull fails.
+                                Never: the kubelet never pulls the reference and only uses a local image or artifact. Container creation will fail if the reference isn't present.
+                                IfNotPresent: the kubelet pulls if the reference isn't already present on disk. Container creation will fail if the reference isn't present and the pull fails.
+                                Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                              type: string
+                            reference:
+                              description: |-
+                                Required: Image or artifact reference to be used.
+                                Behaves in the same way as pod.spec.containers[*].image.
+                                Pull secrets will be assembled in the same way as for the container image by looking up node credentials, SA image pull secrets, and pod spec image pull secrets.
+                                More info: https://kubernetes.io/docs/concepts/containers/images
+                                This field is optional to allow higher level config management to default or override
+                                container images in workload controllers like Deployments and StatefulSets.
+                              type: string
+                          type: object
+                        iscsi:
+                          description: |-
+                            iscsi represents an ISCSI Disk resource that is attached to a
+                            kubelet's host machine and then exposed to the pod.
+                            More info: https://examples.k8s.io/volumes/iscsi/README.md
+                          properties:
+                            chapAuthDiscovery:
+                              description: chapAuthDiscovery defines whether support
+                                iSCSI Discovery CHAP authentication
+                              type: boolean
+                            chapAuthSession:
+                              description: chapAuthSession defines whether support
+                                iSCSI Session CHAP authentication
+                              type: boolean
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type of the volume that you want to mount.
+                                Tip: Ensure that the filesystem type is supported by the host operating system.
+                                Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                              type: string
+                            initiatorName:
+                              description: |-
+                                initiatorName is the custom iSCSI Initiator Name.
+                                If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                <target portal>:<volume name> will be created for the connection.
+                              type: string
+                            iqn:
+                              description: iqn is the target iSCSI Qualified Name.
+                              type: string
+                            iscsiInterface:
+                              default: default
+                              description: |-
+                                iscsiInterface is the interface Name that uses an iSCSI transport.
+                                Defaults to 'default' (tcp).
+                              type: string
+                            lun:
+                              description: lun represents iSCSI Target Lun number.
+                              format: int32
+                              type: integer
+                            portals:
+                              description: |-
+                                portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                is other than default (typically TCP ports 860 and 3260).
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            readOnly:
+                              description: |-
+                                readOnly here will force the ReadOnly setting in VolumeMounts.
+                                Defaults to false.
+                              type: boolean
+                            secretRef:
+                              description: secretRef is the CHAP Secret for iSCSI
+                                target and initiator authentication
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            targetPortal:
+                              description: |-
+                                targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                is other than default (typically TCP ports 860 and 3260).
+                              type: string
+                          required:
+                          - iqn
+                          - lun
+                          - targetPortal
+                          type: object
+                        name:
+                          description: |-
+                            name of the volume.
+                            Must be a DNS_LABEL and unique within the pod.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        nfs:
+                          description: |-
+                            nfs represents an NFS mount on the host that shares a pod's lifetime
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                          properties:
+                            path:
+                              description: |-
+                                path that is exported by the NFS server.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly here will force the NFS export to be mounted with read-only permissions.
+                                Defaults to false.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              type: boolean
+                            server:
+                              description: |-
+                                server is the hostname or IP address of the NFS server.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
+                              type: string
+                          required:
+                          - path
+                          - server
+                          type: object
+                        persistentVolumeClaim:
+                          description: |-
+                            persistentVolumeClaimVolumeSource represents a reference to a
+                            PersistentVolumeClaim in the same namespace.
+                            More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                          properties:
+                            claimName:
+                              description: |-
+                                claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly Will force the ReadOnly setting in VolumeMounts.
+                                Default false.
+                              type: boolean
+                          required:
+                          - claimName
+                          type: object
+                        photonPersistentDisk:
+                          description: |-
+                            photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine.
+                            Deprecated: PhotonPersistentDisk is deprecated and the in-tree photonPersistentDisk type is no longer supported.
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            pdID:
+                              description: pdID is the ID that identifies Photon Controller
+                                persistent disk
+                              type: string
+                          required:
+                          - pdID
+                          type: object
+                        portworxVolume:
+                          description: |-
+                            portworxVolume represents a portworx volume attached and mounted on kubelets host machine.
+                            Deprecated: PortworxVolume is deprecated. All operations for the in-tree portworxVolume type
+                            are redirected to the pxd.portworx.com CSI driver when the CSIMigrationPortworx feature-gate
+                            is on.
+                          properties:
+                            fsType:
+                              description: |-
+                                fSType represents the filesystem type to mount
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            volumeID:
+                              description: volumeID uniquely identifies a Portworx
+                                volume
+                              type: string
+                          required:
+                          - volumeID
+                          type: object
+                        projected:
+                          description: projected items for all in one resources secrets,
+                            configmaps, and downward API
+                          properties:
+                            defaultMode:
+                              description: |-
+                                defaultMode are the mode bits used to set permissions on created files by default.
+                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                Directories within the path are not affected by this setting.
+                                This might be in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode bits set.
+                              format: int32
+                              type: integer
+                            sources:
+                              description: |-
+                                sources is the list of volume projections. Each entry in this list
+                                handles one source.
+                              items:
+                                description: |-
+                                  Projection that may be projected along with other supported volume types.
+                                  Exactly one of these fields must be set.
+                                properties:
+                                  clusterTrustBundle:
+                                    description: |-
+                                      ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                      of ClusterTrustBundle objects in an auto-updating file.
+
+                                      Alpha, gated by the ClusterTrustBundleProjection feature gate.
+
+                                      ClusterTrustBundle objects can either be selected by name, or by the
+                                      combination of signer name and a label selector.
+
+                                      Kubelet performs aggressive normalization of the PEM contents written
+                                      into the pod filesystem.  Esoteric PEM features such as inter-block
+                                      comments and block headers are stripped.  Certificates are deduplicated.
+                                      The ordering of certificates within the file is arbitrary, and Kubelet
+                                      may change the order over time.
+                                    properties:
+                                      labelSelector:
+                                        description: |-
+                                          Select all ClusterTrustBundles that match this label selector.  Only has
+                                          effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                          interpreted as "match nothing".  If set but empty, interpreted as "match
+                                          everything".
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The
+                                              requirements are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                                  x-kubernetes-list-type: atomic
+                                              required:
+                                              - key
+                                              - operator
+                                              type: object
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      name:
+                                        description: |-
+                                          Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                          with signerName and labelSelector.
+                                        type: string
+                                      optional:
+                                        description: |-
+                                          If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                          aren't available.  If using name, then the named ClusterTrustBundle is
+                                          allowed not to exist.  If using signerName, then the combination of
+                                          signerName and labelSelector is allowed to match zero
+                                          ClusterTrustBundles.
+                                        type: boolean
+                                      path:
+                                        description: Relative path from the volume
+                                          root to write the bundle.
+                                        type: string
+                                      signerName:
+                                        description: |-
+                                          Select all ClusterTrustBundles that match this signer name.
+                                          Mutually-exclusive with name.  The contents of all selected
+                                          ClusterTrustBundles will be unified and deduplicated.
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                  configMap:
+                                    description: configMap information about the configMap
+                                      data to project
+                                    properties:
+                                      items:
+                                        description: |-
+                                          items if unspecified, each key-value pair in the Data field of the referenced
+                                          ConfigMap will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present. If a key is specified which is not present in the ConfigMap,
+                                          the volume setup will error unless it is marked optional. Paths must be
+                                          relative and may not contain the '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
+                                                This might be in conflict with other options that affect the file
+                                                mode, like fsGroup, and the result can be other mode bits set.
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: optional specify whether the
+                                          ConfigMap or its keys must be defined
+                                        type: boolean
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  downwardAPI:
+                                    description: downwardAPI information about the
+                                      downwardAPI data to project
+                                    properties:
+                                      items:
+                                        description: Items is a list of DownwardAPIVolume
+                                          file
+                                        items:
+                                          description: DownwardAPIVolumeFile represents
+                                            information to create the file containing
+                                            the pod field
+                                          properties:
+                                            fieldRef:
+                                              description: 'Required: Selects a field
+                                                of the pod: only annotations, labels,
+                                                name, namespace and uid are supported.'
+                                              properties:
+                                                apiVersion:
+                                                  description: Version of the schema
+                                                    the FieldPath is written in terms
+                                                    of, defaults to "v1".
+                                                  type: string
+                                                fieldPath:
+                                                  description: Path of the field to
+                                                    select in the specified API version.
+                                                  type: string
+                                              required:
+                                              - fieldPath
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                            mode:
+                                              description: |-
+                                                Optional: mode bits used to set permissions on this file, must be an octal value
+                                                between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
+                                                This might be in conflict with other options that affect the file
+                                                mode, like fsGroup, and the result can be other mode bits set.
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: 'Required: Path is  the
+                                                relative path name of the file to
+                                                be created. Must not be absolute or
+                                                contain the ''..'' path. Must be utf-8
+                                                encoded. The first item of the relative
+                                                path must not start with ''..'''
+                                              type: string
+                                            resourceFieldRef:
+                                              description: |-
+                                                Selects a resource of the container: only resources limits and requests
+                                                (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
+                                              properties:
+                                                containerName:
+                                                  description: 'Container name: required
+                                                    for volumes, optional for env
+                                                    vars'
+                                                  type: string
+                                                divisor:
+                                                  anyOf:
+                                                  - type: integer
+                                                  - type: string
+                                                  description: Specifies the output
+                                                    format of the exposed resources,
+                                                    defaults to "1"
+                                                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                                  x-kubernetes-int-or-string: true
+                                                resource:
+                                                  description: 'Required: resource
+                                                    to select'
+                                                  type: string
+                                              required:
+                                              - resource
+                                              type: object
+                                              x-kubernetes-map-type: atomic
+                                          required:
+                                          - path
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    type: object
+                                  secret:
+                                    description: secret information about the secret
+                                      data to project
+                                    properties:
+                                      items:
+                                        description: |-
+                                          items if unspecified, each key-value pair in the Data field of the referenced
+                                          Secret will be projected into the volume as a file whose name is the
+                                          key and content is the value. If specified, the listed keys will be
+                                          projected into the specified paths, and unlisted keys will not be
+                                          present. If a key is specified which is not present in the Secret,
+                                          the volume setup will error unless it is marked optional. Paths must be
+                                          relative and may not contain the '..' path or start with '..'.
+                                        items:
+                                          description: Maps a string key to a path
+                                            within a volume.
+                                          properties:
+                                            key:
+                                              description: key is the key to project.
+                                              type: string
+                                            mode:
+                                              description: |-
+                                                mode is Optional: mode bits used to set permissions on this file.
+                                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                If not specified, the volume defaultMode will be used.
+                                                This might be in conflict with other options that affect the file
+                                                mode, like fsGroup, and the result can be other mode bits set.
+                                              format: int32
+                                              type: integer
+                                            path:
+                                              description: |-
+                                                path is the relative path of the file to map the key to.
+                                                May not be an absolute path.
+                                                May not contain the path element '..'.
+                                                May not start with the string '..'.
+                                              type: string
+                                          required:
+                                          - key
+                                          - path
+                                          type: object
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                      optional:
+                                        description: optional field specify whether
+                                          the Secret or its key must be defined
+                                        type: boolean
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  serviceAccountToken:
+                                    description: serviceAccountToken is information
+                                      about the serviceAccountToken data to project
+                                    properties:
+                                      audience:
+                                        description: |-
+                                          audience is the intended audience of the token. A recipient of a token
+                                          must identify itself with an identifier specified in the audience of the
+                                          token, and otherwise should reject the token. The audience defaults to the
+                                          identifier of the apiserver.
+                                        type: string
+                                      expirationSeconds:
+                                        description: |-
+                                          expirationSeconds is the requested duration of validity of the service
+                                          account token. As the token approaches expiration, the kubelet volume
+                                          plugin will proactively rotate the service account token. The kubelet will
+                                          start trying to rotate the token if the token is older than 80 percent of
+                                          its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                          and must be at least 10 minutes.
+                                        format: int64
+                                        type: integer
+                                      path:
+                                        description: |-
+                                          path is the path relative to the mount point of the file to project the
+                                          token into.
+                                        type: string
+                                    required:
+                                    - path
+                                    type: object
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                          type: object
+                        quobyte:
+                          description: |-
+                            quobyte represents a Quobyte mount on the host that shares a pod's lifetime.
+                            Deprecated: Quobyte is deprecated and the in-tree quobyte type is no longer supported.
+                          properties:
+                            group:
+                              description: |-
+                                group to map volume access to
+                                Default is no group
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                                Defaults to false.
+                              type: boolean
+                            registry:
+                              description: |-
+                                registry represents a single or multiple Quobyte Registry services
+                                specified as a string as host:port pair (multiple entries are separated with commas)
+                                which acts as the central registry for volumes
+                              type: string
+                            tenant:
+                              description: |-
+                                tenant owning the given Quobyte volume in the Backend
+                                Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                              type: string
+                            user:
+                              description: |-
+                                user to map volume access to
+                                Defaults to serivceaccount user
+                              type: string
+                            volume:
+                              description: volume is a string that references an already
+                                created Quobyte volume by name.
+                              type: string
+                          required:
+                          - registry
+                          - volume
+                          type: object
+                        rbd:
+                          description: |-
+                            rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                            Deprecated: RBD is deprecated and the in-tree rbd type is no longer supported.
+                            More info: https://examples.k8s.io/volumes/rbd/README.md
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type of the volume that you want to mount.
+                                Tip: Ensure that the filesystem type is supported by the host operating system.
+                                Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                              type: string
+                            image:
+                              description: |-
+                                image is the rados image name.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              type: string
+                            keyring:
+                              default: /etc/ceph/keyring
+                              description: |-
+                                keyring is the path to key ring for RBDUser.
+                                Default is /etc/ceph/keyring.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              type: string
+                            monitors:
+                              description: |-
+                                monitors is a collection of Ceph monitors.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            pool:
+                              default: rbd
+                              description: |-
+                                pool is the rados pool name.
+                                Default is rbd.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly here will force the ReadOnly setting in VolumeMounts.
+                                Defaults to false.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              type: boolean
+                            secretRef:
+                              description: |-
+                                secretRef is name of the authentication secret for RBDUser. If provided
+                                overrides keyring.
+                                Default is nil.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            user:
+                              default: admin
+                              description: |-
+                                user is the rados user name.
+                                Default is admin.
+                                More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
+                              type: string
+                          required:
+                          - image
+                          - monitors
+                          type: object
+                        scaleIO:
+                          description: |-
+                            scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                            Deprecated: ScaleIO is deprecated and the in-tree scaleIO type is no longer supported.
+                          properties:
+                            fsType:
+                              default: xfs
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs".
+                                Default is "xfs".
+                              type: string
+                            gateway:
+                              description: gateway is the host address of the ScaleIO
+                                API Gateway.
+                              type: string
+                            protectionDomain:
+                              description: protectionDomain is the name of the ScaleIO
+                                Protection Domain for the configured storage.
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly Defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: |-
+                                secretRef references to the secret for ScaleIO user and other
+                                sensitive information. If this is not provided, Login operation will fail.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            sslEnabled:
+                              description: sslEnabled Flag enable/disable SSL communication
+                                with Gateway, default false
+                              type: boolean
+                            storageMode:
+                              default: ThinProvisioned
+                              description: |-
+                                storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                Default is ThinProvisioned.
+                              type: string
+                            storagePool:
+                              description: storagePool is the ScaleIO Storage Pool
+                                associated with the protection domain.
+                              type: string
+                            system:
+                              description: system is the name of the storage system
+                                as configured in ScaleIO.
+                              type: string
+                            volumeName:
+                              description: |-
+                                volumeName is the name of a volume already created in the ScaleIO system
+                                that is associated with this volume source.
+                              type: string
+                          required:
+                          - gateway
+                          - secretRef
+                          - system
+                          type: object
+                        secret:
+                          description: |-
+                            secret represents a secret that should populate this volume.
+                            More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                          properties:
+                            defaultMode:
+                              description: |-
+                                defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                YAML accepts both octal and decimal values, JSON requires decimal values
+                                for mode bits. Defaults to 0644.
+                                Directories within the path are not affected by this setting.
+                                This might be in conflict with other options that affect the file
+                                mode, like fsGroup, and the result can be other mode bits set.
+                              format: int32
+                              type: integer
+                            items:
+                              description: |-
+                                items If unspecified, each key-value pair in the Data field of the referenced
+                                Secret will be projected into the volume as a file whose name is the
+                                key and content is the value. If specified, the listed keys will be
+                                projected into the specified paths, and unlisted keys will not be
+                                present. If a key is specified which is not present in the Secret,
+                                the volume setup will error unless it is marked optional. Paths must be
+                                relative and may not contain the '..' path or start with '..'.
+                              items:
+                                description: Maps a string key to a path within a
+                                  volume.
+                                properties:
+                                  key:
+                                    description: key is the key to project.
+                                    type: string
+                                  mode:
+                                    description: |-
+                                      mode is Optional: mode bits used to set permissions on this file.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      If not specified, the volume defaultMode will be used.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
+                                    format: int32
+                                    type: integer
+                                  path:
+                                    description: |-
+                                      path is the relative path of the file to map the key to.
+                                      May not be an absolute path.
+                                      May not contain the path element '..'.
+                                      May not start with the string '..'.
+                                    type: string
+                                required:
+                                - key
+                                - path
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            optional:
+                              description: optional field specify whether the Secret
+                                or its keys must be defined
+                              type: boolean
+                            secretName:
+                              description: |-
+                                secretName is the name of the secret in the pod's namespace to use.
+                                More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
+                              type: string
+                          type: object
+                        storageos:
+                          description: |-
+                            storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                            Deprecated: StorageOS is deprecated and the in-tree storageos type is no longer supported.
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is the filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            readOnly:
+                              description: |-
+                                readOnly defaults to false (read/write). ReadOnly here will force
+                                the ReadOnly setting in VolumeMounts.
+                              type: boolean
+                            secretRef:
+                              description: |-
+                                secretRef specifies the secret to use for obtaining the StorageOS API
+                                credentials.  If not specified, default values will be attempted.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            volumeName:
+                              description: |-
+                                volumeName is the human-readable name of the StorageOS volume.  Volume
+                                names are only unique within a namespace.
+                              type: string
+                            volumeNamespace:
+                              description: |-
+                                volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                namespace is specified then the Pod's namespace will be used.  This allows the
+                                Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                Set VolumeName to any name to override the default behaviour.
+                                Set to "default" if you are not using namespaces within StorageOS.
+                                Namespaces that do not pre-exist within StorageOS will be created.
+                              type: string
+                          type: object
+                        vsphereVolume:
+                          description: |-
+                            vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine.
+                            Deprecated: VsphereVolume is deprecated. All operations for the in-tree vsphereVolume type
+                            are redirected to the csi.vsphere.vmware.com CSI driver.
+                          properties:
+                            fsType:
+                              description: |-
+                                fsType is filesystem type to mount.
+                                Must be a filesystem type supported by the host operating system.
+                                Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              type: string
+                            storagePolicyID:
+                              description: storagePolicyID is the storage Policy Based
+                                Management (SPBM) profile ID associated with the StoragePolicyName.
+                              type: string
+                            storagePolicyName:
+                              description: storagePolicyName is the storage Policy
+                                Based Management (SPBM) profile name.
+                              type: string
+                            volumePath:
+                              description: volumePath is the path that identifies
+                                vSphere volume vmdk
+                              type: string
+                          required:
+                          - volumePath
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                required:
+                - container
+                type: object
+              imageRepoSecret:
+                description: |-
+                  ImageRepoSecret is an optional secret that is used to pull both the module loader and the device plugin, and
+                  to push the resulting image from the module loader build, if enabled.
+                properties:
+                  name:
+                    default: ""
+                    description: |-
+                      Name of the referent.
+                      This field is effectively required, but due to backwards compatibility is
+                      allowed to be empty. Instances of this type with an empty value here are
+                      almost certainly wrong.
+                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              moduleLoader:
+                description: |-
+                  ModuleLoader allows overriding some properties of the container that loads the kernel module on the node.
+                  Name and image are ignored and are set automatically by the KMM Operator.
+                properties:
+                  container:
+                    description: Container holds the properties for the module loader
+                      container that runs modprobe.
+                    properties:
+                      build:
+                        description: Build contains build instructions.
+                        properties:
+                          baseImageRegistryTLS:
+                            description: BaseImageRegistryTLS contains settings determining
+                              how to access registries of the base images in the build-process'
+                              Dockerfile.
+                            properties:
+                              insecure:
+                                description: If Insecure is true, the operator will
+                                  be able to access a registry in an insecure (plain
+                                  HTTP) protocol.
+                                type: boolean
+                              insecureSkipTLSVerify:
+                                description: If InsecureSkipTLSVerify, the operator
+                                  will accept any certificate provided by the registry.
+                                type: boolean
+                            type: object
+                          buildArgs:
+                            description: BuildArgs is an array of build variables
+                              that are provided to the image building backend.
+                            items:
+                              description: BuildArg represents a build argument used
+                                when building a container image.
+                              properties:
+                                name:
+                                  type: string
+                                value:
+                                  type: string
+                              required:
+                              - name
+                              - value
+                              type: object
+                            type: array
+                          dockerfileConfigMap:
+                            description: ConfigMap that holds Dockerfile contents
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          kanikoParams:
+                            description: KanikoParams is used to customize the building
+                              process of the image.
+                            properties:
+                              tag:
+                                description: Kaniko image tag to use when creating
+                                  the build Job
+                                type: string
+                            type: object
+                          secrets:
+                            description: |-
+                              Secrets is an optional list of secrets to be made available to the build system.
+                              Those secrets should be used for private resources such as a private Github repo.
+                              For container registries auth use module.spec.imagePullSecret instead.
+                            items:
+                              description: |-
+                                LocalObjectReference contains enough information to let you locate the
+                                referenced object inside the same namespace.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                          selector:
+                            additionalProperties:
+                              type: string
+                            description: Selector describes on which nodes will run
+                              the building process.
+                            type: object
+                        required:
+                        - dockerfileConfigMap
+                        type: object
+                      containerImage:
+                        description: ContainerImage is a top-level field
+                        type: string
+                      imagePullPolicy:
+                        description: |-
+                          Image pull policy.
+                          One of Always, Never, IfNotPresent.
+                          Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
+                        type: string
+                      inTreeModuleToRemove:
+                        description: |-
+                          Deprecated: please use InTreeModulesToRemove.
+                          InTreeModuleToRemove specifies one in-tree kernel module that should be removed (if present)
+                          before loading the kernel module from the ContainerImage
+                        type: string
+                      inTreeModulesToRemove:
+                        description: |-
+                          InTreeModulesToRemove specifies any number of  in-tree kernel modules that should be removed (if present)
+                          before loading the kernel module from the ContainerImage
+                        items:
+                          type: string
+                        type: array
+                      kernelMappings:
+                        description: |-
+                          KernelMappings is a list of kernel mappings.
+                          When a node's labels match Selector, then the KMM Operator will look for the first mapping that matches its
+                          kernel version, and use the corresponding container image to run the DriverContainer.
+                        items:
+                          description: |-
+                            KernelMapping pairs kernel versions with a DriverContainer image.
+                            Kernel versions can be matched literally or using a regular expression.
+                          properties:
+                            build:
+                              description: Build enables in-cluster builds for this
+                                mapping and allows overriding the Module's build settings.
+                              properties:
+                                baseImageRegistryTLS:
+                                  description: BaseImageRegistryTLS contains settings
+                                    determining how to access registries of the base
+                                    images in the build-process' Dockerfile.
+                                  properties:
+                                    insecure:
+                                      description: If Insecure is true, the operator
+                                        will be able to access a registry in an insecure
+                                        (plain HTTP) protocol.
+                                      type: boolean
+                                    insecureSkipTLSVerify:
+                                      description: If InsecureSkipTLSVerify, the operator
+                                        will accept any certificate provided by the
+                                        registry.
+                                      type: boolean
+                                  type: object
+                                buildArgs:
+                                  description: BuildArgs is an array of build variables
+                                    that are provided to the image building backend.
+                                  items:
+                                    description: BuildArg represents a build argument
+                                      used when building a container image.
+                                    properties:
+                                      name:
+                                        type: string
+                                      value:
+                                        type: string
+                                    required:
+                                    - name
+                                    - value
+                                    type: object
+                                  type: array
+                                dockerfileConfigMap:
+                                  description: ConfigMap that holds Dockerfile contents
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                kanikoParams:
+                                  description: KanikoParams is used to customize the
+                                    building process of the image.
+                                  properties:
+                                    tag:
+                                      description: Kaniko image tag to use when creating
+                                        the build Job
+                                      type: string
+                                  type: object
+                                secrets:
+                                  description: |-
+                                    Secrets is an optional list of secrets to be made available to the build system.
+                                    Those secrets should be used for private resources such as a private Github repo.
+                                    For container registries auth use module.spec.imagePullSecret instead.
+                                  items:
+                                    description: |-
+                                      LocalObjectReference contains enough information to let you locate the
+                                      referenced object inside the same namespace.
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                                selector:
+                                  additionalProperties:
+                                    type: string
+                                  description: Selector describes on which nodes will
+                                    run the building process.
+                                  type: object
+                              required:
+                              - dockerfileConfigMap
+                              type: object
+                            containerImage:
+                              description: ContainerImage is the name of the DriverContainer
+                                image that should be used to deploy the module.
+                              type: string
+                            inTreeModuleToRemove:
+                              description: |-
+                                Deprecated: please use InTreeModulesToRemove.
+                                InTreeModuleToRemove specifies one in-tree kernel module that should be removed (if present)
+                                before loading the kernel module from the ContainerImage
+                              type: string
+                            inTreeModulesToRemove:
+                              description: |-
+                                InTreeModulesToRemove specifies any number of  in-tree kernel modules that should be removed (if present)
+                                before loading the kernel module from the ContainerImage
+                              items:
+                                type: string
+                              type: array
+                            literal:
+                              description: Literal defines a literal target kernel
+                                version to be matched exactly against node kernels.
+                              type: string
+                            regexp:
+                              description: Regexp is a regular expression to be match
+                                against node kernels.
+                              type: string
+                            registryTLS:
+                              description: RegistryTLS set the TLS configs for accessing
+                                the registry of the module-loader's image.
+                              properties:
+                                insecure:
+                                  description: If Insecure is true, the operator will
+                                    be able to access a registry in an insecure (plain
+                                    HTTP) protocol.
+                                  type: boolean
+                                insecureSkipTLSVerify:
+                                  description: If InsecureSkipTLSVerify, the operator
+                                    will accept any certificate provided by the registry.
+                                  type: boolean
+                              type: object
+                            sign:
+                              description: Sign enables in-cluster signing for this
+                                mapping
+                              properties:
+                                certSecret:
+                                  description: a secret containing the public key
+                                    used to sign kernel modules for secureboot
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                filesToSign:
+                                  description: paths inside the image for the kernel
+                                    modules to sign (if ommited all kmods are signed)
+                                  items:
+                                    type: string
+                                  type: array
+                                keySecret:
+                                  description: a secret containing the private key
+                                    used to sign kernel modules for secureboot
+                                  properties:
+                                    name:
+                                      default: ""
+                                      description: |-
+                                        Name of the referent.
+                                        This field is effectively required, but due to backwards compatibility is
+                                        allowed to be empty. Instances of this type with an empty value here are
+                                        almost certainly wrong.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      type: string
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                unsignedImage:
+                                  description: Image to sign, ignored if a Build is
+                                    present, required otherwise
+                                  type: string
+                                unsignedImageRegistryTLS:
+                                  description: UnsignedImageRegistryTLS contains settings
+                                    determining how to access registries of the unsigned
+                                    image.
+                                  properties:
+                                    insecure:
+                                      description: If Insecure is true, the operator
+                                        will be able to access a registry in an insecure
+                                        (plain HTTP) protocol.
+                                      type: boolean
+                                    insecureSkipTLSVerify:
+                                      description: If InsecureSkipTLSVerify, the operator
+                                        will accept any certificate provided by the
+                                        registry.
+                                      type: boolean
+                                  type: object
+                              required:
+                              - certSecret
+                              - keySecret
+                              type: object
+                          required:
+                          - containerImage
+                          type: object
+                        minItems: 1
+                        type: array
+                      modprobe:
+                        description: Modprobe is a set of properties to customize
+                          which module modprobe loads and with which properties.
+                        properties:
+                          args:
+                            description: |-
+                              Args is an optional list of arguments to be passed to modprobe before the name of the kernel module.
+                              The resulting commands will be: `modprobe ${Args} module_name`.
+                            properties:
+                              load:
+                                description: Load is an optional list of arguments
+                                  to be used when loading the kernel module.
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
+                              unload:
+                                description: Unload is an optional list of arguments
+                                  to be used when unloading the kernel module.
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
+                            type: object
+                          dirName:
+                            default: /opt
+                            description: |-
+                              DirName is the root directory for modules.
+                              It adds `-d ${DirName}` to the modprobe command-line.
+                            type: string
+                          firmwarePath:
+                            description: |-
+                              FirmwarePath is the path of the firmware(s).
+                              The firmware(s) will be copied to the host for the kernel to find them.
+                            type: string
+                          moduleName:
+                            description: |-
+                              ModuleName is the name of the Module to be loaded.
+                              This field can only be unset if rawArgs is set.
+                            type: string
+                          modulesLoadingOrder:
+                            description: |-
+                              ModulesLoadingOrder defines the dependency between kernel modules loading, in case
+                              it was not created by depmod (independent kernel modules).
+                              The list order should be: upmost module, then the module it depends on and so on.
+                              Example: if moduleA depends on first loading moduleB, and moduleB depends on first loading moduleC
+                              the entry should look:
+                              ModulesLoadingOrder:
+                                 - moduleA
+                                 - moduleB
+                                 - moduleC
+                              In order to load all 3 modules, moduleA shoud be defined in the ModuleName parameter of this struct
+                            items:
+                              type: string
+                            type: array
+                          parameters:
+                            description: |-
+                              Parameters is an optional list of kernel module parameters to be provided to modprobe.
+                              They should be in the form of key=value and will be separated by spaces in the modprobe command.
+                              The resulting loading command will be: `modprobe module_name ${Parameters}`.
+                            items:
+                              type: string
+                            type: array
+                          rawArgs:
+                            description: |-
+                              If RawArgs are specified, they are passed straight to the modprobe binary; all other properties in this
+                              object are ignored.
+                              The resulting commands will be: `modprobe ${RawArgs}`.
+                            properties:
+                              load:
+                                description: Load is an optional list of arguments
+                                  to be used when loading the kernel module.
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
+                              unload:
+                                description: Unload is an optional list of arguments
+                                  to be used when unloading the kernel module.
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
+                            type: object
+                        type: object
+                      registryTLS:
+                        description: RegistryTLS set the TLS configs for accessing
+                          the registry of the module-loader's image.
+                        properties:
+                          insecure:
+                            description: If Insecure is true, the operator will be
+                              able to access a registry in an insecure (plain HTTP)
+                              protocol.
+                            type: boolean
+                          insecureSkipTLSVerify:
+                            description: If InsecureSkipTLSVerify, the operator will
+                              accept any certificate provided by the registry.
+                            type: boolean
+                        type: object
+                      sign:
+                        description: Sign provides default kmod signing settings
+                        properties:
+                          certSecret:
+                            description: a secret containing the public key used to
+                              sign kernel modules for secureboot
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          filesToSign:
+                            description: paths inside the image for the kernel modules
+                              to sign (if ommited all kmods are signed)
+                            items:
+                              type: string
+                            type: array
+                          keySecret:
+                            description: a secret containing the private key used
+                              to sign kernel modules for secureboot
+                            properties:
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          unsignedImage:
+                            description: Image to sign, ignored if a Build is present,
+                              required otherwise
+                            type: string
+                          unsignedImageRegistryTLS:
+                            description: UnsignedImageRegistryTLS contains settings
+                              determining how to access registries of the unsigned
+                              image.
+                            properties:
+                              insecure:
+                                description: If Insecure is true, the operator will
+                                  be able to access a registry in an insecure (plain
+                                  HTTP) protocol.
+                                type: boolean
+                              insecureSkipTLSVerify:
+                                description: If InsecureSkipTLSVerify, the operator
+                                  will accept any certificate provided by the registry.
+                                type: boolean
+                            type: object
+                        required:
+                        - certSecret
+                        - keySecret
+                        type: object
+                      version:
+                        description: |-
+                          Version defines the current version of the kernel module being used
+                          Used for upgrading the currently loaded kernel module to a new version
+                        type: string
+                    required:
+                    - kernelMappings
+                    - modprobe
+                    type: object
+                  serviceAccountName:
+                    description: |-
+                      ServiceAccountName is the name of the ServiceAccount to use to run this pod.
+                      More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/
+                    type: string
+                required:
+                - container
+                type: object
+              selector:
+                additionalProperties:
+                  type: string
+                description: Selector describes on which nodes the Module should be
+                  loaded and optionally built.
+                type: object
+              tolerations:
+                description: If specified, the pod's tolerations.
+                items:
+                  description: |-
+                    The pod this Toleration is attached to tolerates any taint that matches
+                    the triple <key,value,effect> using the matching operator <operator>.
+                  properties:
+                    effect:
+                      description: |-
+                        Effect indicates the taint effect to match. Empty means match all taint effects.
+                        When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: |-
+                        Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                        If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                      type: string
+                    operator:
+                      description: |-
+                        Operator represents a key's relationship to the value.
+                        Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod can
+                        tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: |-
+                        TolerationSeconds represents the period of time the toleration (which must be
+                        of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                        it is not set, which means tolerate the taint forever (do not evict). Zero and
+                        negative values will be treated as 0 (evict immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: |-
+                        Value is the taint value the toleration matches to.
+                        If the operator is Exists, the value should be empty, otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
+            required:
+            - selector
+            type: object
+          status:
+            description: ModuleStatus defines the observed state of Module.
+            properties:
+              devicePlugin:
+                description: |-
+                  DevicePlugin contains the status of the Device Plugin daemonset
+                  if it was deployed during reconciliation
+                properties:
+                  availableNumber:
+                    description: number of the actually deployed and running pods
+                    format: int32
+                    type: integer
+                  desiredNumber:
+                    description: number of the pods that should be deployed for daemonset
+                    format: int32
+                    type: integer
+                  nodesMatchingSelectorNumber:
+                    description: number of nodes that are targeted by the module selector
+                    format: int32
+                    type: integer
+                type: object
+              moduleLoader:
+                description: ModuleLoader contains the status of the ModuleLoader
+                  daemonset
+                properties:
+                  availableNumber:
+                    description: number of the actually deployed and running pods
+                    format: int32
+                    type: integer
+                  desiredNumber:
+                    description: number of the pods that should be deployed for daemonset
+                    format: int32
+                    type: integer
+                  nodesMatchingSelectorNumber:
+                    description: number of nodes that are targeted by the module selector
+                    format: int32
+                    type: integer
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd-hub/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
+++ b/config/crd-hub/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
@@ -1,0 +1,429 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  name: nodemodulesconfigs.kmm.sigs.x-k8s.io
+spec:
+  group: kmm.sigs.x-k8s.io
+  names:
+    kind: NodeModulesConfig
+    listKind: NodeModulesConfigList
+    plural: nodemodulesconfigs
+    shortNames:
+    - nmc
+    singular: nodemodulesconfig
+  scope: Cluster
+  versions:
+  - name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: NodeModulesConfig keeps spec and state of the KMM modules on
+          a node.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              NodeModulesConfigSpec describes the desired state of modules on the node
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              modules:
+                description: |-
+                  Modules list the spec of all the modules that need to be executed
+                  on the node
+                items:
+                  properties:
+                    config:
+                      properties:
+                        containerImage:
+                          type: string
+                        imagePullPolicy:
+                          default: IfNotPresent
+                          description: PullPolicy describes a policy for if/when to
+                            pull a container image
+                          type: string
+                        inTreeModuleToRemove:
+                          type: string
+                        inTreeModulesToRemove:
+                          items:
+                            type: string
+                          type: array
+                        insecurePull:
+                          description: When InsecurePull is true, the container image
+                            can be pulled without TLS.
+                          type: boolean
+                        kernelVersion:
+                          type: string
+                        modprobe:
+                          properties:
+                            args:
+                              description: |-
+                                Args is an optional list of arguments to be passed to modprobe before the name of the kernel module.
+                                The resulting commands will be: `modprobe ${Args} module_name`.
+                              properties:
+                                load:
+                                  description: Load is an optional list of arguments
+                                    to be used when loading the kernel module.
+                                  items:
+                                    type: string
+                                  minItems: 1
+                                  type: array
+                                unload:
+                                  description: Unload is an optional list of arguments
+                                    to be used when unloading the kernel module.
+                                  items:
+                                    type: string
+                                  minItems: 1
+                                  type: array
+                              type: object
+                            dirName:
+                              default: /opt
+                              description: |-
+                                DirName is the root directory for modules.
+                                It adds `-d ${DirName}` to the modprobe command-line.
+                              type: string
+                            firmwarePath:
+                              description: |-
+                                FirmwarePath is the path of the firmware(s).
+                                The firmware(s) will be copied to the host for the kernel to find them.
+                              type: string
+                            moduleName:
+                              description: |-
+                                ModuleName is the name of the Module to be loaded.
+                                This field can only be unset if rawArgs is set.
+                              type: string
+                            modulesLoadingOrder:
+                              description: |-
+                                ModulesLoadingOrder defines the dependency between kernel modules loading, in case
+                                it was not created by depmod (independent kernel modules).
+                                The list order should be: upmost module, then the module it depends on and so on.
+                                Example: if moduleA depends on first loading moduleB, and moduleB depends on first loading moduleC
+                                the entry should look:
+                                ModulesLoadingOrder:
+                                   - moduleA
+                                   - moduleB
+                                   - moduleC
+                                In order to load all 3 modules, moduleA shoud be defined in the ModuleName parameter of this struct
+                              items:
+                                type: string
+                              type: array
+                            parameters:
+                              description: |-
+                                Parameters is an optional list of kernel module parameters to be provided to modprobe.
+                                They should be in the form of key=value and will be separated by spaces in the modprobe command.
+                                The resulting loading command will be: `modprobe module_name ${Parameters}`.
+                              items:
+                                type: string
+                              type: array
+                            rawArgs:
+                              description: |-
+                                If RawArgs are specified, they are passed straight to the modprobe binary; all other properties in this
+                                object are ignored.
+                                The resulting commands will be: `modprobe ${RawArgs}`.
+                              properties:
+                                load:
+                                  description: Load is an optional list of arguments
+                                    to be used when loading the kernel module.
+                                  items:
+                                    type: string
+                                  minItems: 1
+                                  type: array
+                                unload:
+                                  description: Unload is an optional list of arguments
+                                    to be used when unloading the kernel module.
+                                  items:
+                                    type: string
+                                  minItems: 1
+                                  type: array
+                              type: object
+                          type: object
+                      required:
+                      - containerImage
+                      - insecurePull
+                      - kernelVersion
+                      - modprobe
+                      type: object
+                    imageRepoSecret:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    serviceAccountName:
+                      type: string
+                    tolerations:
+                      description: tolerations define which tolerations should be
+                        added for every load/unload pod running on the node
+                      items:
+                        description: |-
+                          The pod this Toleration is attached to tolerates any taint that matches
+                          the triple <key,value,effect> using the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: |-
+                              Effect indicates the taint effect to match. Empty means match all taint effects.
+                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: |-
+                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: |-
+                              Operator represents a key's relationship to the value.
+                              Valid operators are Exists and Equal. Defaults to Equal.
+                              Exists is equivalent to wildcard for value, so that a pod can
+                              tolerate all taints of a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: |-
+                              TolerationSeconds represents the period of time the toleration (which must be
+                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                              it is not set, which means tolerate the taint forever (do not evict). Zero and
+                              negative values will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: |-
+                              Value is the taint value the toleration matches to.
+                              If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - config
+                  - name
+                  - namespace
+                  - serviceAccountName
+                  type: object
+                type: array
+            type: object
+          status:
+            description: |-
+              NodeModuleConfigStatus is the most recently observed status of the KMM modules on node.
+              It is populated by the system and is read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              modules:
+                description: Modules contain observations about each Module's node
+                  state status
+                items:
+                  properties:
+                    bootId:
+                      type: string
+                    config:
+                      properties:
+                        containerImage:
+                          type: string
+                        imagePullPolicy:
+                          default: IfNotPresent
+                          description: PullPolicy describes a policy for if/when to
+                            pull a container image
+                          type: string
+                        inTreeModuleToRemove:
+                          type: string
+                        inTreeModulesToRemove:
+                          items:
+                            type: string
+                          type: array
+                        insecurePull:
+                          description: When InsecurePull is true, the container image
+                            can be pulled without TLS.
+                          type: boolean
+                        kernelVersion:
+                          type: string
+                        modprobe:
+                          properties:
+                            args:
+                              description: |-
+                                Args is an optional list of arguments to be passed to modprobe before the name of the kernel module.
+                                The resulting commands will be: `modprobe ${Args} module_name`.
+                              properties:
+                                load:
+                                  description: Load is an optional list of arguments
+                                    to be used when loading the kernel module.
+                                  items:
+                                    type: string
+                                  minItems: 1
+                                  type: array
+                                unload:
+                                  description: Unload is an optional list of arguments
+                                    to be used when unloading the kernel module.
+                                  items:
+                                    type: string
+                                  minItems: 1
+                                  type: array
+                              type: object
+                            dirName:
+                              default: /opt
+                              description: |-
+                                DirName is the root directory for modules.
+                                It adds `-d ${DirName}` to the modprobe command-line.
+                              type: string
+                            firmwarePath:
+                              description: |-
+                                FirmwarePath is the path of the firmware(s).
+                                The firmware(s) will be copied to the host for the kernel to find them.
+                              type: string
+                            moduleName:
+                              description: |-
+                                ModuleName is the name of the Module to be loaded.
+                                This field can only be unset if rawArgs is set.
+                              type: string
+                            modulesLoadingOrder:
+                              description: |-
+                                ModulesLoadingOrder defines the dependency between kernel modules loading, in case
+                                it was not created by depmod (independent kernel modules).
+                                The list order should be: upmost module, then the module it depends on and so on.
+                                Example: if moduleA depends on first loading moduleB, and moduleB depends on first loading moduleC
+                                the entry should look:
+                                ModulesLoadingOrder:
+                                   - moduleA
+                                   - moduleB
+                                   - moduleC
+                                In order to load all 3 modules, moduleA shoud be defined in the ModuleName parameter of this struct
+                              items:
+                                type: string
+                              type: array
+                            parameters:
+                              description: |-
+                                Parameters is an optional list of kernel module parameters to be provided to modprobe.
+                                They should be in the form of key=value and will be separated by spaces in the modprobe command.
+                                The resulting loading command will be: `modprobe module_name ${Parameters}`.
+                              items:
+                                type: string
+                              type: array
+                            rawArgs:
+                              description: |-
+                                If RawArgs are specified, they are passed straight to the modprobe binary; all other properties in this
+                                object are ignored.
+                                The resulting commands will be: `modprobe ${RawArgs}`.
+                              properties:
+                                load:
+                                  description: Load is an optional list of arguments
+                                    to be used when loading the kernel module.
+                                  items:
+                                    type: string
+                                  minItems: 1
+                                  type: array
+                                unload:
+                                  description: Unload is an optional list of arguments
+                                    to be used when unloading the kernel module.
+                                  items:
+                                    type: string
+                                  minItems: 1
+                                  type: array
+                              type: object
+                          type: object
+                      required:
+                      - containerImage
+                      - insecurePull
+                      - kernelVersion
+                      - modprobe
+                      type: object
+                    imageRepoSecret:
+                      description: |-
+                        LocalObjectReference contains enough information to let you locate the
+                        referenced object inside the same namespace.
+                      properties:
+                        name:
+                          default: ""
+                          description: |-
+                            Name of the referent.
+                            This field is effectively required, but due to backwards compatibility is
+                            allowed to be empty. Instances of this type with an empty value here are
+                            almost certainly wrong.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                    serviceAccountName:
+                      type: string
+                    tolerations:
+                      description: tolerations define which tolerations should be
+                        added for every load/unload pod running on the node
+                      items:
+                        description: |-
+                          The pod this Toleration is attached to tolerates any taint that matches
+                          the triple <key,value,effect> using the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: |-
+                              Effect indicates the taint effect to match. Empty means match all taint effects.
+                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: |-
+                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: |-
+                              Operator represents a key's relationship to the value.
+                              Valid operators are Exists and Equal. Defaults to Equal.
+                              Exists is equivalent to wildcard for value, so that a pod can
+                              tolerate all taints of a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: |-
+                              TolerationSeconds represents the period of time the toleration (which must be
+                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                              it is not set, which means tolerate the taint forever (do not evict). Zero and
+                              negative values will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: |-
+                              Value is the taint value the toleration matches to.
+                              If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                  required:
+                  - name
+                  - namespace
+                  - serviceAccountName
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd-hub/bases/kmm.sigs.x-k8s.io_preflightvalidations.yaml
+++ b/config/crd-hub/bases/kmm.sigs.x-k8s.io_preflightvalidations.yaml
@@ -1,0 +1,217 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.16.1
+  name: preflightvalidations.kmm.sigs.x-k8s.io
+spec:
+  group: kmm.sigs.x-k8s.io
+  names:
+    kind: PreflightValidation
+    listKind: PreflightValidationList
+    plural: preflightvalidations
+    shortNames:
+    - pfv
+    singular: preflightvalidation
+  scope: Cluster
+  versions:
+  - deprecated: true
+    name: v1beta1
+    schema:
+      openAPIV3Schema:
+        description: PreflightValidation initiates a preflight validations for all
+          Modules on the current Kubernetes cluster.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              PreflightValidationSpec describes the desired state of the resource, such as the kernel version
+              that Module CRs need to be verified against as well as the debug configuration of the logs
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              kernelVersion:
+                description: KernelVersion describes the kernel image that all Modules
+                  need to be checked against.
+                type: string
+              pushBuiltImage:
+                description: |-
+                  Boolean flag that determines whether images build during preflight must also
+                  be pushed to a defined repository
+                type: boolean
+            required:
+            - kernelVersion
+            type: object
+          status:
+            description: |-
+              PreflightValidationStatus is the most recently observed status of the PreflightValidation.
+              It is populated by the system and is read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              crStatuses:
+                additionalProperties:
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the CR status transitioned from one status to another.
+                        This should be when the underlying status changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    statusReason:
+                      description: StatusReason contains a string describing the status
+                        source.
+                      type: string
+                    verificationStage:
+                      description: |-
+                        Current stage of the verification process:
+                        image (image existence verification), build(build process verification)
+                      enum:
+                      - Image
+                      - Done
+                      type: string
+                    verificationStatus:
+                      description: |-
+                        Status of Module CR verification: true (verified), false (verification failed),
+                        error (error during verification process), unknown (verification has not started yet)
+                      enum:
+                      - Success
+                      - Failure
+                      - InProgress
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - verificationStage
+                  - verificationStatus
+                  type: object
+                description: CRStatuses contain observations about each Module's preflight
+                  upgradability validation
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}
+  - name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: PreflightValidation initiates a preflight validations for all
+          Modules on the current Kubernetes cluster.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: |-
+              PreflightValidationSpec describes the desired state of the resource, such as the kernel version
+              that Module CRs need to be verified against as well as the debug configuration of the logs
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              kernelVersion:
+                description: KernelVersion describes the kernel image that all Modules
+                  need to be checked against.
+                type: string
+              pushBuiltImage:
+                description: |-
+                  Boolean flag that determines whether images build during preflight must also
+                  be pushed to a defined repository
+                type: boolean
+            required:
+            - kernelVersion
+            type: object
+          status:
+            description: |-
+              PreflightValidationStatus is the most recently observed status of the PreflightValidation.
+              It is populated by the system and is read-only.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
+            properties:
+              modules:
+                description: Modules contain observations about each Module's preflight
+                  upgradability validation
+                items:
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        LastTransitionTime is the last time the CR status transitioned from one status to another.
+                        This should be when the underlying status changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    name:
+                      description: Name is the name of the Module resource.
+                      type: string
+                    namespace:
+                      description: Namespace is the namespace of the Module resource.
+                      type: string
+                    statusReason:
+                      description: StatusReason contains a string describing the status
+                        source.
+                      type: string
+                    verificationStage:
+                      description: |-
+                        Current stage of the verification process:
+                        image (image existence verification), build(build process verification)
+                      enum:
+                      - Image
+                      - Done
+                      type: string
+                    verificationStatus:
+                      description: |-
+                        Status of Module CR verification: true (verified), false (verification failed),
+                        error (error during verification process), unknown (verification has not started yet)
+                      enum:
+                      - Success
+                      - Failure
+                      - InProgress
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - name
+                  - namespace
+                  - verificationStage
+                  - verificationStatus
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - namespace
+                - name
+                x-kubernetes-list-type: map
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/config/crd-hub/kustomization.yml
+++ b/config/crd-hub/kustomization.yml
@@ -3,6 +3,8 @@ kind: Kustomization
 
 resources:
   - bases/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
+  - bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
+  - bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
 
 patches: []
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.


### PR DESCRIPTION
KMM-hub only generates CRD files based on the `api-hub/` directory which doesn't contain some CRDs required for KMM-hub such as `MIC` and `MBSC`, therefore, KMM-hub isn't working because it tries to start controllers reconciling CRDs that don't exist in the cluster.

It worked in CI until now because we are using the same single-node cluster as the hub cluster and the spoke cluster so KMM-hub was basically using the CRDs applied by the KMM bundle and not the KMM-hub bundle.

This commit is generating all CRD files into the `config/crd-hub/bases` directory but only applies to the cluster the resources it actually needs.

---

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1581
/assign @yevgeny-shnaidman @TomerNewman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new Kubernetes CustomResourceDefinitions (CRDs) for managing kernel module images and build/sign processes: `ModuleBuildSignConfig`, `ModuleImagesConfig`, `NodeModulesConfig`, and `PreflightValidation`.
  - Added support for advanced image build, signing, and verification workflows for Kernel Module Management (KMM) modules.
  - Enabled preflight validation of modules with detailed status reporting.
- **Chores**
  - Updated manifests and configuration files to include the new CRDs and reflect recent changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->