### PR TITLE
[release-2.5] Fixing the installation docs to install from the `stable` channel.

### DIFF
--- a/docs/mkdocs/documentation/install.md
+++ b/docs/mkdocs/documentation/install.md
@@ -38,12 +38,11 @@ metadata:
   name: kernel-module-management
   namespace: openshift-kmm
 spec:
-  channel: release-1.0
+  channel: stable
   installPlanApproval: Automatic
   name: kernel-module-management
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: kernel-module-management.v1.0.0
 ```
 
 ## Using `oc`


### PR DESCRIPTION
The old doc was installing from the `release-1.0` channel which is outdated.

---

/assign @cdvultur 