### PR TITLE
Adding "version.ready" label to the ordered upgrade flow

### DIFF
--- a/api/v1beta1/nodemodulesconfig_types.go
+++ b/api/v1beta1/nodemodulesconfig_types.go
@@ -44,6 +44,9 @@ type ModuleItem struct {
 	//+optional
 	// tolerations define which tolerations should be added for every load/unload pod running on the node
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+	//+optional
+	// Version is the version of the kernel module that should be loaded
+	Version string `json:"version,omitempty"`
 }
 
 type NodeModuleSpec struct {

--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2025-10-21T12:25:08Z"
+    createdAt: "2025-11-16T08:46:00Z"
     operatorframework.io/suggested-namespace: openshift-kmm-hub
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -47,7 +47,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2025-10-21T12:25:07Z"
+    createdAt: "2025-11-16T08:45:50Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/manifests/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
+++ b/bundle/manifests/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
@@ -226,6 +226,10 @@ spec:
                             type: string
                         type: object
                       type: array
+                    version:
+                      description: Version is the version of the kernel module that
+                        should be loaded
+                      type: string
                   required:
                   - config
                   - name
@@ -419,6 +423,10 @@ spec:
                             type: string
                         type: object
                       type: array
+                    version:
+                      description: Version is the version of the kernel module that
+                        should be loaded
+                      type: string
                   required:
                   - name
                   - namespace

--- a/config/crd-hub/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
+++ b/config/crd-hub/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
@@ -222,6 +222,10 @@ spec:
                             type: string
                         type: object
                       type: array
+                    version:
+                      description: Version is the version of the kernel module that
+                        should be loaded
+                      type: string
                   required:
                   - config
                   - name
@@ -415,6 +419,10 @@ spec:
                             type: string
                         type: object
                       type: array
+                    version:
+                      description: Version is the version of the kernel module that
+                        should be loaded
+                      type: string
                   required:
                   - name
                   - namespace

--- a/config/crd/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_nodemodulesconfigs.yaml
@@ -222,6 +222,10 @@ spec:
                             type: string
                         type: object
                       type: array
+                    version:
+                      description: Version is the version of the kernel module that
+                        should be loaded
+                      type: string
                   required:
                   - config
                   - name
@@ -415,6 +419,10 @@ spec:
                             type: string
                         type: object
                       type: array
+                    version:
+                      description: Version is the version of the kernel module that
+                        should be loaded
+                      type: string
                   required:
                   - name
                   - namespace

--- a/internal/controllers/mock_nmc_reconciler.go
+++ b/internal/controllers/mock_nmc_reconciler.go
@@ -192,10 +192,10 @@ func (mr *MocklabelPreparationHelperMockRecorder) addEqualLabels(nodeModuleReady
 }
 
 // getDeprecatedKernelModuleReadyLabels mocks base method.
-func (m *MocklabelPreparationHelper) getDeprecatedKernelModuleReadyLabels(node v1.Node) sets.Set[string] {
+func (m *MocklabelPreparationHelper) getDeprecatedKernelModuleReadyLabels(node v1.Node) map[string]string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "getDeprecatedKernelModuleReadyLabels", node)
-	ret0, _ := ret[0].(sets.Set[string])
+	ret0, _ := ret[0].(map[string]string)
 	return ret0
 }
 
@@ -245,6 +245,20 @@ func (m *MocklabelPreparationHelper) getStatusLabelsAndTheirConfigs(nmc *v1beta1
 func (mr *MocklabelPreparationHelperMockRecorder) getStatusLabelsAndTheirConfigs(nmc any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getStatusLabelsAndTheirConfigs", reflect.TypeOf((*MocklabelPreparationHelper)(nil).getStatusLabelsAndTheirConfigs), nmc)
+}
+
+// getStatusVersions mocks base method.
+func (m *MocklabelPreparationHelper) getStatusVersions(nmc *v1beta1.NodeModulesConfig) map[types.NamespacedName]string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getStatusVersions", nmc)
+	ret0, _ := ret[0].(map[types.NamespacedName]string)
+	return ret0
+}
+
+// getStatusVersions indicates an expected call of getStatusVersions.
+func (mr *MocklabelPreparationHelperMockRecorder) getStatusVersions(nmc any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getStatusVersions", reflect.TypeOf((*MocklabelPreparationHelper)(nil).getStatusVersions), nmc)
 }
 
 // removeOrphanedLabels mocks base method.

