### PR TITLE
Add wildcard and glob pattern support for filesToSign in module signing

### DIFF
--- a/api/v1beta1/module_types.go
+++ b/api/v1beta1/module_types.go
@@ -87,7 +87,8 @@ type Sign struct {
 	CertSecret *v1.LocalObjectReference `json:"certSecret"`
 
 	// +optional
-	// paths inside the image for the kernel modules to sign (if ommited all kmods are signed)
+	// Paths inside the image for the kernel modules to sign.
+	// Full path to explicit files are required or any globs supported by the Bash shell
 	FilesToSign []string `json:"filesToSign,omitempty"`
 }
 

--- a/api/v1beta1/moduleimagesconfig_types.go
+++ b/api/v1beta1/moduleimagesconfig_types.go
@@ -57,6 +57,11 @@ type ModuleImageSpec struct {
 	// +optional
 	// RegistryTLS set the TLS configs for accessing the registry of the image.
 	RegistryTLS *TLSOptions `json:"registryTLS,omitempty"`
+
+	// +optional
+	// DirName is the root directory for modules, used during signing.
+	// +kubebuilder:default=/opt
+	DirName string `json:"dirName,omitempty"`
 }
 
 // ModuleImagesConfigSpec describes the images of the Module whose status needs to be verified

--- a/bundle-hub/manifests/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
+++ b/bundle-hub/manifests/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
@@ -2759,9 +2759,9 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     filesToSign:
-                                      description: paths inside the image for the
-                                        kernel modules to sign (if ommited all kmods
-                                        are signed)
+                                      description: |-
+                                        Paths inside the image for the kernel modules to sign.
+                                        Full path to explicit files are required or any globs supported by the Bash shell
                                       items:
                                         type: string
                                       type: array
@@ -2927,8 +2927,9 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               filesToSign:
-                                description: paths inside the image for the kernel
-                                  modules to sign (if ommited all kmods are signed)
+                                description: |-
+                                  Paths inside the image for the kernel modules to sign.
+                                  Full path to explicit files are required or any globs supported by the Bash shell
                                 items:
                                   type: string
                                 type: array

--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2026-01-19T12:38:02Z"
+    createdAt: "2026-02-10T11:50:11Z"
     operatorframework.io/suggested-namespace: openshift-kmm-hub
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle-hub/manifests/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
+++ b/bundle-hub/manifests/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
@@ -162,6 +162,11 @@ spec:
                       required:
                       - dockerfileConfigMap
                       type: object
+                    dirName:
+                      default: /opt
+                      description: DirName is the root directory for modules, used
+                        during signing.
+                      type: string
                     image:
                       description: image
                       type: string
@@ -201,8 +206,9 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         filesToSign:
-                          description: paths inside the image for the kernel modules
-                            to sign (if ommited all kmods are signed)
+                          description: |-
+                            Paths inside the image for the kernel modules to sign.
+                            Full path to explicit files are required or any globs supported by the Bash shell
                           items:
                             type: string
                           type: array

--- a/bundle-hub/manifests/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/bundle-hub/manifests/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -167,6 +167,11 @@ spec:
                       required:
                       - dockerfileConfigMap
                       type: object
+                    dirName:
+                      default: /opt
+                      description: DirName is the root directory for modules, used
+                        during signing.
+                      type: string
                     image:
                       description: image
                       type: string
@@ -206,8 +211,9 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         filesToSign:
-                          description: paths inside the image for the kernel modules
-                            to sign (if ommited all kmods are signed)
+                          description: |-
+                            Paths inside the image for the kernel modules to sign.
+                            Full path to explicit files are required or any globs supported by the Bash shell
                           items:
                             type: string
                           type: array

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -47,7 +47,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2026-01-19T12:38:02Z"
+    createdAt: "2026-02-10T11:50:10Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/manifests/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
+++ b/bundle/manifests/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
@@ -162,6 +162,11 @@ spec:
                       required:
                       - dockerfileConfigMap
                       type: object
+                    dirName:
+                      default: /opt
+                      description: DirName is the root directory for modules, used
+                        during signing.
+                      type: string
                     image:
                       description: image
                       type: string
@@ -201,8 +206,9 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         filesToSign:
-                          description: paths inside the image for the kernel modules
-                            to sign (if ommited all kmods are signed)
+                          description: |-
+                            Paths inside the image for the kernel modules to sign.
+                            Full path to explicit files are required or any globs supported by the Bash shell
                           items:
                             type: string
                           type: array

