### PR TITLE
Adding internal tolerations support

### DIFF
--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -155,7 +155,7 @@ func (mr *ModuleReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.Modul
 	}
 
 	// get nodes targeted by selector
-	targetedNodes, err := mr.nodeAPI.GetNodesListBySelector(ctx, mod.Spec.Selector, mod.Spec.Tolerations)
+	targetedNodes, err := mr.nodeAPI.GetNodesListBySelector(ctx, mod.Spec.Selector, append(mod.Spec.Tolerations, module.InternalTolerations...))
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get list of nodes by selector: %v", err)
 	}

--- a/internal/controllers/module_reconciler_test.go
+++ b/internal/controllers/module_reconciler_test.go
@@ -122,10 +122,10 @@ var _ = Describe("Reconcile", func() {
 		}
 		mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, mod).Return(nil)
 		if c.getNodesError {
-			mn.EXPECT().GetNodesListBySelector(ctx, mod.Spec.Selector, nil).Return(nil, returnedError)
+			mn.EXPECT().GetNodesListBySelector(ctx, mod.Spec.Selector, module.InternalTolerations).Return(nil, returnedError)
 			goto executeTestFunction
 		}
-		mn.EXPECT().GetNodesListBySelector(ctx, mod.Spec.Selector, nil).Return(targetedNodes, nil)
+		mn.EXPECT().GetNodesListBySelector(ctx, mod.Spec.Selector, module.InternalTolerations).Return(targetedNodes, nil)
 		if c.handleMICError {
 			mockReconHelper.EXPECT().handleMIC(ctx, mod, targetedNodes).Return(returnedError)
 			goto executeTestFunction
@@ -186,7 +186,7 @@ var _ = Describe("Reconcile", func() {
 			mockReconHelper.EXPECT().handleNetworkPolicies(ctx, mod).Return(nil),
 			mockNamespaceHelper.EXPECT().setLabel(ctx, mod.Namespace),
 			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, mod).Return(nil),
-			mn.EXPECT().GetNodesListBySelector(ctx, mod.Spec.Selector, nil).Return(targetedNodes, nil),
+			mn.EXPECT().GetNodesListBySelector(ctx, mod.Spec.Selector, module.InternalTolerations).Return(targetedNodes, nil),
 			mockReconHelper.EXPECT().handleMIC(ctx, mod, targetedNodes).Return(nil),
 			mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, mod).Return(currentNMCs, nil),
 			mockReconHelper.EXPECT().prepareSchedulingData(ctx, mod, targetedNodes, currentNMCs).Return(nmcMLDConfigs, nil),
@@ -206,7 +206,7 @@ var _ = Describe("Reconcile", func() {
 			mockReconHelper.EXPECT().handleNetworkPolicies(ctx, mod).Return(nil),
 			mockNamespaceHelper.EXPECT().setLabel(ctx, mod.Namespace),
 			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, mod).Return(nil),
-			mn.EXPECT().GetNodesListBySelector(ctx, mod.Spec.Selector, nil).Return(targetedNodes, nil),
+			mn.EXPECT().GetNodesListBySelector(ctx, mod.Spec.Selector, module.InternalTolerations).Return(targetedNodes, nil),
 			mockReconHelper.EXPECT().handleMIC(ctx, mod, targetedNodes).Return(nil),
 			mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, mod).Return(currentNMCs, nil),
 			mockReconHelper.EXPECT().prepareSchedulingData(ctx, mod, targetedNodes, currentNMCs).Return(nmcMLDConfigs, nil),

--- a/internal/module/helper.go
+++ b/internal/module/helper.go
@@ -1,10 +1,29 @@
 package module
 
 import (
+	v1 "k8s.io/api/core/v1"
 	"strings"
 
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
 )
+
+var InternalTolerations = []v1.Toleration{
+	{
+		Key:      v1.TaintNodeDiskPressure,
+		Operator: v1.TolerationOpExists,
+		Effect:   v1.TaintEffectNoSchedule,
+	},
+	{
+		Key:      v1.TaintNodeMemoryPressure,
+		Operator: v1.TolerationOpExists,
+		Effect:   v1.TaintEffectNoSchedule,
+	},
+	{
+		Key:      v1.TaintNodePIDPressure,
+		Operator: v1.TolerationOpExists,
+		Effect:   v1.TaintEffectNoSchedule,
+	},
+}
 
 // AppendToTag adds the specified tag to the image name cleanly, i.e. by avoiding messing up
 // the name or getting "name:-tag"

--- a/internal/module/kernelmapper.go
+++ b/internal/module/kernelmapper.go
@@ -138,7 +138,7 @@ func (kh *kernelMapperHelper) prepareModuleLoaderData(mapping *kmmv1beta1.Kernel
 	mld.Namespace = mod.Namespace
 	mld.ImageRepoSecret = mod.Spec.ImageRepoSecret
 	mld.Selector = mod.Spec.Selector
-	mld.Tolerations = mod.Spec.Tolerations
+	mld.Tolerations = append(mod.Spec.Tolerations, InternalTolerations...)
 	mld.ServiceAccountName = mod.Spec.ModuleLoader.ServiceAccountName
 	mld.Modprobe = mod.Spec.ModuleLoader.Container.Modprobe
 	mld.ModuleVersion = mod.Spec.ModuleLoader.Container.Version

--- a/internal/module/kernelmapper_test.go
+++ b/internal/module/kernelmapper_test.go
@@ -201,6 +201,7 @@ var _ = Describe("prepareModuleLoaderData", func() {
 			ImagePullPolicy:         mod.Spec.ModuleLoader.Container.ImagePullPolicy,
 			KernelVersion:           kernelVersion,
 			KernelNormalizedVersion: kernelVersion,
+			Tolerations:             InternalTolerations,
 		}
 
 		if buildExistsInMapping {
@@ -264,6 +265,7 @@ var _ = Describe("prepareModuleLoaderData", func() {
 			ImagePullPolicy:         mod.Spec.ModuleLoader.Container.ImagePullPolicy,
 			KernelVersion:           kernelVersion,
 			KernelNormalizedVersion: kernelVersion,
+			Tolerations:             InternalTolerations,
 		}
 		mld.RegistryTLS = &mod.Spec.ModuleLoader.Container.RegistryTLS
 		mld.ContainerImage = mod.Spec.ModuleLoader.Container.ContainerImage


### PR DESCRIPTION
There are some taints that can be created by kuberentes on-the-fly: disk-pressure, memory-pressure, pid-pressure. In case node is tainted in such way, it should not cause KMM to unload the kernel module, since it is already loaded, and the effect of those tolerations is NoSchedule. In addition, even in case we are delaing with a kernel module being loaded for the first time, we can proceed, since the whole loading process is a one-time action: pod is created and then destroyed

---

Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1733

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module scheduling to account for additional system resource pressure conditions. Modules can now be deployed across a broader range of cluster nodes, enhancing resource utilization and deployment flexibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->