--- a/internal/controllers/nmc_reconciler.go
+++ b/internal/controllers/nmc_reconciler.go
@@ -101,7 +101,7 @@ func (r *NMCReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 	}
 
 	errs := make([]error, 0, len(nmcObj.Spec.Modules)+len(nmcObj.Status.Modules))
-	var readyLabelsToRemove []string
+	readyLabelsToRemove := make(map[string]string)
 	for _, mod := range nmcObj.Spec.Modules {
 		moduleNameKey := mod.Namespace + "/" + mod.Name
 
@@ -109,7 +109,7 @@ func (r *NMCReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 
 		// skipping handling NMC spec module until node is ready
 		if !r.nodeAPI.IsNodeSchedulable(&node, mod.Tolerations) {
-			readyLabelsToRemove = append(readyLabelsToRemove, utils.GetKernelModuleReadyNodeLabel(mod.Namespace, mod.Name))
+			readyLabelsToRemove[utils.GetKernelModuleReadyNodeLabel(mod.Namespace, mod.Name)] = ""
 			delete(statusMap, moduleNameKey)
 			continue
 		}
@@ -140,7 +140,7 @@ func (r *NMCReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 	}
 
 	// removing label of loaded kmods
-	if readyLabelsToRemove != nil {
+	if len(readyLabelsToRemove) != 0 {
 		if err := r.nodeAPI.UpdateLabels(ctx, &node, nil, readyLabelsToRemove); err != nil {
 			return ctrl.Result{}, fmt.Errorf("could remove node %s labels: %v", node.Name, err)
 		}
@@ -574,6 +574,8 @@ func (h *nmcReconcilerHelperImpl) SyncStatus(ctx context.Context, nmcObj *kmmv1b
 
 			status.BootId = node.Status.NodeInfo.BootID
 
+			status.Version = h.podManager.GetModuleVersionAnnotation(&p)
+
 			nmc.SetModuleStatus(&nmcObj.Status.Modules, *status)
 
 			podsToDelete = append(podsToDelete, p)
@@ -598,63 +600,6 @@ func (h *nmcReconcilerHelperImpl) SyncStatus(ctx context.Context, nmcObj *kmmv1b
 	return errors.Join(errs...)
 }
 
-type labelPreparationHelper interface {
-	getDeprecatedKernelModuleReadyLabels(node v1.Node) sets.Set[string]
-	getNodeKernelModuleReadyLabels(node v1.Node) sets.Set[types.NamespacedName]
-	getSpecLabelsAndTheirConfigs(nmc *kmmv1beta1.NodeModulesConfig) map[types.NamespacedName]kmmv1beta1.ModuleConfig
-	getStatusLabelsAndTheirConfigs(nmc *kmmv1beta1.NodeModulesConfig) map[types.NamespacedName]kmmv1beta1.ModuleConfig
-	addEqualLabels(nodeModuleReadyLabels sets.Set[types.NamespacedName],
-		specLabels, statusLabels map[types.NamespacedName]kmmv1beta1.ModuleConfig) []types.NamespacedName
-	removeOrphanedLabels(nodeModuleReadyLabels sets.Set[types.NamespacedName],
-		specLabels, statusLabels map[types.NamespacedName]kmmv1beta1.ModuleConfig) []types.NamespacedName
-}
-type labelPreparationHelperImpl struct{}
-
-func newLabelPreparationHelper() labelPreparationHelper {
-	return &labelPreparationHelperImpl{}
-}
-
-func (lph *labelPreparationHelperImpl) getNodeKernelModuleReadyLabels(node v1.Node) sets.Set[types.NamespacedName] {
-	nodeModuleReadyLabels := sets.New[types.NamespacedName]()
-
-	for label := range node.GetLabels() {
-		if ok, namespace, name := utils.IsKernelModuleReadyNodeLabel(label); ok {
-			nodeModuleReadyLabels.Insert(types.NamespacedName{Namespace: namespace, Name: name})
-		}
-	}
-	return nodeModuleReadyLabels
-}
-
-func (lph *labelPreparationHelperImpl) getDeprecatedKernelModuleReadyLabels(node v1.Node) sets.Set[string] {
-	deprecatedNodeModuleReadyLabels := sets.New[string]()
-
-	for label := range node.GetLabels() {
-		if utils.IsDeprecatedKernelModuleReadyNodeLabel(label) {
-			deprecatedNodeModuleReadyLabels.Insert(label)
-		}
-	}
-	return deprecatedNodeModuleReadyLabels
-}
-
-func (lph *labelPreparationHelperImpl) getSpecLabelsAndTheirConfigs(nmc *kmmv1beta1.NodeModulesConfig) map[types.NamespacedName]kmmv1beta1.ModuleConfig {
-	specLabels := make(map[types.NamespacedName]kmmv1beta1.ModuleConfig)
-
-	for _, module := range nmc.Spec.Modules {
-		specLabels[types.NamespacedName{Namespace: module.Namespace, Name: module.Name}] = module.Config
-	}
-	return specLabels
-}
-
-func (lph *labelPreparationHelperImpl) getStatusLabelsAndTheirConfigs(nmc *kmmv1beta1.NodeModulesConfig) map[types.NamespacedName]kmmv1beta1.ModuleConfig {
-	statusLabels := make(map[types.NamespacedName]kmmv1beta1.ModuleConfig)
-
-	for _, module := range nmc.Status.Modules {
-		label := types.NamespacedName{Namespace: module.Namespace, Name: module.Name}
-		statusLabels[label] = module.Config
-	}
-	return statusLabels
-}
-
 func (h *nmcReconcilerHelperImpl) UpdateNodeLabels(ctx context.Context, nmc *kmmv1beta1.NodeModulesConfig, node *v1.Node) ([]types.NamespacedName, []types.NamespacedName, error) {
 
 	// get all the kernel module ready labels of the node
@@ -667,20 +612,30 @@ func (h *nmcReconcilerHelperImpl) UpdateNodeLabels(ctx context.Context, nmc *kmm
 	// get status labels and their config
 	statusLabels := h.lph.getStatusLabelsAndTheirConfigs(nmc)
 
+	// get the versions per the name/namespace of the module
+	statusVersions := h.lph.getStatusVersions(nmc)
+
 	// label in node but not in spec or status - should be removed
 	nsnLabelsToBeRemoved := h.lph.removeOrphanedLabels(nodeModuleReadyLabels, specLabels, statusLabels)
 
 	// label in spec and status and config equal - should be added
 	nsnLabelsToBeLoaded := h.lph.addEqualLabels(nodeModuleReadyLabels, specLabels, statusLabels)
 
-	var loadedLabels []string
-	unloadedLabels := deprecatedNodeModuleReadyLabels.UnsortedList()
+	loadedLabels := make(map[string]string)
+	unloadedLabels := deprecatedNodeModuleReadyLabels
 
 	for _, label := range nsnLabelsToBeRemoved {
-		unloadedLabels = append(unloadedLabels, utils.GetKernelModuleReadyNodeLabel(label.Namespace, label.Name))
+		unloadedLabels[utils.GetKernelModuleReadyNodeLabel(label.Namespace, label.Name)] = ""
+		// unload the kernel ready version label also. if it does not exists, that's ok, the code won't fail.It also means
+		// that the version label will not be in labelsToAdd, since status and spec are missing
+		unloadedLabels[utils.GetKernelModuleVersionReadyNodeLabel(label.Namespace, label.Name)] = ""
 	}
+
 	for _, label := range nsnLabelsToBeLoaded {
-		loadedLabels = append(loadedLabels, utils.GetKernelModuleReadyNodeLabel(label.Namespace, label.Name))
+		loadedLabels[utils.GetKernelModuleReadyNodeLabel(label.Namespace, label.Name)] = ""
+		if version, ok := statusVersions[label]; ok {
+			loadedLabels[utils.GetKernelModuleVersionReadyNodeLabel(label.Namespace, label.Name)] = version
+		}
 	}
 
 	if err := h.nodeAPI.UpdateLabels(ctx, node, loadedLabels, unloadedLabels); err != nil {
@@ -711,6 +666,75 @@ func (h *nmcReconcilerHelperImpl) RecordEvents(node *v1.Node, loadedModules, unl
 			nsn.String(),
 		)
 	}
+}
+
+type labelPreparationHelper interface {
+	getDeprecatedKernelModuleReadyLabels(node v1.Node) map[string]string
+	getNodeKernelModuleReadyLabels(node v1.Node) sets.Set[types.NamespacedName]
+	getSpecLabelsAndTheirConfigs(nmc *kmmv1beta1.NodeModulesConfig) map[types.NamespacedName]kmmv1beta1.ModuleConfig
+	getStatusLabelsAndTheirConfigs(nmc *kmmv1beta1.NodeModulesConfig) map[types.NamespacedName]kmmv1beta1.ModuleConfig
+	getStatusVersions(nmc *kmmv1beta1.NodeModulesConfig) map[types.NamespacedName]string
+	addEqualLabels(nodeModuleReadyLabels sets.Set[types.NamespacedName],
+		specLabels, statusLabels map[types.NamespacedName]kmmv1beta1.ModuleConfig) []types.NamespacedName
+	removeOrphanedLabels(nodeModuleReadyLabels sets.Set[types.NamespacedName],
+		specLabels, statusLabels map[types.NamespacedName]kmmv1beta1.ModuleConfig) []types.NamespacedName
+}
+type labelPreparationHelperImpl struct{}
+
+func newLabelPreparationHelper() labelPreparationHelper {
+	return &labelPreparationHelperImpl{}
+}
+
+func (lph *labelPreparationHelperImpl) getNodeKernelModuleReadyLabels(node v1.Node) sets.Set[types.NamespacedName] {
+	nodeModuleReadyLabels := sets.New[types.NamespacedName]()
+
+	for label := range node.GetLabels() {
+		if ok, namespace, name := utils.IsKernelModuleReadyNodeLabel(label); ok {
+			nodeModuleReadyLabels.Insert(types.NamespacedName{Namespace: namespace, Name: name})
+		}
+	}
+	return nodeModuleReadyLabels
+}
+
+func (lph *labelPreparationHelperImpl) getDeprecatedKernelModuleReadyLabels(node v1.Node) map[string]string {
+	deprecatedLabels := make(map[string]string)
+
+	for key, val := range node.GetLabels() {
+		if utils.IsDeprecatedKernelModuleReadyNodeLabel(key) {
+			deprecatedLabels[key] = val
+		}
+	}
+	return deprecatedLabels
+}
+
+func (lph *labelPreparationHelperImpl) getSpecLabelsAndTheirConfigs(nmc *kmmv1beta1.NodeModulesConfig) map[types.NamespacedName]kmmv1beta1.ModuleConfig {
+	specLabels := make(map[types.NamespacedName]kmmv1beta1.ModuleConfig)
+
+	for _, module := range nmc.Spec.Modules {
+		specLabels[types.NamespacedName{Namespace: module.Namespace, Name: module.Name}] = module.Config
+	}
+	return specLabels
+}
+
+func (lph *labelPreparationHelperImpl) getStatusLabelsAndTheirConfigs(nmc *kmmv1beta1.NodeModulesConfig) map[types.NamespacedName]kmmv1beta1.ModuleConfig {
+	statusLabels := make(map[types.NamespacedName]kmmv1beta1.ModuleConfig)
+
+	for _, module := range nmc.Status.Modules {
+		label := types.NamespacedName{Namespace: module.Namespace, Name: module.Name}
+		statusLabels[label] = module.Config
+	}
+	return statusLabels
+}
+
+func (lph *labelPreparationHelperImpl) getStatusVersions(nmc *kmmv1beta1.NodeModulesConfig) map[types.NamespacedName]string {
+	versions := make(map[types.NamespacedName]string)
+
+	for _, module := range nmc.Status.Modules {
+		if module.Version != "" {
+			versions[types.NamespacedName{Namespace: module.Namespace, Name: module.Name}] = module.Version
+		}
+	}
+	return versions
 }
 
 func (lph *labelPreparationHelperImpl) removeOrphanedLabels(nodeModuleReadyLabels sets.Set[types.NamespacedName],

--- a/internal/controllers/nmc_reconciler_test.go
+++ b/internal/controllers/nmc_reconciler_test.go
@@ -164,8 +164,8 @@ var _ = Describe("NodeModulesConfigReconciler_Reconcile", func() {
 			),
 			wh.EXPECT().SyncStatus(ctx, nmc, &node),
 			nm.EXPECT().IsNodeSchedulable(&node, nil).Return(false),
-			nm.EXPECT().UpdateLabels(ctx, &node, nil, []string{kmodName}).DoAndReturn(
-				func(_ context.Context, obj ctrlclient.Object, _, _ []string) error {
+			nm.EXPECT().UpdateLabels(ctx, &node, nil, map[string]string{kmodName: ""}).DoAndReturn(
+				func(_ context.Context, obj ctrlclient.Object, _, _ map[string]string) error {
 					delete(node.ObjectMeta.Labels, kmodName)
 					return nil
 				},
@@ -220,8 +220,8 @@ var _ = Describe("NodeModulesConfigReconciler_Reconcile", func() {
 			),
 			wh.EXPECT().SyncStatus(ctx, nmc, &node),
 			nm.EXPECT().IsNodeSchedulable(&node, nil).Return(false),
-			nm.EXPECT().UpdateLabels(ctx, &node, nil, []string{kmodName}).DoAndReturn(
-				func(_ context.Context, obj ctrlclient.Object, _, _ []string) error {
+			nm.EXPECT().UpdateLabels(ctx, &node, nil, map[string]string{kmodName: ""}).DoAndReturn(
+				func(_ context.Context, obj ctrlclient.Object, _, _ map[string]string) error {
 					return fmt.Errorf("some error")
 				},
 			),
@@ -1236,6 +1236,7 @@ var _ = Describe("nmcReconcilerHelperImpl_SyncStatus", func() {
 			mockWorkerPodManager.EXPECT().IsUnloaderPod(&p).Return(false),
 			mockWorkerPodManager.EXPECT().GetConfigAnnotation(&p).Return(string(b)),
 			mockWorkerPodManager.EXPECT().GetTolerationsAnnotation(&p).Return(string(tolerations)),
+			mockWorkerPodManager.EXPECT().GetModuleVersionAnnotation(&p).Return("some version"),
 			kubeClient.EXPECT().Status().Return(sw),
 			sw.EXPECT().Patch(ctx, nmc, gomock.Any()),
 			mockWorkerPodManager.EXPECT().DeletePod(ctx, &p),
@@ -1256,6 +1257,7 @@ var _ = Describe("nmcReconcilerHelperImpl_SyncStatus", func() {
 				Namespace:          modNamespace,
 				ServiceAccountName: serviceAccountName,
 				Tolerations:        []v1.Toleration{testToleration},
+				Version:            "some version",
 			},
 			Config: cfg,
 		}
@@ -1376,15 +1378,17 @@ var kernelModuleLabelName = utils.GetKernelModuleReadyNodeLabel(moduleNamespace,
 
 var _ = Describe("nmcReconcilerHelperImpl_UpdateNodeLabels", func() {
 	var (
-		ctx             context.Context
-		client          *testclient.MockClient
-		fakeRecorder    *record.FakeRecorder
-		n               *node.MockNode
-		nmc             kmmv1beta1.NodeModulesConfig
-		wh              nmcReconcilerHelper
-		mlph            *MocklabelPreparationHelper
-		firstLabelName  string
-		secondLabelName string
+		ctx                    context.Context
+		client                 *testclient.MockClient
+		fakeRecorder           *record.FakeRecorder
+		n                      *node.MockNode
+		nmc                    kmmv1beta1.NodeModulesConfig
+		wh                     nmcReconcilerHelper
+		mlph                   *MocklabelPreparationHelper
+		firstLabelName         string
+		secondLabelName        string
+		firstVersionLabelName  string
+		secondVersionLabelName string
 	)
 
 	BeforeEach(func() {
@@ -1425,6 +1429,8 @@ var _ = Describe("nmcReconcilerHelperImpl_UpdateNodeLabels", func() {
 		}
 		firstLabelName = fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.ready", nsFirst, nameFirst)
 		secondLabelName = fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.ready", nsSecond, nameSecond)
+		firstVersionLabelName = fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.version.ready", nsFirst, nameFirst)
+		secondVersionLabelName = fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.version.ready", nsSecond, nameSecond)
 	})
 
 	It("failed to get node", func() {
@@ -1446,17 +1452,18 @@ var _ = Describe("nmcReconcilerHelperImpl_UpdateNodeLabels", func() {
 
 		gomock.InOrder(
 			mlph.EXPECT().getNodeKernelModuleReadyLabels(node).Return(emptySet),
-			mlph.EXPECT().getDeprecatedKernelModuleReadyLabels(node).Return(sets.Set[string]{}),
+			mlph.EXPECT().getDeprecatedKernelModuleReadyLabels(node).Return(map[string]string{}),
 			mlph.EXPECT().getSpecLabelsAndTheirConfigs(&nmc).Return(emptyMap),
 			mlph.EXPECT().getStatusLabelsAndTheirConfigs(&nmc).Return(emptyMap),
+			mlph.EXPECT().getStatusVersions(&nmc).Return(map[types.NamespacedName]string{}),
 			mlph.EXPECT().removeOrphanedLabels(emptySet, emptyMap, emptyMap).Return([]types.NamespacedName{{Name: nameSecond, Namespace: nsSecond}}),
 			mlph.EXPECT().addEqualLabels(emptySet, emptyMap, emptyMap).Return([]types.NamespacedName{{Name: nameFirst, Namespace: nsFirst}}),
 			n.EXPECT().
 				UpdateLabels(
 					ctx,
 					&node,
-					[]string{firstLabelName},
-					[]string{secondLabelName},
+					map[string]string{firstLabelName: ""},
+					map[string]string{secondLabelName: "", secondVersionLabelName: ""},
 				).Return(fmt.Errorf("some error")),
 		)
 		_, _, err := wh.UpdateNodeLabels(ctx, &nmc, &node)
@@ -1473,20 +1480,23 @@ var _ = Describe("nmcReconcilerHelperImpl_UpdateNodeLabels", func() {
 		}
 		emptySet := sets.Set[types.NamespacedName]{}
 		emptyMap := map[types.NamespacedName]kmmv1beta1.ModuleConfig{}
+		firstNN := types.NamespacedName{Name: nameFirst, Namespace: nsFirst}
+		secondNN := types.NamespacedName{Name: nameSecond, Namespace: nsSecond}
 
 		gomock.InOrder(
 			mlph.EXPECT().getNodeKernelModuleReadyLabels(node).Return(emptySet),
-			mlph.EXPECT().getDeprecatedKernelModuleReadyLabels(node).Return(sets.Set[string]{}),
+			mlph.EXPECT().getDeprecatedKernelModuleReadyLabels(node).Return(map[string]string{}),
 			mlph.EXPECT().getSpecLabelsAndTheirConfigs(&nmc).Return(emptyMap),
 			mlph.EXPECT().getStatusLabelsAndTheirConfigs(&nmc).Return(emptyMap),
-			mlph.EXPECT().removeOrphanedLabels(emptySet, emptyMap, emptyMap).Return([]types.NamespacedName{{Name: nameSecond, Namespace: nsSecond}}),
-			mlph.EXPECT().addEqualLabels(emptySet, emptyMap, emptyMap).Return([]types.NamespacedName{{Name: nameFirst, Namespace: nsFirst}}),
+			mlph.EXPECT().getStatusVersions(&nmc).Return(map[types.NamespacedName]string{firstNN: "some version"}),
+			mlph.EXPECT().removeOrphanedLabels(emptySet, emptyMap, emptyMap).Return([]types.NamespacedName{secondNN}),
+			mlph.EXPECT().addEqualLabels(emptySet, emptyMap, emptyMap).Return([]types.NamespacedName{firstNN}),
 			n.EXPECT().
 				UpdateLabels(
 					ctx,
 					&node,
-					[]string{firstLabelName},
-					[]string{secondLabelName},
+					map[string]string{firstLabelName: "", firstVersionLabelName: "some version"},
+					map[string]string{secondLabelName: "", secondVersionLabelName: ""},
 				).Return(nil),
 		)
 		_, _, err := wh.UpdateNodeLabels(ctx, &nmc, &node)
@@ -1764,7 +1774,7 @@ var _ = Describe("getDeprecatedKernelModuleReadyLabels", func() {
 
 	lph := newLabelPreparationHelper()
 	DescribeTable("getDeprecatedKernelModuleReadyLabels different scenarios", func(labels map[string]string,
-		deprecatedNodeModuleReadyLabelsEqual sets.Set[string]) {
+		deprecatedNodeModuleReadyLabelsEqual map[string]string) {
 		node := v1.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: labels,
@@ -1776,16 +1786,16 @@ var _ = Describe("getDeprecatedKernelModuleReadyLabels", func() {
 		Expect(deprecatedNodeModuleReadyLabels).To(Equal(deprecatedNodeModuleReadyLabelsEqual))
 	},
 		Entry("Should be empty", map[string]string{},
-			sets.Set[string]{},
+			map[string]string{},
 		),
 
 		Entry("deprecated node module ready labels not found", map[string]string{"invalid": ""},
-			sets.Set[string]{},
+			map[string]string{},
 		),
 
 		Entry("deprecated node module ready labels found", map[string]string{fmt.Sprintf("kmm.node.kubernetes.io/%s.ready", nameFirst): ""},
-			sets.Set[string]{
-				fmt.Sprintf("kmm.node.kubernetes.io/%s.ready", nameFirst): {},
+			map[string]string{
+				fmt.Sprintf("kmm.node.kubernetes.io/%s.ready", nameFirst): "",
 			},
 		),
 	)

--- a/internal/nmc/helper.go
+++ b/internal/nmc/helper.go
@@ -70,6 +70,7 @@ func (h *helper) SetModuleConfig(
 	foundEntry.ImageRepoSecret = mld.ImageRepoSecret
 	foundEntry.ServiceAccountName = saName
 	foundEntry.Tolerations = mld.Tolerations
+	foundEntry.Version = mld.ModuleVersion
 
 	return nil
 }

--- a/internal/node/mock_node.go
+++ b/internal/node/mock_node.go
@@ -98,7 +98,7 @@ func (mr *MockNodeMockRecorder) IsNodeSchedulable(node, tolerations any) *gomock
 }
 
 // UpdateLabels mocks base method.
-func (m *MockNode) UpdateLabels(ctx context.Context, node *v1.Node, toBeAdded, toBeRemoved []string) error {
+func (m *MockNode) UpdateLabels(ctx context.Context, node *v1.Node, toBeAdded, toBeRemoved map[string]string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateLabels", ctx, node, toBeAdded, toBeRemoved)
 	ret0, _ := ret[0].(error)

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -15,7 +15,7 @@ type Node interface {
 	IsNodeSchedulable(node *v1.Node, tolerations []v1.Toleration) bool
 	GetNodesListBySelector(ctx context.Context, selector map[string]string, tolerations []v1.Toleration) ([]v1.Node, error)
 	GetNumTargetedNodes(ctx context.Context, selector map[string]string, tolerations []v1.Toleration) (int, error)
-	UpdateLabels(ctx context.Context, node *v1.Node, toBeAdded, toBeRemoved []string) error
+	UpdateLabels(ctx context.Context, node *v1.Node, toBeAdded, toBeRemoved map[string]string) error
 	IsNodeRebooted(node *v1.Node, statusBootId string) bool
 }
 
@@ -72,7 +72,7 @@ func (n *node) GetNumTargetedNodes(ctx context.Context, selector map[string]stri
 	return len(targetedNode), nil
 }
 
-func (n *node) UpdateLabels(ctx context.Context, node *v1.Node, toBeAdded, toBeRemoved []string) error {
+func (n *node) UpdateLabels(ctx context.Context, node *v1.Node, toBeAdded, toBeRemoved map[string]string) error {
 	patchFrom := client.MergeFrom(node.DeepCopy())
 
 	addLabels(node, toBeAdded)
@@ -95,18 +95,18 @@ func (n *node) IsNodeRebooted(node *v1.Node, statusBootId string) bool {
 	return false
 }
 
-func addLabels(node *v1.Node, labels []string) {
-	for _, label := range labels {
+func addLabels(node *v1.Node, labels map[string]string) {
+	for label, value := range labels {
 		meta.SetLabel(
 			node,
 			label,
-			"",
+			value,
 		)
 	}
 }
 
-func removeLabels(node *v1.Node, labels []string) {
-	for _, label := range labels {
+func removeLabels(node *v1.Node, labels map[string]string) {
+	for label := range labels {
 		meta.RemoveLabel(
 			node,
 			label,

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -186,8 +186,8 @@ var _ = Describe("UpdateLabels", func() {
 				Labels: map[string]string{},
 			},
 		}
-		loaded := []string{firstloadedKernelModuleReadyNodeLabel}
-		unloaded := []string{unloadedKernelModuleReadyNodeLabel}
+		loaded := map[string]string{firstloadedKernelModuleReadyNodeLabel: ""}
+		unloaded := map[string]string{unloadedKernelModuleReadyNodeLabel: ""}
 
 		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
@@ -202,8 +202,8 @@ var _ = Describe("UpdateLabels", func() {
 				Labels: map[string]string{},
 			},
 		}
-		loaded := []string{firstloadedKernelModuleReadyNodeLabel}
-		unloaded := []string{unloadedKernelModuleReadyNodeLabel}
+		loaded := map[string]string{firstloadedKernelModuleReadyNodeLabel: ""}
+		unloaded := map[string]string{unloadedKernelModuleReadyNodeLabel: ""}
 
 		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
 
@@ -329,7 +329,7 @@ var _ = Describe("removeLabels", func() {
 	})
 
 	It("Should remove labels", func() {
-		labels := []string{firstloadedKernelModuleReadyNodeLabel}
+		labels := map[string]string{firstloadedKernelModuleReadyNodeLabel: ""}
 		removeLabels(&node, labels)
 		Expect(node.Labels).ToNot(HaveKey(firstloadedKernelModuleReadyNodeLabel))
 	})

--- a/internal/pod/mock_workerpodmanager.go
+++ b/internal/pod/mock_workerpodmanager.go
@@ -97,6 +97,20 @@ func (mr *MockWorkerPodManagerMockRecorder) GetConfigAnnotation(p any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfigAnnotation", reflect.TypeOf((*MockWorkerPodManager)(nil).GetConfigAnnotation), p)
 }
 
+// GetModuleVersionAnnotation mocks base method.
+func (m *MockWorkerPodManager) GetModuleVersionAnnotation(p *v1.Pod) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetModuleVersionAnnotation", p)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetModuleVersionAnnotation indicates an expected call of GetModuleVersionAnnotation.
+func (mr *MockWorkerPodManagerMockRecorder) GetModuleVersionAnnotation(p any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetModuleVersionAnnotation", reflect.TypeOf((*MockWorkerPodManager)(nil).GetModuleVersionAnnotation), p)
+}
+
 // GetTolerationsAnnotation mocks base method.
 func (m *MockWorkerPodManager) GetTolerationsAnnotation(p *v1.Pod) string {
 	m.ctrl.T.Helper()

--- a/internal/utils/kmmlabels.go
+++ b/internal/utils/kmmlabels.go
@@ -76,6 +76,10 @@ func GetKernelModuleReadyNodeLabel(namespace, moduleName string) string {
 	return fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.ready", namespace, moduleName)
 }
 
+func GetKernelModuleVersionReadyNodeLabel(namespace, moduleName string) string {
+	return fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.version.ready", namespace, moduleName)
+}
+
 func GetDevicePluginNodeLabel(namespace, moduleName string) string {
 	return fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.device-plugin-ready", namespace, moduleName)
 }


### PR DESCRIPTION
Currently we have only one "ready" label to signify that the kernel module is loaded successfuly. In order upgrade scenario, the user needs to know that the loaded module is actually the one with the targeted module version, in order to coordinated further actions. This PR introduces a new label: kmm.node.kubernetes.io/%s.%s.version.ready, whose value will signify the version of the currently loaded kernel module.
The changes in the code are:
1. Adding Version field both to status and spec of NMC (will be used to construct the new label)
2. Polulating the Version field of the NCM's spec during NMC update/create
3. Adding the "version" annotation to the worker pod, so that the version may be extracted for NMC's status
4. Changing the Node package API to receive maps instead of slice for labels to be added/remove. This is done since now we must also update the value of the label, and not just the key
5. Rewrite the UpdateNodeLabel function in the NMC controller to support new flow and new Node API
6. In case "ready" label is removed, we also automaticaly remove "version.ready" label. If it does not exists - nothing happens
7. In case "ready" label needs to be added, we check if the version field exists in the NMC status, and if it does, then we add the "version.ready" label with appropriate value