--- a/bundle/manifests/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/bundle/manifests/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -167,6 +167,11 @@ spec:
                       required:
                       - dockerfileConfigMap
                       type: object
+                    dirName:
+                      default: /opt
+                      description: DirName is the root directory for modules, used
+                        during signing.
+                      type: string
                     image:
                       description: image
                       type: string
@@ -206,8 +211,9 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         filesToSign:
-                          description: paths inside the image for the kernel modules
-                            to sign (if ommited all kmods are signed)
+                          description: |-
+                            Paths inside the image for the kernel modules to sign.
+                            Full path to explicit files are required or any globs supported by the Bash shell
                           items:
                             type: string
                           type: array

--- a/bundle/manifests/kmm.sigs.x-k8s.io_modules.yaml
+++ b/bundle/manifests/kmm.sigs.x-k8s.io_modules.yaml
@@ -2735,8 +2735,9 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 filesToSign:
-                                  description: paths inside the image for the kernel
-                                    modules to sign (if ommited all kmods are signed)
+                                  description: |-
+                                    Paths inside the image for the kernel modules to sign.
+                                    Full path to explicit files are required or any globs supported by the Bash shell
                                   items:
                                     type: string
                                   type: array
@@ -2902,8 +2903,9 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           filesToSign:
-                            description: paths inside the image for the kernel modules
-                              to sign (if ommited all kmods are signed)
+                            description: |-
+                              Paths inside the image for the kernel modules to sign.
+                              Full path to explicit files are required or any globs supported by the Bash shell
                             items:
                               type: string
                             type: array

--- a/ci/e2e-hub/managedclustermodule.yaml
+++ b/ci/e2e-hub/managedclustermodule.yaml
@@ -12,6 +12,7 @@ spec:
       container:
         modprobe:
           moduleName: mod-example
+          dirName: /bin
         imagePullPolicy: Always
         kernelMappings:
         - regexp: '^.+$'

--- a/ci/e2e/module.yaml
+++ b/ci/e2e/module.yaml
@@ -27,6 +27,6 @@ spec:
             unsignedImageRegistryTLS:
               insecure: true
             filesToSign:
-              - /opt/lib/modules/${KERNEL_FULL_VERSION}/kmm_ci_a.ko
+              - /opt/lib/modules/${KERNEL_FULL_VERSION}/kmm_ci_?.ko
   selector:
     task: kmm-ci

--- a/config/crd-hub/bases/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
+++ b/config/crd-hub/bases/hub.kmm.sigs.x-k8s.io_managedclustermodules.yaml
@@ -2755,9 +2755,9 @@ spec:
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     filesToSign:
-                                      description: paths inside the image for the
-                                        kernel modules to sign (if ommited all kmods
-                                        are signed)
+                                      description: |-
+                                        Paths inside the image for the kernel modules to sign.
+                                        Full path to explicit files are required or any globs supported by the Bash shell
                                       items:
                                         type: string
                                       type: array
@@ -2923,8 +2923,9 @@ spec:
                                 type: object
                                 x-kubernetes-map-type: atomic
                               filesToSign:
-                                description: paths inside the image for the kernel
-                                  modules to sign (if ommited all kmods are signed)
+                                description: |-
+                                  Paths inside the image for the kernel modules to sign.
+                                  Full path to explicit files are required or any globs supported by the Bash shell
                                 items:
                                   type: string
                                 type: array

--- a/config/crd-hub/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
+++ b/config/crd-hub/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
@@ -158,6 +158,11 @@ spec:
                       required:
                       - dockerfileConfigMap
                       type: object
+                    dirName:
+                      default: /opt
+                      description: DirName is the root directory for modules, used
+                        during signing.
+                      type: string
                     image:
                       description: image
                       type: string
@@ -197,8 +202,9 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         filesToSign:
-                          description: paths inside the image for the kernel modules
-                            to sign (if ommited all kmods are signed)
+                          description: |-
+                            Paths inside the image for the kernel modules to sign.
+                            Full path to explicit files are required or any globs supported by the Bash shell
                           items:
                             type: string
                           type: array

--- a/config/crd-hub/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/config/crd-hub/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -163,6 +163,11 @@ spec:
                       required:
                       - dockerfileConfigMap
                       type: object
