### PR TITLE
adding public API for additional labels

### DIFF
--- a/docs/mkdocs/documentation/ordered_upgrade.md
+++ b/docs/mkdocs/documentation/ordered_upgrade.md
@@ -50,11 +50,15 @@ Steps 3, 4 and 5 are then unified into one step: update the
 `kmm.node.kubernetes.io/version-module.<module-namespace>.<module-name>` label value to new `$moduleVersion` as set in
 the `Module`.
 
+It is strongly recommended to use `GetModuleVersionLabelName` function from the `labels` package in order to construct the correct label used in the step 1
+of the upgrade flow
+
 ### Indicator that the new version is ready to be used
 
 The operator will label the node with a "version.ready" label to indicate that the new version of the kernel module is loaded
 and ready to be used:
 `kmm.node.kubernetes.io/<module-namespace>.<module-name>.version.ready=<module-version>`
+It is strongly recommended to use `GetKernelModuleVersionReadyNodeLabel` function from the `labels` package in order to construct the correct label
 
 ## Implementation details
 

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -11,3 +11,11 @@ func GetKernelModuleReadyNodeLabel(namespace, moduleName string) string {
 func GetDevicePluginNodeLabel(namespace, moduleName string) string {
 	return utils.GetDevicePluginNodeLabel(namespace, moduleName)
 }
+
+func GetModuleVersionLabelName(namespace, name string) string {
+	return utils.GetModuleVersionLabelName(namespace, name)
+}
+
+func GetKernelModuleVersionReadyNodeLabel(namespace, moduleName string) string {
+	return utils.GetKernelModuleVersionReadyNodeLabel(namespace, moduleName)
+}

--- a/pkg/labels/labels_test.go
+++ b/pkg/labels/labels_test.go
@@ -15,4 +15,15 @@ var _ = Describe("GetModuleReadyAndDevicePluginReadyLabels", func() {
 		res := GetDevicePluginNodeLabel("some-namespace", "some-module")
 		Expect(res).To(Equal("kmm.node.kubernetes.io/some-namespace.some-module.device-plugin-ready"))
 	})
+
+	It("module version label", func() {
+		res := GetModuleVersionLabelName("some-namespace", "some-module")
+		Expect(res).To(Equal("kmm.node.kubernetes.io/version-module.some-namespace.some-module"))
+	})
+
+	It("module version ready label", func() {
+		res := GetKernelModuleVersionReadyNodeLabel("some-namespace", "some-module")
+		Expect(res).To(Equal("kmm.node.kubernetes.io/some-namespace.some-module.version.ready"))
+	})
+
 })


### PR DESCRIPTION
adding public API that can be used by KMM's user:
1. API to get the module version label format
2. API to get the module version ready label format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two helper functions for label construction in the labels package.

* **Documentation**
  * Updated upgrade flow documentation with recommendations for using provided label helper functions.

* **Tests**
  * Added test coverage for new label helper functions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->