### PR TITLE
Removing node's ready labels on deletion for Modules with `.` in their name.

### DIFF
--- a/internal/utils/kmmlabels.go
+++ b/internal/utils/kmmlabels.go
@@ -2,15 +2,16 @@ package utils
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	"regexp"
 	"strings"
 
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 )
 
-var reKernelModuleReadyLabel = regexp.MustCompile(`^kmm\.node\.kubernetes\.io/([a-zA-Z0-9-]+)\.([a-zA-Z0-9-]+)\.ready$`)
+var reKernelModuleReadyLabel = regexp.MustCompile(`^kmm\.node\.kubernetes\.io/([a-zA-Z0-9-]+)\.([a-zA-Z0-9-\.]+)\.ready$`)
+var reKernelModuleVersionReadyLabel = regexp.MustCompile(`^kmm\.node\.kubernetes\.io/([a-zA-Z0-9-]+)\.([a-zA-Z0-9-\.]+)\.version\.ready$`)
 var reDeprecatedKernelModuleReadyLabel = regexp.MustCompile(`^kmm\.node\.kubernetes\.io/[a-zA-Z0-9-]+\.ready$`)
 
 func GetModuleVersionLabelName(namespace, name string) string {
@@ -88,7 +89,20 @@ func IsDeprecatedKernelModuleReadyNodeLabel(label string) bool {
 	return reDeprecatedKernelModuleReadyLabel.MatchString(label)
 }
 
+func IsKernelModuleVersionReadyNodeLabel(label string) bool {
+	return reKernelModuleVersionReadyLabel.MatchString(label)
+}
+
 func IsKernelModuleReadyNodeLabel(label string) (bool, string, string) {
+
+	if IsDeprecatedKernelModuleReadyNodeLabel(label) {
+		return false, "", ""
+	}
+
+	if IsKernelModuleVersionReadyNodeLabel(label) {
+		return false, "", ""
+	}
+
 	matches := reKernelModuleReadyLabel.FindStringSubmatch(label)
 
 	if len(matches) != 3 {

--- a/internal/utils/kmmlabels_test.go
+++ b/internal/utils/kmmlabels_test.go
@@ -65,6 +65,23 @@ var _ = Describe("IsDeprecatedKernelModuleReadyNodeLabel", func() {
 	)
 })
 
+var _ = Describe("IsKernelModuleVersionReadyNodeLabel", func() {
+	DescribeTable(
+		"should work as expected",
+		func(input string, expected bool) {
+			Expect(
+				IsKernelModuleVersionReadyNodeLabel(input),
+			).To(
+				Equal(expected),
+			)
+		},
+		Entry(nil, "kmm.node.kubernetes.io/ns.name.version.ready", true),
+		Entry(nil, "kmm.node.kubernetes.io/ns.dot.in.name.version.ready", true),
+		Entry(nil, "kmm.node.kubernetes.io/ns.name.ready", false),
+		Entry(nil, "kmm.node.kubernetes.io/ns.dot.in.name.ready", false),
+	)
+})
+
 var _ = Describe("IsKernelModuleReadyNodeLabel", func() {
 	DescribeTable(
 		"should work as expected",
@@ -90,5 +107,8 @@ var _ = Describe("IsKernelModuleReadyNodeLabel", func() {
 		Entry(nil, "a.b.read", false, "", ""),
 		Entry(nil, "kmm.node.kubernetes.io/a.b.ready", true, "a", "b"),
 		Entry(nil, "kmm.node.kubernetes.io/a1-2b.c3-4d.ready", true, "a1-2b", "c3-4d"),
+		Entry(nil, "kmm.node.kubernetes.io/ns.dot.in.name.ready", true, "ns", "dot.in.name"),
+		Entry(nil, "kmm.node.kubernetes.io/ns.name.version.ready", false, "", ""),
+		Entry(nil, "kmm.node.kubernetes.io/ns.dot.in.name.version.ready", false, "", ""),
 	)
 })


### PR DESCRIPTION
This is a followup commit on 0f5d931bffdb68581f327e7709111dc01359a1f6 in which we removed the NMC labels which are specified in the Module's finalizer and preventing it from being deleted.

This commit is complementing the previous commit by also modifying the regexp used to remove the ready label on the node upon deletion of Modules with a `.` in their name.

---

/assign @TomerNewman @yevgeny-shnaidman 
Fixes https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1736 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for detecting version-ready kernel module labels.

* **Bug Fixes**
  * Improved kernel module readiness detection logic to correctly distinguish between label types and prevent misclassification.

* **Tests**
  * Expanded test coverage for kernel module label detection scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->