### PR TITLE
harden container securityContext

### DIFF
--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2026-01-19T09:24:17Z"
+    createdAt: "2026-01-19T12:38:02Z"
     operatorframework.io/suggested-namespace: openshift-kmm-hub
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -312,6 +312,10 @@ spec:
                     memory: 64Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  readOnlyRootFilesystem: true
                 volumeMounts:
                 - mountPath: /certs
                   name: metrics-tls
@@ -409,6 +413,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: kmm-operator-hub-controller

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -47,7 +47,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2026-01-19T09:20:55Z"
+    createdAt: "2026-01-19T12:38:02Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -421,6 +421,10 @@ spec:
                     memory: 64Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+                  readOnlyRootFilesystem: true
                 volumeMounts:
                 - mountPath: /certs
                   name: metrics-tls
@@ -520,6 +524,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
               securityContext:
                 runAsNonRoot: true
               serviceAccountName: kmm-operator-controller

--- a/config/manager-base/manager.yaml
+++ b/config/manager-base/manager.yaml
@@ -55,6 +55,9 @@ spec:
             value: signer
         securityContext:
           allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: [ALL]
         livenessProbe:
           httpGet:
             path: /healthz

--- a/config/webhook-server/deployment.yaml
+++ b/config/webhook-server/deployment.yaml
@@ -44,6 +44,7 @@ spec:
           args: [--config=kmm-operator-manager-config]
           securityContext:
             allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
             capabilities:
               drop: [ALL]
           livenessProbe:


### PR DESCRIPTION
Add security settings to manager and webhook-server containers:
- readOnlyRootFilesystem: true - prevents filesystem tampering
- capabilities.drop: [ALL] - removes privileged kernel operations

---

fixes #1726

---

/cc @ybettan @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced container security by restricting system capabilities and enabling read-only root filesystems across manager, webhook-server, and operator components to strengthen security posture and reduce attack surface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->