### PR TITLE
Updating all images to default to the `release-2.5` tag.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 IMAGE_TAG_BASE ?= quay.io/edge-infrastructure/kernel-module-management-operator
 
 # This is the default tag of all images made by this Makefile.
-IMAGE_TAG ?= latest
+IMAGE_TAG ?= release-2.5
 
 SIGNER_IMAGE_TAG_BASE ?= quay.io/edge-infrastructure/kernel-module-management-signimage
 SIGNER_IMG ?= $(SIGNER_IMAGE_TAG_BASE):$(IMAGE_TAG)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the kernel modules for new incoming kernel versions attached to upgrades.
 ## Getting started
 Install the bleeding edge KMM in one command:
 ```shell
-oc apply -k https://github.com/rh-ecosystem-edge/kernel-module-management/config/default
+oc apply -k https://github.com/rh-ecosystem-edge/kernel-module-management/config/default?ref=release-2.5
 ```
 
 ## Documentation and lab

--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2025-10-15T07:06:43Z"
+    createdAt: "2025-10-21T12:25:08Z"
     operatorframework.io/suggested-namespace: openshift-kmm-hub
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -264,10 +264,10 @@ spec:
                     fieldRef:
                       fieldPath: metadata.namespace
                 - name: RELATED_IMAGE_MUST_GATHER
-                  value: quay.io/edge-infrastructure/kernel-module-management-must-gather:latest
+                  value: quay.io/edge-infrastructure/kernel-module-management-must-gather:release-2.5
                 - name: RELATED_IMAGE_SIGN
-                  value: quay.io/edge-infrastructure/kernel-module-management-signimage:latest
-                image: quay.io/edge-infrastructure/kernel-module-management-operator-hub:latest
+                  value: quay.io/edge-infrastructure/kernel-module-management-signimage:release-2.5
+                image: quay.io/edge-infrastructure/kernel-module-management-operator-hub:release-2.5
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -361,7 +361,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/edge-infrastructure/kernel-module-management-webhook-server:latest
+                image: quay.io/edge-infrastructure/kernel-module-management-webhook-server:release-2.5
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -456,9 +456,9 @@ spec:
     name: Red Hat
     url: https://www.redhat.com
   relatedImages:
-  - image: quay.io/edge-infrastructure/kernel-module-management-must-gather:latest
+  - image: quay.io/edge-infrastructure/kernel-module-management-must-gather:release-2.5
     name: must-gather
-  - image: quay.io/edge-infrastructure/kernel-module-management-signimage:latest
+  - image: quay.io/edge-infrastructure/kernel-module-management-signimage:release-2.5
     name: sign
   version: 0.0.1
   webhookdefinitions:

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -47,7 +47,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2025-10-15T07:06:35Z"
+    createdAt: "2025-10-21T12:25:07Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -367,16 +367,16 @@ spec:
                 - --config=kmm-operator-manager-config
                 env:
                 - name: RELATED_IMAGE_WORKER
-                  value: quay.io/edge-infrastructure/kernel-module-management-worker:latest
+                  value: quay.io/edge-infrastructure/kernel-module-management-worker:release-2.5
                 - name: OPERATOR_NAMESPACE
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
                 - name: RELATED_IMAGE_MUST_GATHER
-                  value: quay.io/edge-infrastructure/kernel-module-management-must-gather:latest
+                  value: quay.io/edge-infrastructure/kernel-module-management-must-gather:release-2.5
                 - name: RELATED_IMAGE_SIGN
-                  value: quay.io/edge-infrastructure/kernel-module-management-signimage:latest
-                image: quay.io/edge-infrastructure/kernel-module-management-operator:latest
+                  value: quay.io/edge-infrastructure/kernel-module-management-signimage:release-2.5
+                image: quay.io/edge-infrastructure/kernel-module-management-operator:release-2.5
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -472,7 +472,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                image: quay.io/edge-infrastructure/kernel-module-management-webhook-server:latest
+                image: quay.io/edge-infrastructure/kernel-module-management-webhook-server:release-2.5
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -585,11 +585,11 @@ spec:
     name: Red Hat
     url: https://www.redhat.com
   relatedImages:
-  - image: quay.io/edge-infrastructure/kernel-module-management-worker:latest
+  - image: quay.io/edge-infrastructure/kernel-module-management-worker:release-2.5
     name: worker
-  - image: quay.io/edge-infrastructure/kernel-module-management-must-gather:latest
+  - image: quay.io/edge-infrastructure/kernel-module-management-must-gather:release-2.5
     name: must-gather
-  - image: quay.io/edge-infrastructure/kernel-module-management-signimage:latest
+  - image: quay.io/edge-infrastructure/kernel-module-management-signimage:release-2.5
     name: sign
   version: 0.0.1
   webhookdefinitions:

--- a/config/manager-base/kustomization.yaml
+++ b/config/manager-base/kustomization.yaml
@@ -10,10 +10,10 @@ patches:
 images:
 - name: must-gather
   newName: quay.io/edge-infrastructure/kernel-module-management-must-gather
-  newTag: latest
+  newTag: release-2.5
 - name: signer
   newName: quay.io/edge-infrastructure/kernel-module-management-signimage
-  newTag: latest
+  newTag: release-2.5
 
 configurations:
 - kustomizeconfig.yaml

--- a/config/manager-hub/kustomization.yaml
+++ b/config/manager-hub/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 images:
 - name: controller
   newName: quay.io/edge-infrastructure/kernel-module-management-operator-hub
-  newTag: latest
+  newTag: release-2.5
 
 patches:
 - path: manager_hub_config_patch.yaml

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -11,7 +11,7 @@ patches:
 images:
 - name: controller
   newName: quay.io/edge-infrastructure/kernel-module-management-operator
-  newTag: latest
+  newTag: release-2.5
 - name: worker
   newName: quay.io/edge-infrastructure/kernel-module-management-worker
-  newTag: latest
+  newTag: release-2.5

--- a/config/webhook-server/kustomization.yaml
+++ b/config/webhook-server/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
 images:
 - name: webhook-server
   newName: quay.io/edge-infrastructure/kernel-module-management-webhook-server
-  newTag: latest
+  newTag: release-2.5
 labels:
 - includeSelectors: true
   pairs:


### PR DESCRIPTION
We should be able to checkout the release branch and just run `make deploy` or `oc apply -k config/default` and get the release-2.5 version deployed.

---

/assign @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Container image references have been updated from "latest" to "release-2.5" across all deployment configurations, build files, kustomization manifests, and related configurations. This ensures consistent versioning for the operator, worker, webhook-server, must-gather, and sign-image components across all installation environments.
  * Deployment documentation and example commands have been updated to reference "release-2.5" to provide accurate guidance for users deploying this specific release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->