### PR TITLE
BMC finalization implementation

### DIFF
--- a/internal/mcfg/mock_mcfg.go
+++ b/internal/mcfg/mock_mcfg.go
@@ -56,6 +56,18 @@ func (mr *MockMCFGMockRecorder) GenerateIgnition(kernelModuleImage, kernelModule
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateIgnition", reflect.TypeOf((*MockMCFG)(nil).GenerateIgnition), kernelModuleImage, kernelModuleName, inTreeModuleToRemove, firmwareFilesPath, workerImage, servicePrefix)
 }
 
+// RemoveDisruptionPolicies mocks base method.
+func (m *MockMCFG) RemoveDisruptionPolicies(mc *v10.MachineConfiguration, bmc *v1beta1.BootModuleConfig, removeAll bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RemoveDisruptionPolicies", mc, bmc, removeAll)
+}
+
+// RemoveDisruptionPolicies indicates an expected call of RemoveDisruptionPolicies.
+func (mr *MockMCFGMockRecorder) RemoveDisruptionPolicies(mc, bmc, removeAll any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveDisruptionPolicies", reflect.TypeOf((*MockMCFG)(nil).RemoveDisruptionPolicies), mc, bmc, removeAll)
+}
+
 // UpdateDisruptionPolicies mocks base method.
 func (m *MockMCFG) UpdateDisruptionPolicies(mc *v10.MachineConfiguration, bmc *v1beta1.BootModuleConfig) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
This PR implenents the flow of BMC finalization:
1. Check how many BMC's are in the cluster
2. Remove the pull systemd unit and replace systemd unit for that BMC from the MachineConfiguration
3. In case this is the only BMC in the cluster, also remove crio systemd unit, and all the shell scripts used by the systemd units from the MachineConfiguration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Machine configurations can now conditionally remove disruption policies based on system state.
  * Automatic cleanup logic for multi-BMC environments with improved error handling and diagnostic logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->