+                    dirName:
+                      default: /opt
+                      description: DirName is the root directory for modules, used
+                        during signing.
+                      type: string
                     image:
                       description: image
                       type: string
@@ -202,8 +207,9 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         filesToSign:
-                          description: paths inside the image for the kernel modules
-                            to sign (if ommited all kmods are signed)
+                          description: |-
+                            Paths inside the image for the kernel modules to sign.
+                            Full path to explicit files are required or any globs supported by the Bash shell
                           items:
                             type: string
                           type: array

--- a/config/crd-hub/bases/kmm.sigs.x-k8s.io_modules.yaml
+++ b/config/crd-hub/bases/kmm.sigs.x-k8s.io_modules.yaml
@@ -2731,8 +2731,9 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 filesToSign:
-                                  description: paths inside the image for the kernel
-                                    modules to sign (if ommited all kmods are signed)
+                                  description: |-
+                                    Paths inside the image for the kernel modules to sign.
+                                    Full path to explicit files are required or any globs supported by the Bash shell
                                   items:
                                     type: string
                                   type: array
@@ -2898,8 +2899,9 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           filesToSign:
-                            description: paths inside the image for the kernel modules
-                              to sign (if ommited all kmods are signed)
+                            description: |-
+                              Paths inside the image for the kernel modules to sign.
+                              Full path to explicit files are required or any globs supported by the Bash shell
                             items:
                               type: string
                             type: array

--- a/config/crd/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_modulebuildsignconfigs.yaml
@@ -158,6 +158,11 @@ spec:
                       required:
                       - dockerfileConfigMap
                       type: object
+                    dirName:
+                      default: /opt
+                      description: DirName is the root directory for modules, used
+                        during signing.
+                      type: string
                     image:
                       description: image
                       type: string
@@ -197,8 +202,9 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         filesToSign:
-                          description: paths inside the image for the kernel modules
-                            to sign (if ommited all kmods are signed)
+                          description: |-
+                            Paths inside the image for the kernel modules to sign.
+                            Full path to explicit files are required or any globs supported by the Bash shell
                           items:
                             type: string
                           type: array

--- a/config/crd/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_moduleimagesconfigs.yaml
@@ -163,6 +163,11 @@ spec:
                       required:
                       - dockerfileConfigMap
                       type: object
+                    dirName:
+                      default: /opt
+                      description: DirName is the root directory for modules, used
+                        during signing.
+                      type: string
                     image:
                       description: image
                       type: string
@@ -202,8 +207,9 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         filesToSign:
-                          description: paths inside the image for the kernel modules
-                            to sign (if ommited all kmods are signed)
+                          description: |-
+                            Paths inside the image for the kernel modules to sign.
+                            Full path to explicit files are required or any globs supported by the Bash shell
                           items:
                             type: string
                           type: array

--- a/config/crd/bases/kmm.sigs.x-k8s.io_modules.yaml
+++ b/config/crd/bases/kmm.sigs.x-k8s.io_modules.yaml
@@ -2731,8 +2731,9 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 filesToSign:
-                                  description: paths inside the image for the kernel
-                                    modules to sign (if ommited all kmods are signed)
+                                  description: |-
+                                    Paths inside the image for the kernel modules to sign.
+                                    Full path to explicit files are required or any globs supported by the Bash shell
                                   items:
                                     type: string
                                   type: array
@@ -2898,8 +2899,9 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           filesToSign:
-                            description: paths inside the image for the kernel modules
-                              to sign (if ommited all kmods are signed)
+                            description: |-
+                              Paths inside the image for the kernel modules to sign.
+                              Full path to explicit files are required or any globs supported by the Bash shell
                             items:
                               type: string
                             type: array

--- a/internal/buildsign/resource/common.go
+++ b/internal/buildsign/resource/common.go
@@ -29,6 +29,7 @@ type TemplateData struct {
 	FilesToSign   []string
 	SignImage     string
 	UnsignedImage string
+	DirName       string
 }
 
 //go:embed templates
