### PR TITLE
Fixing the metrics-server docs.

### DIFF
--- a/docs/mkdocs/documentation/configure.md
+++ b/docs/mkdocs/documentation/configure.md
@@ -56,7 +56,6 @@ Default value: `kmm.sigs.x-k8s.io` for KMM and `kmm-hub.sigs.x-k8s.io` for KMM-h
 #### `metrics.bindAddress`
 
 Determines the bind address for the metrics server.
-It will be defaulted to `:8080` if unspecified.
 Set this to "0" to disable the metrics server.  
 Default value: `0.0.0.0:8443`.
 


### PR DESCRIPTION
Removed an outdated default value.

---

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1611
/assign @TomerNewman @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the documentation for the `metrics.bindAddress` configuration option to clarify its default value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->