### PR TITLE
Fixing the usage of current worker image for BMC

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -144,7 +144,7 @@ func main() {
 	micAPI := mic.New(client, scheme)
 	mbscAPI := mbsc.New(client, scheme)
 	imagePullerAPI := pod.NewImagePuller(client, scheme)
-	mcfgAPI := mcfg.NewMCFG()
+	mcfgAPI := mcfg.NewMCFG(workerImage)
 
 	dpc := controllers.NewDevicePluginReconciler(
 		client,

--- a/internal/mcfg/mcfg.go
+++ b/internal/mcfg/mcfg.go
@@ -48,10 +48,13 @@ type MCFG interface {
 }
 
 type mcfgImpl struct {
+	currentWorkerImage string
 }
 
-func NewMCFG() MCFG {
-	return &mcfgImpl{}
+func NewMCFG(currentWorkerImage string) MCFG {
+	return &mcfgImpl{
+		currentWorkerImage: currentWorkerImage,
+	}
 }
 
 func (m *mcfgImpl) UpdateDisruptionPolicies(mc *apioperatorv1.MachineConfiguration, bmc *kmmv1beta1.BootModuleConfig) {
@@ -70,6 +73,9 @@ func (m *mcfgImpl) UpdateMachineConfig(mc *mcfgv1.MachineConfig, bmc *kmmv1beta1
 
 func (m *mcfgImpl) GenerateIgnition(kernelModuleImage, kernelModuleName, inTreeModuleToRemove, firmwareFilesPath,
 	workerImage, servicePrefix string) ([]byte, string, error) {
+	if workerImage == "" {
+		workerImage = m.currentWorkerImage
+	}
 	templateParams := map[string]any{
 		"FirmwareFilesPath":                 firmwareFilesPath,
 		"KernelModuleImage":                 kernelModuleImage,

--- a/internal/mcfg/mcfg_test.go
+++ b/internal/mcfg/mcfg_test.go
@@ -20,7 +20,7 @@ var _ = Describe("UpdateDisruptionPolicies", func() {
 				MachineConfigName: "test-name",
 			},
 		}
-		mcfgAPI := NewMCFG()
+		mcfgAPI := NewMCFG("")
 		mcfgAPI.UpdateDisruptionPolicies(mc, bmc)
 
 		expectedUnit := apioperatorv1.NodeDisruptionPolicySpecUnit{
@@ -81,7 +81,7 @@ var _ = Describe("UpdateMachineConfig", func() {
 		}
 
 		By("machine config labels are empty")
-		mcfgAPI := NewMCFG()
+		mcfgAPI := NewMCFG("")
 		err := mcfgAPI.UpdateMachineConfig(mc, bmc)
 		Expect(err).To(BeNil())
 		expectedLabels := map[string]string{"machineconfiguration.openshift.io/role": "test-pool-name"}
@@ -120,9 +120,25 @@ var _ = Describe("GenerateIgnition", func() {
 	// encoding on testdata/pull-image-test.sh and testdata/replace-kernel-module-test.sh
 	// and setting the values into the testdata/machineconfig-test.yaml
 	It("verify correct ignition output", func() {
-		mcfgAPI := NewMCFG()
+		mcfgAPI := NewMCFG("")
 
 		_, yamlRes, err := mcfgAPI.GenerateIgnition(imageName, kernelModuleName, inTreeKernelModuleName, firmwareFilesPath, workerImage, "test-mc")
+
+		Expect(err).ToNot(HaveOccurred())
+		expectedRes, err := os.ReadFile("testdata/ignition-test.yaml")
+		Expect(err).ToNot(HaveOccurred())
+
+		if string(expectedRes) != yamlRes {
+			fmt.Printf("<%s>\n", yamlRes)
+			fmt.Printf("<%s>\n", expectedRes)
+		}
+		Expect(string(yamlRes)).To(Equal(string(expectedRes)))
+	})
+
+	It("verify the usage of the default worker image", func() {
+		mcfgAPI := NewMCFG(workerImage)
+
+		_, yamlRes, err := mcfgAPI.GenerateIgnition(imageName, kernelModuleName, inTreeKernelModuleName, firmwareFilesPath, "", "test-mc")
 
 		Expect(err).ToNot(HaveOccurred())
 		expectedRes, err := os.ReadFile("testdata/ignition-test.yaml")

--- a/pkg/mcproducer/mcproducer.go
+++ b/pkg/mcproducer/mcproducer.go
@@ -40,13 +40,8 @@ func ProduceMachineConfig(machineConfigName,
 		return "", fmt.Errorf("failed to verify kernel module image name %s: %v", kernelModuleImage, err)
 	}
 
-	workerImageToUse := defaultWorkerImage
-	if workerImage != "" {
-		workerImageToUse = workerImage
-	}
-
-	mcfgAPI := mcfg.NewMCFG()
-	_, ignition, err := mcfgAPI.GenerateIgnition(kernelModuleImage, kernelModuleName, inTreeModuleToRemove, firmwareFilesPath, workerImageToUse, machineConfigName)
+	mcfgAPI := mcfg.NewMCFG(defaultWorkerImage)
+	_, ignition, err := mcfgAPI.GenerateIgnition(kernelModuleImage, kernelModuleName, inTreeModuleToRemove, firmwareFilesPath, workerImage, machineConfigName)
 	if err != nil {
 		return "", fmt.Errorf("failed to create ignition string: %v", err)
 	}


### PR DESCRIPTION
in case BMC spec does not contain the worker image, the worker image that should be used in the flow is the current worker image of the KMM. The changes:
1. MCFG package gets the current worker image during its initialization.
2. During IgnitionGeneration, the input worker image is replaced with the current worker image, in case its is empty

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced worker image configuration: allows an initialization-time default and a runtime fallback when an explicit worker image isn't provided, improving flexibility and consistency of generated outputs.
* **Tests**
  * Added and updated tests to verify default worker image usage and ensure identical ignition output when runtime image is omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->