@@ -313,6 +314,7 @@ func (rm *resourceManager) makeSignTemplate(ctx context.Context, mld *api.Module
 	td := TemplateData{
 		FilesToSign: mld.Sign.FilesToSign,
 		SignImage:   os.Getenv("RELATED_IMAGE_SIGN"),
+		DirName:     mld.Modprobe.DirName,
 	}
 
 	imageToSign := ""

--- a/internal/buildsign/resource/templates/Dockerfile.gotmpl
+++ b/internal/buildsign/resource/templates/Dockerfile.gotmpl
@@ -5,13 +5,12 @@ FROM {{ .SignImage }} AS signimage
 
 USER 0
 
-RUN ["mkdir", "/signroot"]
-{{ range .FilesToSign }}
-COPY --from=source {{ . }} /signroot{{ . }}
-RUN /usr/local/bin/sign-file sha256 /run/secrets/key/key /run/secrets/cert/cert /signroot{{ . }}
+COPY --from=source {{ .DirName }} /opt{{ .DirName }}
+{{- range .FilesToSign }}
+RUN for file in /opt{{ . }}; do \
+      [ -e "${file}" ] && /usr/local/bin/sign-file sha256 /run/secrets/key/key /run/secrets/cert/cert "${file}"; \
+    done
 {{- end }}
 
 FROM source
-{{ range .FilesToSign }}
-COPY --from=signimage /signroot{{ . }} {{ . }}
-{{- end }}
+COPY --from=signimage /opt{{ .DirName }} {{ .DirName }}

--- a/internal/controllers/hub/managedclustermodule_reconciler.go
+++ b/internal/controllers/hub/managedclustermodule_reconciler.go
@@ -243,6 +243,7 @@ func (rh *managedClusterModuleReconcilerHelper) setMicAsDesired(ctx context.Cont
 			Build:         mld.Build,
 			Sign:          mld.Sign,
 			RegistryTLS:   mld.RegistryTLS,
+			DirName:       mld.Modprobe.DirName,
 		}
 		images = append(images, mis)
 	}

--- a/internal/controllers/mbsc_reconciler.go
+++ b/internal/controllers/mbsc_reconciler.go
@@ -188,5 +188,6 @@ func createMLD(mbscObj *kmmv1beta1.ModuleBuildSignConfig, imageSpec *kmmv1beta1.
 		ImageRepoSecret:         mbscObj.Spec.ImageRepoSecret,
 		RegistryTLS:             imageSpec.RegistryTLS,
 		Tolerations:             mbscObj.Spec.Tolerations,
+		Modprobe:                kmmv1beta1.ModprobeSpec{DirName: imageSpec.DirName},
 	}
 }

--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -426,6 +426,7 @@ func (mrh *moduleReconcilerHelper) handleMIC(ctx context.Context, mod *kmmv1beta
 			Build:         mld.Build,
 			Sign:          mld.Sign,
 			RegistryTLS:   mld.RegistryTLS,
+			DirName:       mld.Modprobe.DirName,
 		}
 		images = append(images, mis)
 	}

--- a/internal/controllers/preflightvalidation_reconciler.go
+++ b/internal/controllers/preflightvalidation_reconciler.go
@@ -228,6 +228,7 @@ func (p *preflightReconcilerHelperImpl) processPreflightValidation(ctx context.C
 			Build:         mod.Build,
 			Sign:          mod.Sign,
 			RegistryTLS:   mod.RegistryTLS,
+			DirName:       mod.Modprobe.DirName,
 		}
 		micName := mod.Name + "-preflight"
 		err := p.micAPI.CreateOrPatch(ctx, micName, mod.Namespace, []kmmv1beta1.ModuleImageSpec{micObjSpec},


### PR DESCRIPTION
This commit adds support for wildcard and glob patterns in the filesToSign field when signing kernel modules. Previously, users had to specify the exact path to each .ko file they wanted to sign.
Now, the user can specify full paths to explicit files (required as before), or any glob patterns supported by the Bash shell (UBI sign image).

Additionally, this commit propagates DirName from the API into the sign image template, and adds the signed files to the validation webhook.


---

fix #1740

---

/cc @yevgeny-shnaidman @ybettan 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional DirName setting for module image specs to set the module root directory used during signing (default: /opt).

* **Documentation**
  * Clarified filesToSign guidance: requires full explicit paths or glob patterns supported by the Bash shell.

* **Improvements**
  * Validation now requires filesToSign to be present and ensures entries reside under the configured DirName.
  * Signing flow updated to support directory/glob-based signing instead of per-file copy steps.

* **Tests**
  * Updated signing tests and CI fixtures to cover DirName and glob scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->