### PR TITLE
Adding more explicit documentation regarding the node's ready label.

### DIFF
--- a/docs/mkdocs/documentation/deploy_kmod.md
+++ b/docs/mkdocs/documentation/deploy_kmod.md
@@ -14,6 +14,11 @@ on the target node(s) to run the necessary action.
 The operator monitors the outcome of those Pods and records that information.
 It uses it to label `Node` objects when the module was successfully loaded, and to run the device plugin (if
 configured).
+The label can be found in the node's label with the following format:
+```
+kmm.node.kubernetes.io/<namespace>.<modulename>.ready
+```
+but it is strongly recommended to use `GetKernelModuleReadyNodeLabel` function from the `labels` package in order to construct the correct label
 
 ### Worker Pods
 


### PR DESCRIPTION
---

/assign @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment documentation with information about kernel module readiness node labels
  * Added guidance on the node label format for kernel module readiness detection and best practices for constructing labels correctly

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->