### PR TITLE
Considering the `New` build status when updating the MBSC status.

### DIFF
--- a/internal/buildsign/resource/resourcemanager.go
+++ b/internal/buildsign/resource/resourcemanager.go
@@ -102,7 +102,7 @@ func (rm *resourceManager) GetResourceStatus(obj metav1.Object) (buildsign.Statu
 	switch resource.Status.Phase {
 	case buildv1.BuildPhaseComplete:
 		return buildsign.StatusCompleted, nil
-	case buildv1.BuildPhaseRunning, buildv1.BuildPhasePending:
+	case buildv1.BuildPhaseRunning, buildv1.BuildPhasePending, buildv1.BuildPhaseNew:
 		return buildsign.StatusInProgress, nil
 	case buildv1.BuildPhaseFailed, buildv1.BuildPhaseCancelled, buildv1.BuildPhaseError:
 		return buildsign.StatusFailed, nil


### PR DESCRIPTION
The MBSC status is updated based on the build statuses. We were missing the `New` status which would log some errors until the build phase matures to a later phase.

This commit isn't changing the functionality but just making sure we don't log errors due to a temporary, end expected, phase.

---

/assign @TomerNewman @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Builds in the "New" phase are now correctly shown as "In Progress" in status displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->