### PR TITLE
Adding network policies to kmm including to kmm bundle

### DIFF
--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -245,9 +245,6 @@ spec:
           replicas: 1
           selector:
             matchLabels:
-              app.kubernetes.io/component: kmm-hub
-              app.kubernetes.io/name: kmm-hub
-              app.kubernetes.io/part-of: kmm
               control-plane: controller
           strategy: {}
           template:
@@ -255,9 +252,6 @@ spec:
               annotations:
                 kubectl.kubernetes.io/default-container: manager
               labels:
-                app.kubernetes.io/component: kmm-hub
-                app.kubernetes.io/name: kmm-hub
-                app.kubernetes.io/part-of: kmm
                 control-plane: controller
             spec:
               affinity:
@@ -342,9 +336,6 @@ spec:
           replicas: 1
           selector:
             matchLabels:
-              app.kubernetes.io/component: kmm-hub
-              app.kubernetes.io/name: kmm-hub
-              app.kubernetes.io/part-of: kmm
               control-plane: webhook-server
           strategy: {}
           template:
@@ -352,9 +343,6 @@ spec:
               annotations:
                 kubectl.kubernetes.io/default-container: webhook-server
               labels:
-                app.kubernetes.io/component: kmm-hub
-                app.kubernetes.io/name: kmm-hub
-                app.kubernetes.io/part-of: kmm
                 control-plane: webhook-server
             spec:
               affinity:

--- a/bundle-hub/manifests/kmm-operator-hub-controller-metrics-service_v1_service.yaml
+++ b/bundle-hub/manifests/kmm-operator-hub-controller-metrics-service_v1_service.yaml
@@ -17,9 +17,6 @@ spec:
     protocol: TCP
     targetPort: metrics
   selector:
-    app.kubernetes.io/component: kmm-hub
-    app.kubernetes.io/name: kmm-hub
-    app.kubernetes.io/part-of: kmm
     control-plane: controller
 status:
   loadBalancer: {}

--- a/bundle-hub/manifests/kmm-operator-hub-controller_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle-hub/manifests/kmm-operator-hub-controller_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,36 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: controller
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller
+  policyTypes:
+    - Egress
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP # metrics port
+          port: 8443
+        - protocol: TCP
+          port: 8081 # Healthz
+  egress:
+    - to:
+        - namespaceSelector: # DNS
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+          podSelector:
+            matchLabels:
+              dns.operator.openshift.io/daemonset-dns: default
+      ports:
+        - protocol: UDP # DNS
+          port: 53
+        - protocol: TCP # DNS
+          port: 53
+    - ports: # kube api server
+        - protocol: TCP
+          port: 6443
+        - protocol: TCP
+          port: 443

--- a/bundle-hub/manifests/kmm-operator-hub-webhook-service_v1_service.yaml
+++ b/bundle-hub/manifests/kmm-operator-hub-webhook-service_v1_service.yaml
@@ -16,9 +16,6 @@ spec:
     protocol: TCP
     targetPort: 9443
   selector:
-    app.kubernetes.io/component: kmm-hub
-    app.kubernetes.io/name: kmm-hub
-    app.kubernetes.io/part-of: kmm
     control-plane: webhook-server
 status:
   loadBalancer: {}

--- a/bundle-hub/manifests/kmm-operator-hub-webhook_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle-hub/manifests/kmm-operator-hub-webhook_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: webhook
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: webhook-server
+  policyTypes:
+  - Egress
+  - Ingress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 9443
+  egress:
+  - ports: # kube api server port
+    - protocol: TCP
+      port: 6443
+    - protocol: TCP
+      port: 443

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -352,9 +352,6 @@ spec:
           replicas: 1
           selector:
             matchLabels:
-              app.kubernetes.io/component: kmm
-              app.kubernetes.io/name: kmm
-              app.kubernetes.io/part-of: kmm
               control-plane: controller
           strategy: {}
           template:
@@ -362,9 +359,6 @@ spec:
               annotations:
                 kubectl.kubernetes.io/default-container: manager
               labels:
-                app.kubernetes.io/component: kmm
-                app.kubernetes.io/name: kmm
-                app.kubernetes.io/part-of: kmm
                 control-plane: controller
             spec:
               affinity:
@@ -451,9 +445,6 @@ spec:
           replicas: 1
           selector:
             matchLabels:
-              app.kubernetes.io/component: kmm
-              app.kubernetes.io/name: kmm
-              app.kubernetes.io/part-of: kmm
               control-plane: webhook-server
           strategy: {}
           template:
