### PR TITLE
Adding delete to modulebuildsignconfigs rbac

### DIFF
--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2026-02-15T12:41:06Z"
+    createdAt: "2026-02-17T13:40:33Z"
     operatorframework.io/suggested-namespace: openshift-kmm-hub
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -159,6 +159,7 @@ spec:
           - modulebuildsignconfigs
           verbs:
           - create
+          - delete
           - get
           - list
           - patch

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -47,7 +47,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2026-02-15T12:40:55Z"
+    createdAt: "2026-02-17T13:38:08Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -207,6 +207,7 @@ spec:
           - kmm.sigs.x-k8s.io
           resources:
           - bootmoduleconfigs
+          - modulebuildsignconfigs
           - preflightvalidations
           - preflightvalidationsocp
           verbs:
@@ -227,17 +228,6 @@ spec:
           verbs:
           - patch
           - update
-        - apiGroups:
-          - kmm.sigs.x-k8s.io
-          resources:
-          - modulebuildsignconfigs
-          verbs:
-          - create
-          - get
-          - list
-          - patch
-          - update
-          - watch
         - apiGroups:
           - kmm.sigs.x-k8s.io
           resources:

--- a/config/rbac-hub/role.yaml
+++ b/config/rbac-hub/role.yaml
@@ -83,6 +83,7 @@ rules:
   - modulebuildsignconfigs
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -96,6 +96,7 @@ rules:
   - kmm.sigs.x-k8s.io
   resources:
   - bootmoduleconfigs
+  - modulebuildsignconfigs
   - preflightvalidations
   - preflightvalidationsocp
   verbs:
@@ -116,17 +117,6 @@ rules:
   verbs:
   - patch
   - update
-- apiGroups:
-  - kmm.sigs.x-k8s.io
-  resources:
-  - modulebuildsignconfigs
-  verbs:
-  - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - kmm.sigs.x-k8s.io
   resources:

--- a/internal/controllers/hub/managedclustermodule_reconciler.go
+++ b/internal/controllers/hub/managedclustermodule_reconciler.go
@@ -66,7 +66,7 @@ type ManagedClusterModuleReconciler struct {
 //+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=moduleimagesconfigs,verbs=get;list;watch;patch;create;delete
 //+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=moduleimagesconfigs/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=moduleimagesconfigs/finalizers,verbs=update
-//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modulebuildsignconfigs,verbs=get;list;watch;update;patch;create
+//+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modulebuildsignconfigs,verbs=get;list;watch;update;patch;create;delete
 //+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modulebuildsignconfigs/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modulebuildsignconfigs/finalizers,verbs=update
 //+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=manifestworks,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -43,7 +43,7 @@ import (
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=create;delete;get;list;patch;watch
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;watch
-// +kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modulebuildsignconfigs,verbs=create;get;list;patch;update;watch
+// +kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modulebuildsignconfigs,verbs=create;delete;get;list;patch;update;watch
 // +kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modulebuildsignconfigs/status,verbs=get;patch;update
 // +kubebuilder:rbac:groups=kmm.sigs.x-k8s.io,resources=modulebuildsignconfigs/finalizers,verbs=update
 


### PR DESCRIPTION
Following #1725 commit, we now deleting mbsc resources from the controllers (regular + hub) pods, but since we missed the rbac annotation for that, it failed to delete.
This commits adds the missing rbac annotation.

---

/cc @ybettan @yevgeny-shnaidman 

---
fixes #1751

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated operator RBAC permissions to grant delete capability for module build sign configurations across all cluster roles and operator service manifests.
  * Reorganized and consolidated module build sign configuration permissions with boot module configurations in role definitions.
  * Updated service version metadata timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->