### PR TITLE
Fixing KMM-hub's upgrade flow from 2.3.0 --> 2.4.0.

### DIFF
--- a/cmd/manager-hub/main.go
+++ b/cmd/manager-hub/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"flag"
 	"os"
 
@@ -103,7 +104,11 @@ func main() {
 
 	cfg, err := cg.GetConfig(ctx, userConfigMapName, operatorNamespace, true)
 	if err != nil {
-		cmd.FatalError(setupLogger, err, "failed to get kmm config")
+		if errors.Is(err, config.ErrCannotUseCustomConfig) {
+			setupLogger.Error(err, "failed to get kmm config")
+		} else {
+			cmd.FatalError(setupLogger, err, "failed to get kmm config")
+		}
 	}
 
 	options := cg.GetManagerOptionsFromConfig(cfg, scheme)

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -108,7 +109,11 @@ func main() {
 
 	cfg, err := cg.GetConfig(ctx, userConfigMapName, operatorNamespace, false)
 	if err != nil {
-		cmd.FatalError(setupLogger, err, "failed to get kmm config")
+		if errors.Is(err, config.ErrCannotUseCustomConfig) {
+			setupLogger.Error(err, "failed to get kmm config")
+		} else {
+			cmd.FatalError(setupLogger, err, "failed to get kmm config")
+		}
 	}
 
 	options := cg.GetManagerOptionsFromConfig(cfg, scheme)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,9 @@ package config
 import (
 	"context"
 	"fmt"
+	"os"
+	"time"
+
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -12,10 +15,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-	"time"
 )
 
 var _ = Describe("overrideConfigFromCM", func() {
@@ -167,6 +168,7 @@ var _ = Describe("GetConfig", func() {
 			mch.EXPECT().newDefaultConfig(false).Return(&Config{}),
 			mch.EXPECT().getClient().Return(clnt, nil),
 			clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(nil),
+			mch.EXPECT().newDefaultConfig(false).Return(&Config{}),
 			mch.EXPECT().overrideConfigFromCM(gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error")),
 		)
 		_, err := cg.GetConfig(ctx, "test-cm", "test-ns", false)
@@ -179,6 +181,7 @@ var _ = Describe("GetConfig", func() {
 			mch.EXPECT().newDefaultConfig(false).Return(&Config{}),
 			mch.EXPECT().getClient().Return(clnt, nil),
 			clnt.EXPECT().Get(ctx, gomock.Any(), cm).Return(nil),
+			mch.EXPECT().newDefaultConfig(false).Return(&Config{}),
 			mch.EXPECT().overrideConfigFromCM(gomock.Any(), gomock.Any()).Return(nil),
 		)
 		_, err := cg.GetConfig(ctx, "test-cm", "test-ns", false)


### PR DESCRIPTION
The KMM-hub controller-config configMap had an invalid entry named `metricsBindAddress` in addition to the valid entry which is `metrics.bindAddress`. This issue didn't exist in the KMM controller-config configMap.

As part of making the operators configuration persist operator upgrads, we removed the default controller-config configMaps and changed the way we
read the data. The most important part was that we started to parse this data in a strict way, failing in case there is an invalid entry in the data.

When upgrading from 2.3.0 --> 2.4.0, OLM (and operator-sdk) waits for the 2.4.0 to be installed *before* removing 2.3.0, therefore, 2.4.0 was thinking KMM-hub's old controller-config configMap was actually the user's custom config for 2.4.0, and failed due to a non valid field in our old default configMap.

Once the upgrade is done, OLM will remove the configMap since it was deployed as part of 2.3.0, therefore, since our default configs and the old configMap have the same values, then KMM-hub should be configured correctly even without the need to restart the controller pod.

This commit is only logging an error and use the default configs in case the configMap parse failed without making the operator crash.

---

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1617
/assign @yevgeny-shnaidman @TomerNewman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when loading configurations, ensuring that known configuration issues no longer cause the application to exit unexpectedly. Instead, the default configuration will be used and an error will be logged.
* **Tests**
  * Updated tests to reflect new error handling logic and configuration loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->