### PR TITLE
Fixing status not appear in deprecated PreflightValidationOCP

### DIFF
--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -47,7 +47,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2025-09-09T13:35:44Z"
+    createdAt: "2025-09-15T08:02:05Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -568,8 +568,9 @@ spec:
     containerPort: 443
     conversionCRDs:
     - preflightvalidations.kmm.sigs.x-k8s.io
+    - preflightvalidationsocp.kmm.sigs.x-k8s.io
     deploymentName: kmm-operator-webhook
-    generateName: cpreflightvalidations.kb.io
+    generateName: cpreflightvalidationspreflightvalidationsocp.kb.io
     sideEffects: None
     targetPort: 9443
     type: ConversionWebhook

--- a/bundle/manifests/kmm.sigs.x-k8s.io_preflightvalidationsocp.yaml
+++ b/bundle/manifests/kmm.sigs.x-k8s.io_preflightvalidationsocp.yaml
@@ -10,6 +10,17 @@ metadata:
     app.kubernetes.io/part-of: kmm
   name: preflightvalidationsocp.kmm.sigs.x-k8s.io
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: kmm-operator-webhook-service
+          namespace: system
+          path: /convert
+      conversionReviewVersions:
+      - v1beta2
+      - v1beta1
   group: kmm.sigs.x-k8s.io
   names:
     kind: PreflightValidationOCP

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -18,6 +18,7 @@ patches:
 # patches here are for enabling the conversion webhook for each CRD
 #- path: patches/webhook_in_modules.yaml
 - path: patches/webhook_in_preflightvalidations.yaml
+- path: patches/webhook_in_preflightvalidationsocp.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch

--- a/config/crd/patches/webhook_in_preflightvalidationsocp.yaml
+++ b/config/crd/patches/webhook_in_preflightvalidationsocp.yaml
@@ -1,0 +1,17 @@
+# The following patch enables a conversion webhook for the CRD
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: preflightvalidationsocp.kmm.sigs.x-k8s.io
+spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          namespace: system
+          name: webhook-service
+          path: /convert
+      conversionReviewVersions:
+      - v1beta2
+      - v1beta1


### PR DESCRIPTION
When creating  PreflightValidationOCP with v1beta1 version a new resource with v1beta2 version is created as expected, but the status is only appear in v1beta2 and not in the v1beta1 one.
This is happening because the conversion webhook was not well defined in the CRD.
This commit fixes it by adding into the PreflightValidationOCP CRD a conversion between v1beta1 and v1beta2.

---

/cc @ybettan @yevgeny-shnaidman 
/assign @yevgeny-shnaidman @ybettan 