@@ -461,9 +452,6 @@ spec:
               annotations:
                 kubectl.kubernetes.io/default-container: webhook-server
               labels:
-                app.kubernetes.io/component: kmm
-                app.kubernetes.io/name: kmm
-                app.kubernetes.io/part-of: kmm
                 control-plane: webhook-server
             spec:
               affinity:

--- a/bundle/manifests/kmm-operator-controller-metrics-service_v1_service.yaml
+++ b/bundle/manifests/kmm-operator-controller-metrics-service_v1_service.yaml
@@ -17,9 +17,6 @@ spec:
     protocol: TCP
     targetPort: metrics
   selector:
-    app.kubernetes.io/component: kmm
-    app.kubernetes.io/name: kmm
-    app.kubernetes.io/part-of: kmm
     control-plane: controller
 status:
   loadBalancer: {}

--- a/bundle/manifests/kmm-operator-controller_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/manifests/kmm-operator-controller_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,36 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: controller
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller
+  policyTypes:
+    - Egress
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP # metrics port
+          port: 8443
+        - protocol: TCP
+          port: 8081 # Healthz
+  egress:
+    - to:
+        - namespaceSelector: # DNS
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+          podSelector:
+            matchLabels:
+              dns.operator.openshift.io/daemonset-dns: default
+      ports:
+        - protocol: UDP # DNS
+          port: 53
+        - protocol: TCP # DNS
+          port: 53
+    - ports: # kube api server
+        - protocol: TCP
+          port: 6443
+        - protocol: TCP
+          port: 443

--- a/bundle/manifests/kmm-operator-webhook-service_v1_service.yaml
+++ b/bundle/manifests/kmm-operator-webhook-service_v1_service.yaml
@@ -16,9 +16,6 @@ spec:
     protocol: TCP
     targetPort: 9443
   selector:
-    app.kubernetes.io/component: kmm
-    app.kubernetes.io/name: kmm
-    app.kubernetes.io/part-of: kmm
     control-plane: webhook-server
 status:
   loadBalancer: {}

--- a/bundle/manifests/kmm-operator-webhook_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/manifests/kmm-operator-webhook_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: webhook
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: webhook-server
+  policyTypes:
+  - Egress
+  - Ingress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 9443
+  egress:
+  - ports: # kube api server port
+    - protocol: TCP
+      port: 6443
+    - protocol: TCP
+      port: 443

--- a/ci/e2e/kustomization.yaml
+++ b/ci/e2e/kustomization.yaml
@@ -10,8 +10,10 @@ generatorOptions:
 
 configMapGenerator:
   - name: kmm-kmod-dockerfile
+    namespace: openshift-kmm
     files: [dockerfile=Dockerfile]
 
 secretGenerator:
   - name: build-secret
+    namespace: openshift-kmm
     literals: [ci-build-secret=super-secret-value]

--- a/ci/e2e/module.yaml
+++ b/ci/e2e/module.yaml
@@ -3,6 +3,7 @@ apiVersion: kmm.sigs.x-k8s.io/v1beta1
 kind: Module
 metadata:
   name: kmm-ci
+  namespace: openshift-kmm
 spec:
   moduleLoader:
     container:

