### PR TITLE
Adding PushBuiltImage variable to MIC and MBSC objects

### DIFF
--- a/api/v1beta1/modulebuildsignconfig_types.go
+++ b/api/v1beta1/modulebuildsignconfig_types.go
@@ -55,6 +55,11 @@ type ModuleBuildSignConfigSpec struct {
 	// ImageRepoSecret contains pull secret for the image's repo, if needed
 	// +optional
 	ImageRepoSecret *v1.LocalObjectReference `json:"imageRepoSecret,omitempty"`
+
+	// Boolean flag that determines whether images built must also
+	// be pushed to a defined repository
+	// +optional
+	PushBuiltImage bool `json:"pushBuiltImage"`
 }
 
 // BuildSignImageState contains the status of the image that was requested to be built/signed

--- a/api/v1beta1/moduleimagesconfig_types.go
+++ b/api/v1beta1/moduleimagesconfig_types.go
@@ -72,6 +72,11 @@ type ModuleImagesConfigSpec struct {
 	// ImagePullPolicy defines the pull policy used for verifying the presence of the image
 	//+optional
 	ImagePullPolicy v1.PullPolicy `json:"imagePullPolicy"`
+
+	// Boolean flag that determines whether images built must also
+	// be pushed to a defined repository
+	// +optional
+	PushBuiltImage bool `json:"pushBuiltImage"`
 }
 
 type ModuleImageState struct {

--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2025-06-19T20:27:42Z"
+    createdAt: "2025-06-22T13:59:30Z"
     operatorframework.io/suggested-namespace: openshift-kmm-hub
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle-hub/manifests/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
+++ b/bundle-hub/manifests/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
@@ -254,6 +254,11 @@ spec:
                   - kernelVersion
                   type: object
                 type: array
+              pushBuiltImage:
+                description: |-
+                  Boolean flag that determines whether images built must also
+                  be pushed to a defined repository
+                type: boolean
             required:
             - images
             type: object

--- a/bundle-hub/manifests/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/bundle-hub/manifests/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -253,6 +253,11 @@ spec:
                   - kernelVersion
                   type: object
                 type: array
+              pushBuiltImage:
+                description: |-
+                  Boolean flag that determines whether images built must also
+                  be pushed to a defined repository
+                type: boolean
             type: object
           status:
             description: |-

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -47,7 +47,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2025-06-19T20:27:41Z"
+    createdAt: "2025-06-22T13:59:20Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
+++ b/bundle/manifests/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
@@ -254,6 +254,11 @@ spec:
                   - kernelVersion
                   type: object
                 type: array
+              pushBuiltImage:
+                description: |-
+                  Boolean flag that determines whether images built must also
+                  be pushed to a defined repository
+                type: boolean
             required:
             - images
             type: object

--- a/bundle/manifests/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/bundle/manifests/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -253,6 +253,11 @@ spec:
                   - kernelVersion
                   type: object
                 type: array
+              pushBuiltImage:
+                description: |-
+                  Boolean flag that determines whether images built must also
+                  be pushed to a defined repository
+                type: boolean
             type: object
           status:
             description: |-

--- a/config/crd-hub/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
+++ b/config/crd-hub/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
@@ -250,6 +250,11 @@ spec:
                   - kernelVersion
                   type: object
                 type: array
+              pushBuiltImage:
+                description: |-
+                  Boolean flag that determines whether images built must also
+                  be pushed to a defined repository
+                type: boolean
             required:
             - images
             type: object

--- a/config/crd-hub/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/config/crd-hub/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -249,6 +249,11 @@ spec:
                   - kernelVersion
                   type: object
                 type: array
+              pushBuiltImage:
+                description: |-
+                  Boolean flag that determines whether images built must also
+                  be pushed to a defined repository
+                type: boolean
             type: object
           status:
             description: |-

--- a/config/crd/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
@@ -250,6 +250,11 @@ spec:
                   - kernelVersion
                   type: object
                 type: array
+              pushBuiltImage:
+                description: |-
+                  Boolean flag that determines whether images built must also
+                  be pushed to a defined repository
+                type: boolean
             required:
             - images
             type: object

--- a/config/crd/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -249,6 +249,11 @@ spec:
                   - kernelVersion
                   type: object
                 type: array
+              pushBuiltImage:
+                description: |-
+                  Boolean flag that determines whether images built must also
+                  be pushed to a defined repository
+                type: boolean
             type: object
           status:
             description: |-


### PR DESCRIPTION
This flag will be used to signal whether the built object must be also push to the destination registry. The main user will be the Preflight. In the regular flow (Module) the image that is built is also always pushed. When running Preflight, user might specify whether to push the built image, or not (he wants to verify that image can be built in time, but does not want to push it right now)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new optional setting to module image and build sign configurations to control whether built images should also be pushed to a specified repository.

- **Documentation**
  - Updated CustomResourceDefinition (CRD) schemas to include the new push option for built images.

- **Chores**
  - Updated metadata timestamps in ClusterServiceVersion manifest files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->