### PR TITLE
Adding documentation for the versioned ready label on the nodes.

### DIFF
--- a/docs/mkdocs/documentation/ordered_upgrade.md
+++ b/docs/mkdocs/documentation/ordered_upgrade.md
@@ -50,6 +50,12 @@ Steps 3, 4 and 5 are then unified into one step: update the
 `kmm.node.kubernetes.io/version-module.<module-namespace>.<module-name>` label value to new `$moduleVersion` as set in
 the `Module`.
 
+### Indicator that the new version is ready to be used
+
+The operator will label the node with a "version.ready" label to indicate that the new version of the kernel module is loaded
+and ready to be used:
+`kmm.node.kubernetes.io/<module-namespace>.<module-name>.version.ready=<module-version>`
+
 ## Implementation details
 
 ### Components


### PR DESCRIPTION
Users need an official API to determine if their kmod was upgraded to the newer version successfully when using the ordered-upgrade flow.

Before this commit, we only had a label describing if a specific kmod is ready to be used or not but the same label was used for all versions.

To prevent users from watching the ready label being removed and then re-appearing for the new kmod, we decided to add a new label with the kmod version in it.

---

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1700
/assign @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing the "version.ready" label used to indicate when a new kernel module version is loaded and ready for use, including the label format specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->