--- a/ci/prow/e2e-incluster-build
+++ b/ci/prow/e2e-incluster-build
@@ -6,10 +6,10 @@ POD_NAME=''
 
 wait_for_pod_and_print_logs () {
   # we can't exec a command nor get the logs on a pod that isn't `Running` yet.
-  oc wait "pod/${POD_NAME}" --for jsonpath='{.status.phase}'=Running --timeout=60s
+  oc wait -n openshift-kmm"pod/${POD_NAME}" --for jsonpath='{.status.phase}'=Running --timeout=60s
 
   echo "Print pod ${POD_NAME} logs..."
-  oc logs "pod/${POD_NAME}" -f
+  oc logs -n openshift-kmm "pod/${POD_NAME}" -f
 }
 
 check_module_not_loaded () {
@@ -46,14 +46,14 @@ timeout 1m bash -c 'until oc apply -k ci/e2e; do sleep 3; done'
 # Wait for the build pod to be created. `kubectl wait` doesn't support such option,
 # see https://github.com/kubernetes/kubernetes/issues/83242.
 echo "Waiting for the build pod to be created..."
-timeout 1m bash -c 'until oc get pods -o json | jq -er ".items[].metadata.name | select(.? | match(\"build\"))"; do sleep 1; done'
-POD_NAME=$(oc get pods -o json | jq -r '.items[].metadata.name | select(.? | match("build"))')
+timeout 1m bash -c 'until oc get pods -n openshift-kmm -o json | jq -er ".items[].metadata.name | select(.? | match(\"build\"))"; do sleep 1; done'
+POD_NAME=$(oc get pods -n openshift-kmm -o json | jq -r '.items[].metadata.name | select(.? | match("build"))')
 
 wait_for_pod_and_print_logs
 
 echo "Waiting for the signing pod to be created..."
-timeout 1m bash -c 'until oc get pods -o json | jq -er ".items[].metadata.name | select(.? | match(\"sign\"))"; do sleep 1; done'
-POD_NAME=$(oc get pods -o json | jq -r '.items[].metadata.name | select(.? | match("sign"))')
+timeout 1m bash -c 'until oc get pods -n openshift-kmm -o json | jq -er ".items[].metadata.name | select(.? | match(\"sign\"))"; do sleep 1; done'
+POD_NAME=$(oc get pods -n openshift-kmm -o json | jq -r '.items[].metadata.name | select(.? | match("sign"))')
 
 wait_for_pod_and_print_logs
 
@@ -66,7 +66,7 @@ oc debug "node/${NODE}" -- chroot host/ lsmod | grep kmm_ci_b
 check_module_not_loaded "dummy"
 
 echo "Remove the Module..."
-oc delete modules.kmm.sigs.x-k8s.io/kmm-ci --wait=false
+oc delete modules.kmm.sigs.x-k8s.io/kmm-ci --wait=false -n openshift-kmm
 
 echo "Check that the module gets unloaded from the node..."
 timeout 1m bash -c 'until ! oc debug node/${NODE} -- chroot host/ lsmod | grep kmm_ci_a; do sleep 3; done'
@@ -75,4 +75,4 @@ echo "Check that the dependent module is also unloaded from the node..."
 check_module_not_loaded "kmm_ci_b"
 
 echo "Wait for the Module to be deleted..."
-oc wait --for delete modules.kmm.sigs.x-k8s.io/kmm-ci
+oc wait --for delete modules.kmm.sigs.x-k8s.io/kmm-ci -n openshift-kmm

--- a/ci/sign-key-certs/kustomization.yaml
+++ b/ci/sign-key-certs/kustomization.yaml
@@ -6,6 +6,8 @@ generatorOptions:
 
 secretGenerator:
   - name: kmm-kmod-signing-cert
+    namespace: openshift-kmm
     files: [cert=signing-cert.pem]
   - name: kmm-kmod-signing-key
+    namespace: openshift-kmm
     files: [key=signing-key.pem]

--- a/config/default-hub/kustomization.yaml
+++ b/config/default-hub/kustomization.yaml
@@ -17,7 +17,7 @@ components:
 configurations:
 - kustomizeconfig.yaml
 labels:
-- includeSelectors: true
+- includeSelectors: false
   pairs:
     app.kubernetes.io/component: kmm-hub
     app.kubernetes.io/name: kmm-hub

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -17,7 +17,7 @@ namePrefix: kmm-operator-
 configurations:
 - kustomizeconfig.yaml
 labels:
-- includeSelectors: true
+- includeSelectors: false
   pairs:
     app.kubernetes.io/component: kmm
     app.kubernetes.io/name: kmm

--- a/config/deploy-hub/kustomization.yaml
+++ b/config/deploy-hub/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - ../manager-hub
 - ../webhook-hub
 - ../webhook-server
+- ../network-policy
 
 patches:
 - target:

--- a/config/deploy/kustomization.yaml
+++ b/config/deploy/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - ../prometheus
 - ../webhook
 - ../webhook-server
+- ../network-policy
 
 patches:
 - target:

--- a/config/manifests-hub/kustomization.yaml
+++ b/config/manifests-hub/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 - ../samples-hub
 - ../scorecard
 labels:
-- includeSelectors: true
+- includeSelectors: false
   pairs:
     app.kubernetes.io/component: kmm-hub
     app.kubernetes.io/name: kmm-hub

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 - ../samples
 - ../scorecard
 labels:
-- includeSelectors: true
+- includeSelectors: false
   pairs:
     app.kubernetes.io/component: kmm
     app.kubernetes.io/name: kmm

--- a/config/network-policy/controller.yaml
+++ b/config/network-policy/controller.yaml
@@ -1,0 +1,36 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: controller
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller
+  policyTypes:
+    - Egress
+    - Ingress
+  ingress:
+    - ports:
+        - protocol: TCP # metrics port
+          port: 8443
+        - protocol: TCP
+          port: 8081 # Healthz
+  egress:
+    - to:
+        - namespaceSelector: # DNS
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-dns
+          podSelector:
+            matchLabels:
+              dns.operator.openshift.io/daemonset-dns: default
+      ports:
+        - protocol: UDP # DNS
+          port: 53
+        - protocol: TCP # DNS
+          port: 53
+    - ports: # kube api server
+        - protocol: TCP
+          port: 6443
+        - protocol: TCP
+          port: 443

--- a/config/network-policy/kustomization.yaml
+++ b/config/network-policy/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- controller.yaml
+- webhook.yaml

--- a/config/network-policy/webhook.yaml
+++ b/config/network-policy/webhook.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: webhook
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: webhook-server
+  policyTypes:
+  - Egress
+  - Ingress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 9443
+  egress:
+  - ports: # kube api server port
+    - protocol: TCP
+      port: 6443
+    - protocol: TCP
+      port: 443

--- a/config/olm-hub/kustomization.yaml
+++ b/config/olm-hub/kustomization.yaml
@@ -10,7 +10,7 @@ namePrefix: kmm-operator-hub-
 resources:
 - ../deploy-hub
 labels:
-- includeSelectors: true
+- includeSelectors: false
   pairs:
     app.kubernetes.io/component: kmm-hub
     app.kubernetes.io/name: kmm-hub

--- a/config/olm/kustomization.yaml
+++ b/config/olm/kustomization.yaml
@@ -10,7 +10,7 @@ namePrefix: kmm-operator-
 resources:
 - ../deploy
 labels:
-- includeSelectors: true
+- includeSelectors: false
   pairs:
     app.kubernetes.io/component: kmm
     app.kubernetes.io/name: kmm

--- a/config/webhook-server/kustomization.yaml
+++ b/config/webhook-server/kustomization.yaml
@@ -10,6 +10,5 @@ images:
   newName: quay.io/edge-infrastructure/kernel-module-management-webhook-server
   newTag: latest
 labels:
-- includeSelectors: true
-  pairs:
+- pairs:
     app.kubernetes.io/component: webhook-server

--- a/hack/generate-bundle
+++ b/hack/generate-bundle
@@ -8,6 +8,7 @@ set -euxo pipefail
 : "$PKG"
 : "$SOURCE_DIR"
 : "${SUFFIX:=}"
+: "${INCLUDE_NETWORK_POLICIES:=false}"
 
 readonly BUNDLE_DIR="bundle${SUFFIX}"
 
@@ -22,6 +23,16 @@ oc kustomize "$MANIFESTS_DIR" | "$OPERATOR_SDK" generate bundle \
   --output-dir "$BUNDLE_DIR" \
   --package "$PKG" \
   $BUNDLE_GEN_FLAGS
+
+# add network policies
+if [ "$INCLUDE_NETWORK_POLICIES" = "true" ] && [ -d "$SOURCE_DIR/config/network-policy" ]; then
+  for np_file in "$SOURCE_DIR/config/network-policy"/*.yaml; do
+    if [ -f "$np_file" ] && [ "$(basename "$np_file")" != "kustomization.yaml" ]; then
+      filename=$(basename "$np_file" .yaml)
+      cp "$np_file" "$BUNDLE_DIR/manifests/kmm-operator${SUFFIX}-${filename}_networking.k8s.io_v1_networkpolicy.yaml"
+    fi
+  done
+fi
 
 mv "$BUNDLE_DIR" "$SOURCE_DIR/$BUNDLE_DIR"
 mv bundle.Dockerfile "$SOURCE_DIR/bundle${SUFFIX}.Dockerfile"


### PR DESCRIPTION
Due to security concerns, we need to allow KMM
operator only the nessecery traffic.
This commits adds Network policies for each kmm pod.
1. controller
2. webhook
3. build and sign This commit also changes e2e tests to verify the network policies affect.
This commit also affects KMM bundle to include the network policy mainfests.

---

/hold 
/cc @ybettan @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added network policies for enhanced network security and isolation for controller and webhook components.

* **Configuration Updates**
  * Simplified pod labeling for cleaner resource identification.
  * Updated service routing configuration to align with new label scheme.
  * Configured namespace targeting for test environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->