### PR TITLE
Updating the Gitstream configuration to a more recent date.

### DIFF
--- a/.github/gitstream.yml
+++ b/.github/gitstream.yml
@@ -11,7 +11,7 @@ downstream:
 log_level: 1000
 
 diff:
-  commits_since: 2022-08-31T00:00:00.00Z
+  commits_since: 2025-11-01T00:00:00.00Z
 
 sync:
   before_commit:


### PR DESCRIPTION
In the Gitstream configuration, we configure the date from which we start cherry-picking commits.

Some packages has been updated in the Gitsream project which make it cherry-pick very old commits.

Hopefully, setting a new "base date" should resolve this issue.

---

/assign @yevgeny-shnaidman @TomerNewman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build configuration to optimize workflow processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->