### PR TITLE
Fixing the installation docs to install from the `stable` channel.

### DIFF
--- a/docs/mkdocs/documentation/install.md
+++ b/docs/mkdocs/documentation/install.md
@@ -38,12 +38,11 @@ metadata:
   name: kernel-module-management
   namespace: openshift-kmm
 spec:
-  channel: release-1.0
+  channel: stable
   installPlanApproval: Automatic
   name: kernel-module-management
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: kernel-module-management.v1.0.0
 ```
 
 ### Configuring tolerations for KMM
@@ -62,12 +61,11 @@ metadata:
   name: kernel-module-management
   namespace: openshift-kmm
 spec:
-  channel: release-1.0
+  channel: stable
   installPlanApproval: Automatic
   name: kernel-module-management
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: kernel-module-management.v1.0.0
   config:
     tolerations:
     - key: "node.kubernetes.io/unschedulable"


### PR DESCRIPTION
The old doc was installing from the `release-1.0` channel which is outdated.

---

/assign @cdvultur 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated OpenShift OLM Subscription examples to use the stable update channel.
  * Simplified examples by removing explicit starting-version entries, and adjusted toleration configuration examples to match the stable channel — making docs clearer and encouraging flexible automatic updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->