### PR TITLE
Add docs for imageRebuildTriggerGeneration field

### DIFF
--- a/docs/mkdocs/documentation/hub_spoke.md
+++ b/docs/mkdocs/documentation/hub_spoke.md
@@ -74,6 +74,8 @@ metadata:
 spec:
   moduleSpec:
     # Contains moduleLoader and devicePlugin sections, just like in a Module resource.
+    # Optional. Change this value to force image re-verification and rebuilds.
+    imageRebuildTriggerGeneration: 1
     selector:
       node-wants-my-mcm: 'true'  # Selects nodes within the ManagedCluster.
 


### PR DESCRIPTION
Document the new imageRebuildTriggerGeneration field that allows users to force KMM to re-verify and rebuild module images when using ephemeral image registries.

---

fix #1735 

---

/cc @ybettan @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the new optional `imageRebuildTriggerGeneration` field for Module and ManagedClusterModule specifications.
  * Added usage examples and behavior documentation explaining how this field enables re-verification and triggering of module image rebuild processes.
  * Updated deployment and hub-spoke configuration reference documentation with consistent implementation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->