### PR TITLE
Propagate PushBuiltImage flag from different controllers to Build object

### DIFF
--- a/internal/controllers/hub/managedclustermodule_reconciler.go
+++ b/internal/controllers/hub/managedclustermodule_reconciler.go
@@ -237,7 +237,7 @@ func (rh *managedClusterModuleReconcilerHelper) setMicAsDesired(ctx context.Cont
 	micName := mcm.Name + "-" + clusterName
 	micNamespace := rh.clusterAPI.GetDefaultArtifactsNamespace()
 	if err := rh.micAPI.CreateOrPatch(ctx, micName, micNamespace, images, mcm.Spec.ModuleSpec.ImageRepoSecret,
-		mcm.Spec.ModuleSpec.ModuleLoader.Container.ImagePullPolicy, mcm); err != nil {
+		mcm.Spec.ModuleSpec.ModuleLoader.Container.ImagePullPolicy, true, mcm); err != nil {
 		return fmt.Errorf("failed to createOrPatch MIC %s: %v", micName, err)
 	}
 

--- a/internal/controllers/hub/managedclustermodule_reconciler_test.go
+++ b/internal/controllers/hub/managedclustermodule_reconciler_test.go
@@ -476,7 +476,7 @@ var _ = Describe("managedClusterModuleReconcilerHelperAPI_setMicAsDesired", func
 		gomock.InOrder(
 			mockClusterAPI.EXPECT().GetModuleLoaderDataForKernel(mcm, kernelVersions[0]).Return(&api.ModuleLoaderData{}, nil),
 			mockClusterAPI.EXPECT().GetDefaultArtifactsNamespace().Return(defaultNs),
-			mockMIC.EXPECT().CreateOrPatch(ctx, micName, defaultNs, gomock.Any(), nil, v1.PullPolicy(""), mcm).
+			mockMIC.EXPECT().CreateOrPatch(ctx, micName, defaultNs, gomock.Any(), nil, v1.PullPolicy(""), true, mcm).
 				Return(errors.New("some error")),
 		)
 
@@ -514,7 +514,7 @@ var _ = Describe("managedClusterModuleReconcilerHelperAPI_setMicAsDesired", func
 			mockClusterAPI.EXPECT().GetModuleLoaderDataForKernel(mcm, kernelVersions[0]).Return(nil, module.ErrNoMatchingKernelMapping),
 			mockClusterAPI.EXPECT().GetModuleLoaderDataForKernel(mcm, kernelVersions[1]).Return(expectedMLD, nil),
 			mockClusterAPI.EXPECT().GetDefaultArtifactsNamespace().Return(defaultNs),
-			mockMIC.EXPECT().CreateOrPatch(ctx, micName, defaultNs, expectedImages, gomock.Any(), v1.PullPolicy(""), mcm).Return(nil),
+			mockMIC.EXPECT().CreateOrPatch(ctx, micName, defaultNs, expectedImages, gomock.Any(), v1.PullPolicy(""), true, mcm).Return(nil),
 		)
 
 		err := mcmReconHelperAPI.setMicAsDesired(ctx, mcm, clusterName, kernelVersions)
@@ -560,7 +560,7 @@ var _ = Describe("managedClusterModuleReconcilerHelperAPI_setMicAsDesired", func
 			mockClusterAPI.EXPECT().GetModuleLoaderDataForKernel(mcm, kernelVersions[0]).Return(expectedMLDs[0], nil),
 			mockClusterAPI.EXPECT().GetModuleLoaderDataForKernel(mcm, kernelVersions[1]).Return(expectedMLDs[1], nil),
 			mockClusterAPI.EXPECT().GetDefaultArtifactsNamespace().Return(defaultNs),
-			mockMIC.EXPECT().CreateOrPatch(ctx, micName, defaultNs, expectedImages, gomock.Any(), v1.PullPolicy(""), mcm).Return(nil),
+			mockMIC.EXPECT().CreateOrPatch(ctx, micName, defaultNs, expectedImages, gomock.Any(), v1.PullPolicy(""), true, mcm).Return(nil),
 		)
 
 		err := mcmReconHelperAPI.setMicAsDesired(ctx, mcm, clusterName, kernelVersions)

--- a/internal/controllers/mbsc_reconciler.go
+++ b/internal/controllers/mbsc_reconciler.go
@@ -144,7 +144,7 @@ func (mrh *mbscReconcilerHelper) processImagesSpecs(ctx context.Context, mbscObj
 			continue
 		}
 		mld := createMLD(mbscObj, &imageSpec.ModuleImageSpec)
-		err := mrh.buildSignAPI.Sync(ctx, mld, true, imageSpec.Action, mbscObj)
+		err := mrh.buildSignAPI.Sync(ctx, mld, mbscObj.Spec.PushBuiltImage, imageSpec.Action, mbscObj)
 		if err != nil {
 			errs = append(errs, err)
 			logger.Info(utils.WarnString(fmt.Sprintf("sync for image %s, action %s failed: %v", imageSpec.Image, imageSpec.Action, err)))

--- a/internal/controllers/mbsc_reconciler_test.go
+++ b/internal/controllers/mbsc_reconciler_test.go
@@ -196,6 +196,7 @@ var _ = Describe("processImagesSpecs", func() {
 					Action: kmmv1beta1.BuildImage,
 				},
 			},
+			PushBuiltImage: true,
 		},
 	}
 

--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -413,7 +413,7 @@ func (mrh *moduleReconcilerHelper) handleMIC(ctx context.Context, mod *kmmv1beta
 	}
 
 	if err := mrh.micAPI.CreateOrPatch(ctx, mod.Name, mod.Namespace, images, mod.Spec.ImageRepoSecret,
-		mod.Spec.ModuleLoader.Container.ImagePullPolicy, mod); err != nil {
+		mod.Spec.ModuleLoader.Container.ImagePullPolicy, true, mod); err != nil {
 		errs = append(errs, fmt.Errorf("failed to apply %s/%s MIC: %v", mod.Namespace, mod.Name, err))
 	}
 

--- a/internal/controllers/module_reconciler_test.go
+++ b/internal/controllers/module_reconciler_test.go
@@ -459,7 +459,7 @@ var _ = Describe("handleMIC", func() {
 	It("should return an error if we failed to get moduleLoaderData for kernel", func() {
 
 		mockKernelMapper.EXPECT().GetModuleLoaderDataForKernel(mod, gomock.Any()).Return(nil, errors.New("some error"))
-		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret, v1.PullPolicy(""), mod).Return(nil)
+		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret, v1.PullPolicy(""), true, mod).Return(nil)
 
 		err := mrh.handleMIC(ctx, mod, targetedNodes)
 		Expect(err).To(HaveOccurred())
@@ -472,7 +472,7 @@ var _ = Describe("handleMIC", func() {
 		mld := &api.ModuleLoaderData{ContainerImage: img}
 		mockKernelMapper.EXPECT().GetModuleLoaderDataForKernel(mod, gomock.Any()).Return(mld, nil)
 		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret,
-			v1.PullPolicy(""), mod).Return(errors.New("some error"))
+			v1.PullPolicy(""), true, mod).Return(errors.New("some error"))
 
 		err := mrh.handleMIC(ctx, mod, targetedNodes)
 		Expect(err).To(HaveOccurred())
@@ -480,7 +480,7 @@ var _ = Describe("handleMIC", func() {
 	})
 
 	It("should not do anything if targetedNodes is empty", func() {
-		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret, v1.PullPolicy(""), mod).Return(nil)
+		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, gomock.Any(), mod.Spec.ImageRepoSecret, v1.PullPolicy(""), true, mod).Return(nil)
 		err := mrh.handleMIC(ctx, mod, []v1.Node{})
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -504,7 +504,7 @@ var _ = Describe("handleMIC", func() {
 		}
 		mockKernelMapper.EXPECT().GetModuleLoaderDataForKernel(mod, gomock.Any()).Return(mld, nil)
 		mockMICAPI.EXPECT().CreateOrPatch(ctx, mod.Name, mod.Namespace, []kmmv1beta1.ModuleImageSpec{expectedSpec},
-			mod.Spec.ImageRepoSecret, v1.PullPolicy(""), mod).Return(nil)
+			mod.Spec.ImageRepoSecret, v1.PullPolicy(""), true, mod).Return(nil)
 
 		err := mrh.handleMIC(ctx, mod, targetedNodes)
 		Expect(err).NotTo(HaveOccurred())

--- a/internal/controllers/preflightvalidation_reconciler.go
+++ b/internal/controllers/preflightvalidation_reconciler.go
@@ -230,7 +230,8 @@ func (p *preflightReconcilerHelperImpl) processPreflightValidation(ctx context.C
 			RegistryTLS:   mod.RegistryTLS,
 		}
 		micName := mod.Name + "-preflight"
-		err := p.micAPI.CreateOrPatch(ctx, micName, mod.Namespace, []kmmv1beta1.ModuleImageSpec{micObjSpec}, mod.ImageRepoSecret, mod.ImagePullPolicy, pv)
+		err := p.micAPI.CreateOrPatch(ctx, micName, mod.Namespace, []kmmv1beta1.ModuleImageSpec{micObjSpec},
+			mod.ImageRepoSecret, mod.ImagePullPolicy, pv.Spec.PushBuiltImage, pv)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to apply %s/%s MIC: %v", mod.Namespace, mod.Name, err))
 		}

--- a/internal/controllers/preflightvalidation_reconciler_test.go
+++ b/internal/controllers/preflightvalidation_reconciler_test.go
@@ -275,10 +275,10 @@ var _ = Describe("processPreflightValidation", func() {
 			mockPreflight.EXPECT().GetModuleStatus(pv, "mld namespace2", "mld name2").Return(v1beta2.VerificationFailure),
 			mockPreflight.EXPECT().GetModuleStatus(pv, "mld namespace3", "mld name3").Return(v1beta2.VerificationInProgress),
 			mockMic.EXPECT().CreateOrPatch(ctx, "mld name3-preflight", "mld namespace3", []kmmv1beta1.ModuleImageSpec{expectedMic3},
-				nil, v1.PullPolicy(""), pv).Return(nil),
+				nil, v1.PullPolicy(""), pv.Spec.PushBuiltImage, pv).Return(nil),
 			mockPreflight.EXPECT().GetModuleStatus(pv, "mld namespace4", "mld name4").Return(""),
 			mockMic.EXPECT().CreateOrPatch(ctx, "mld name4-preflight", "mld namespace4", []kmmv1beta1.ModuleImageSpec{expectedMic4},
-				nil, v1.PullPolicy(""), pv).Return(nil),
+				nil, v1.PullPolicy(""), pv.Spec.PushBuiltImage, pv).Return(nil),
 		)
 
 		err := p.processPreflightValidation(ctx, modsWithMapping, pv)

--- a/internal/mbsc/mbsc.go
+++ b/internal/mbsc/mbsc.go
@@ -57,6 +57,7 @@ func (m *mbsc) CreateOrPatch(ctx context.Context, micObj *kmmv1beta1.ModuleImage
 	_, err := controllerutil.CreateOrPatch(ctx, m.client, mbscObj, func() error {
 		setModuleImageSpec(mbscObj, moduleImageSpec, action)
 		mbscObj.Spec.ImageRepoSecret = micObj.Spec.ImageRepoSecret
+		mbscObj.Spec.PushBuiltImage = micObj.Spec.PushBuiltImage
 		return controllerutil.SetControllerReference(micObj, mbscObj, m.scheme)
 	})
 	return err

--- a/internal/mic/mic.go
+++ b/internal/mic/mic.go
@@ -19,7 +19,7 @@ import (
 
 type MIC interface {
 	CreateOrPatch(ctx context.Context, name, ns string, images []kmmv1beta1.ModuleImageSpec,
-		imageRepoSecret *v1.LocalObjectReference, pullPolicy v1.PullPolicy, owner metav1.Object) error
+		imageRepoSecret *v1.LocalObjectReference, pullPolicy v1.PullPolicy, pushBuiltImage bool, owner metav1.Object) error
 	Get(ctx context.Context, name, ns string) (*kmmv1beta1.ModuleImagesConfig, error)
 	GetModuleImageSpec(micObj *kmmv1beta1.ModuleImagesConfig, image string) *kmmv1beta1.ModuleImageSpec
 	SetImageStatus(micObj *kmmv1beta1.ModuleImagesConfig, image string, status kmmv1beta1.ImageState)
@@ -40,7 +40,7 @@ func New(client client.Client, scheme *runtime.Scheme) MIC {
 }
 
 func (mici *micImpl) CreateOrPatch(ctx context.Context, name, ns string, images []kmmv1beta1.ModuleImageSpec,
-	imageRepoSecret *v1.LocalObjectReference, pullPolicy v1.PullPolicy, owner metav1.Object) error {
+	imageRepoSecret *v1.LocalObjectReference, pullPolicy v1.PullPolicy, pushBuiltImage bool, owner metav1.Object) error {
 
 	logger := log.FromContext(ctx)
 
@@ -59,6 +59,7 @@ func (mici *micImpl) CreateOrPatch(ctx context.Context, name, ns string, images 
 			Images:          images,
 			ImageRepoSecret: imageRepoSecret,
 			ImagePullPolicy: pullPolicy,
+			PushBuiltImage:  pushBuiltImage,
 		}
 
 		return controllerutil.SetControllerReference(owner, mic, mici.scheme)

--- a/internal/mic/mic_test.go
+++ b/internal/mic/mic_test.go
@@ -45,7 +45,7 @@ var _ = Describe("CreateOrPatch", func() {
 
 		mockClient.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
 
-		err := micAPI.CreateOrPatch(ctx, micName, micNamespace, []v1beta1.ModuleImageSpec{}, nil, "", &kmmv1beta1.Module{})
+		err := micAPI.CreateOrPatch(ctx, micName, micNamespace, []v1beta1.ModuleImageSpec{}, nil, "", false, &kmmv1beta1.Module{})
 
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("failed to create or patch"))
@@ -81,7 +81,7 @@ var _ = Describe("CreateOrPatch", func() {
 			},
 		}
 
-		err := micAPI.CreateOrPatch(ctx, micName, micNamespace, images, imageRepoSecret, "", owner)
+		err := micAPI.CreateOrPatch(ctx, micName, micNamespace, images, imageRepoSecret, "", true, owner)
 
 		Expect(err).NotTo(HaveOccurred())
 	})
@@ -107,6 +107,7 @@ var _ = Describe("CreateOrPatch", func() {
 						ImageRepoSecret: &v1.LocalObjectReference{
 							Name: "some-secret",
 						},
+						PushBuiltImage: true,
 					}
 					return nil
 				},
@@ -127,7 +128,7 @@ var _ = Describe("CreateOrPatch", func() {
 			},
 		}
 
-		err := micAPI.CreateOrPatch(ctx, micName, micNamespace, images, nil, v1.PullIfNotPresent, owner)
+		err := micAPI.CreateOrPatch(ctx, micName, micNamespace, images, nil, v1.PullIfNotPresent, true, owner)
 
 		Expect(err).NotTo(HaveOccurred())
 	})

--- a/internal/mic/mock_mic.go
+++ b/internal/mic/mock_mic.go
@@ -42,17 +42,17 @@ func (m *MockMIC) EXPECT() *MockMICMockRecorder {
 }
 
 // CreateOrPatch mocks base method.
-func (m *MockMIC) CreateOrPatch(ctx context.Context, name, ns string, images []v1beta1.ModuleImageSpec, imageRepoSecret *v1.LocalObjectReference, pullPolicy v1.PullPolicy, owner v10.Object) error {
+func (m *MockMIC) CreateOrPatch(ctx context.Context, name, ns string, images []v1beta1.ModuleImageSpec, imageRepoSecret *v1.LocalObjectReference, pullPolicy v1.PullPolicy, pushBuiltImage bool, owner v10.Object) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOrPatch", ctx, name, ns, images, imageRepoSecret, pullPolicy, owner)
+	ret := m.ctrl.Call(m, "CreateOrPatch", ctx, name, ns, images, imageRepoSecret, pullPolicy, pushBuiltImage, owner)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateOrPatch indicates an expected call of CreateOrPatch.
-func (mr *MockMICMockRecorder) CreateOrPatch(ctx, name, ns, images, imageRepoSecret, pullPolicy, owner any) *gomock.Call {
+func (mr *MockMICMockRecorder) CreateOrPatch(ctx, name, ns, images, imageRepoSecret, pullPolicy, pushBuiltImage, owner any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrPatch", reflect.TypeOf((*MockMIC)(nil).CreateOrPatch), ctx, name, ns, images, imageRepoSecret, pullPolicy, owner)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrPatch", reflect.TypeOf((*MockMIC)(nil).CreateOrPatch), ctx, name, ns, images, imageRepoSecret, pullPolicy, pushBuiltImage, owner)
 }
 
 // DoAllImagesExist mocks base method.


### PR DESCRIPTION
Propagating the PushBuilt image to the MIC object and eventually to the MBSC object. Module/MCM reconcilers are setting it to true, Preflight is setting ti based on value of the PushBuiltImage in Preflight Spec