### PR TITLE
Add documentation for running KMM on tainted worker nodes

### DIFF
--- a/docs/mkdocs/documentation/install.md
+++ b/docs/mkdocs/documentation/install.md
@@ -46,6 +46,62 @@ spec:
   startingCSV: kernel-module-management.v1.0.0
 ```
 
+### Configuring tolerations for KMM
+
+By default, the KMM Operator is installed on control plane nodes when possible and includes tolerations that allow it to be scheduled on them.
+In environments where the control plane is not accessible, KMM is installed on worker nodes.
+In such cases, when an upgrade flow is triggered, and nodes are tainted, workloads are removed from the nodes to allow the operator to remove the old kmods and insert the new kmod into the kernel. In order to do so, we need to make sure the operator's pods are not evicted if they are running on the tainted node.
+In order to fix it, you can add additional tolerations to the operator.
+
+When installing KMM using OLM, you can add tolerations to the Subscription resource using the `spec.config` field:
+
+```yaml
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kernel-module-management
+  namespace: openshift-kmm
+spec:
+  channel: release-1.0
+  installPlanApproval: Automatic
+  name: kernel-module-management
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: kernel-module-management.v1.0.0
+  config:
+    tolerations:
+    - key: "node.kubernetes.io/unschedulable"
+      operator: "Exists"
+      effect: "NoSchedule"
+```
+
+To tolerate any taint, you can use an empty key with the `Exists` operator:
+
+```yaml
+  config:
+    tolerations:
+    - operator: "Exists"
+```
+
+If KMM is already installed, you can patch the existing Subscription to add tolerations:
+
+```shell
+oc patch subscription kernel-module-management -n openshift-kmm --type='merge' -p '
+spec:
+  config:
+    tolerations:
+    - key: "node.kubernetes.io/unschedulable"
+      operator: "Exists"
+      effect: "NoSchedule"
+'
+```
+
+After patching, restart the operator deployment to apply the new tolerations:
+
+```shell
+oc rollout restart deploy/kmm-operator-controller -n openshift-kmm
+```
+
 ## Using `oc`
 
 The command below installs the bleeding edge version of KMM.
@@ -53,6 +109,12 @@ The command below installs the bleeding edge version of KMM.
 ```shell
 oc apply -k https://github.com/rh-ecosystem-edge/kernel-module-management/config/default
 ```
+
+### Configuring tolerations with kustomize
+
+When deploying KMM with kustomize, you can add tolerations directly to the deployment spec in
+[`config/manager-base/manager.yaml`](https://github.com/rh-ecosystem-edge/kernel-module-management/blob/main/config/manager-base/manager.yaml)
+under `spec.template.spec.tolerations`.
 
 ## OpenShift versions below 4.12
 


### PR DESCRIPTION
Document how to add custom tolerations via OLM Subscription's for OpenShift environments where worker nodes have custom taints.

This is a manual cherry pick of this [issue](https://github.com/rh-ecosystem-edge/kernel-module-management/issues/1742).
And this is the upstream [PR](https://github.com/kubernetes-sigs/kernel-module-management/pull/1226) changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring tolerations for Kernel Module Management across OLM and kustomize deployments.
  * Included YAML examples for setting specific tolerations and using the Exists operator to tolerate any taint.
  * Provided commands to patch existing Subscriptions and perform rollout restarts of the operator.
  * Clarified where to define tolerations in deployment manifests, with step-by-step instructions and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->