### PR TITLE
Removing the kernel version tag from the `kernelModuleImage` BMC docs.

### DIFF
--- a/docs/mkdocs/documentation/day1_limited_option.md
+++ b/docs/mkdocs/documentation/day1_limited_option.md
@@ -140,7 +140,7 @@ A detailed description of MachineConfig and MachineConfigPool can be found in [M
 
 ## Cluster Upgrade support
 Using kernel version as a tag for kernel module image, allows supporting cluster upgrade. Pull service will determine the kernel version of the 
-node and then use this value as a tag for kernel module image. This way, all the customer needs to do prior to upgrading the cluster, it to create a kernel module image
+node and then use this value as a tag for kernel module image. This way, all the customer needs to do prior to upgrading the cluster, is to create a kernel module image
 with the appropriate tag, without any need to update day1 MC. Once the node is rebooted, pull service will pull the correct image
 
 ## kmod Upgrade support
@@ -165,7 +165,7 @@ When a day1 kmod was "transitioned" to the KMM operator using a `Module`, a BMC 
  spec:
   machineConfigName: worker-kmod-config
   machineConfigPoolName: worker
-  kernelModuleImage: quay.io/example/kmod:5.14.0-284.59.1.el9_2.x86_64
+  kernelModuleImage: quay.io/example/kmod
   kernelModuleName: my_module
  status:
   conditions: []
@@ -173,7 +173,8 @@ When a day1 kmod was "transitioned" to the KMM operator using a `Module`, a BMC 
 
 * `machineConfigName`: the machineConfig that is targeted by the BMC
 * `machineConfigPoolName`: the machineConfig pool that is linked to the targeted machineConfig
-* `kernelModuleImage`: kernel module container image that contains the kernel module .ko file
+* `kernelModuleImage`: kernel module container image that contains the kernel module .ko file without the tag
+The pull service will determine the kernel version of the node and then use this value as a tag for kernel module image. This way, all the customer needs to do prior to upgrading the cluster, is to create a kernel module image with the appropriate tag, without any need to update day1 MC. Once the node is rebooted, pull service will pull the correct image.
 * `kernelModuleName`: the name of the kernel module to be loaded (the name of the .ko file without the .ko)
 * `inTreeModulesToRemove`: Optional; a list of the in-tree kernel module to remove prior to loading the OOT kernel module
 * `firmwareFilesPath`: Optional; path of the firmware files in the kernel module container image


### PR DESCRIPTION
This tag is being automatically computed by the pull service and shouldn't we set by the user.

---

/assign @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated kernel module image guidance: no explicit tag required — the pull service will determine and apply the correct tag based on the node kernel at pull time.
  * Clarified upgrade behavior: images are pulled and the node may reboot as needed, enabling upgrades without updating day‑1 configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->