### PR TITLE
Fix in-tree module dependency docs

### DIFF
--- a/internal/pod/workerpodmanager.go
+++ b/internal/pod/workerpodmanager.go
@@ -332,8 +332,7 @@ func (wpmi *workerPodManagerImpl) baseWorkerPod(ctx context.Context, nmc client.
 	moduleConfig *kmmv1beta1.ModuleConfig) (*v1.Pod, error) {
 
 	const (
-		volNameLibModules    = "lib-modules"
-		volNameUsrLibModules = "usr-lib-modules"
+		volNameLibModules = "lib-modules"
 	)
 
 	hostPathDirectory := v1.HostPathDirectory
@@ -364,15 +363,6 @@ func (wpmi *workerPodManagerImpl) baseWorkerPod(ctx context.Context, nmc client.
 			},
 		},
 		{
-			Name: volNameUsrLibModules,
-			VolumeSource: v1.VolumeSource{
-				HostPath: &v1.HostPathVolumeSource{
-					Path: "/usr/lib/modules",
-					Type: &hostPathDirectory,
-				},
-			},
-		},
-		{
 			Name: volNameTmp,
 			VolumeSource: v1.VolumeSource{
 				EmptyDir: &v1.EmptyDirVolumeSource{},
@@ -389,11 +379,6 @@ func (wpmi *workerPodManagerImpl) baseWorkerPod(ctx context.Context, nmc client.
 		{
 			Name:      volNameLibModules,
 			MountPath: "/lib/modules",
-			ReadOnly:  true,
-		},
-		{
-			Name:      volNameUsrLibModules,
-			MountPath: "/usr/lib/modules",
 			ReadOnly:  true,
 		},
 		{

--- a/internal/pod/workerpodmanager_test.go
+++ b/internal/pod/workerpodmanager_test.go
@@ -433,7 +433,6 @@ func getBaseWorkerPod(subcommand string, owner ctrlclient.Object, firmwareHostPa
 
 	const (
 		volNameLibModules     = "lib-modules"
-		volNameUsrLibModules  = "usr-lib-modules"
 		volNameVarLibFirmware = "lib-firmware"
 	)
 
@@ -552,11 +551,6 @@ cp -R /firmware-path/* /tmp/firmware-path;
 							ReadOnly:  true,
 						},
 						{
-							Name:      volNameUsrLibModules,
-							MountPath: "/usr/lib/modules",
-							ReadOnly:  true,
-						},
-						{
 							Name:      volNameTmp,
 							MountPath: sharedFilesDir,
 							ReadOnly:  true,
@@ -593,15 +587,6 @@ cp -R /firmware-path/* /tmp/firmware-path;
 					VolumeSource: v1.VolumeSource{
 						HostPath: &v1.HostPathVolumeSource{
 							Path: "/lib/modules",
-							Type: &hostPathDirectory,
-						},
-					},
-				},
-				{
-					Name: volNameUsrLibModules,
-					VolumeSource: v1.VolumeSource{
-						HostPath: &v1.HostPathVolumeSource{
-							Path: "/usr/lib/modules",
 							Type: &hostPathDirectory,
 						},
 					},


### PR DESCRIPTION
The docs incorrectly said `/lib/modules` is mounted into build pods - it's only mounted into worker pods.
Added the missing COPY instruction that users need to make depmod work at build time (mounting the `/lib/modules` from the DTK image).

Additionally removing `usr` mount volume from worker pod.


---

fixes #1739 

---

/cc @yevgeny-shnaidman @ybettan 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Run depmod in the final build stage; use /lib/modules and /opt/lib/modules in examples and symlink guidance; clarify depmod relies on modules present in the build image.
* **Bug Fixes**
  * Pod definition and tests now mount only /lib/modules (removed separate /usr/lib/modules mount), simplifying module host-to-container handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->