### PR TITLE
docs: fix typos and grammatical errors in Day 1 and Labs documentation

### DIFF
--- a/docs/mkdocs/documentation/day1_limited_option.md
+++ b/docs/mkdocs/documentation/day1_limited_option.md
@@ -13,7 +13,7 @@ The following are the conditions needed by Day 1 functionality:
 1. kernel module is currently not loaded in the kernel
 2. the in-tree kernel module is loaded into the kernel, but can be unloaded and replaced by the OOT kernel module.
    This means that the in-tree module is not referenced by any other kernel modules
-3. in order for the Day 1 functionlity to work, the node must have an functional network interface, meaning: an in-tree kernel driver for that interface.
+3. in order for the Day 1 functionality to work, the node must have a functional network interface, meaning: an in-tree kernel driver for that interface.
    The OOT kernel module can be a network driver that will replace the functional network driver.
 
 ## Day 1 OOT kernel module loading flow
@@ -126,13 +126,13 @@ Defining a MachineConfig that has:
 ```yaml
 metadata:
   labels:
-    machineconfiguration.opensfhit.io/role: master
+    machineconfiguration.openshift.io/role: master
 ```
 will target the master MachineConfigPool, while defining MachineConfig:
 ```yaml
 metadata:
   labels:
-    machineconfiguration.opensfhit.io/role: worker
+    machineconfiguration.openshift.io/role: worker
 ```
 will target the worker MachineConfigPool
 
@@ -147,7 +147,7 @@ with the appropriate tag, without any need to update day1 MC. Once the node is r
 Kmod installed using the day1-utility can be managed by the KMM operator for full lifecycle management.
 
 1. A kmod was installed using the day-utility and a `MachineConfig` is present in the cluster.
-2. One can create a `Module` in the cluster targetting the same kmod and kernel as the `MachineConfig` did.
+2. One can create a `Module` in the cluster targeting the same kmod and kernel as the `MachineConfig` did.
 3. The KMM operator will try to load the kmod - nothing will happen since it is already loaded in the kernel.
 4. From now on, upgrades can be done like day2 operations by updating the `Module` CR in the cluster.
 

--- a/docs/mkdocs/labsv2.md
+++ b/docs/mkdocs/labsv2.md
@@ -360,7 +360,7 @@ oc edit module kmm-ci-a
 
 ## Loading soft dependencies
 
-Kernel modules sometimes have dependencies on other modules so these dependencies have to be loaded in advance. If module symbols exist then `modprobe` would load the dependant modules automatically but if there are no symbols and we need to load dependant modules we can set those in our `Module` object definition.
+Kernel modules sometimes have dependencies on other modules so these dependencies have to be loaded in advance. If module symbols exist then `modprobe` would load the dependent modules automatically but if there are no symbols and we need to load dependent modules we can set those in our `Module` object definition.
 
 In the following example `kmm-ci-a` depends on `kmm-ci-b` so we will set `modulesLoadingOrder` and then the list with the `moduleName` as the first entry followed by all of its dependencies. In our case it is just `kmm-ci-b` but it could be a longer list with multiple dependency modules.
 


### PR DESCRIPTION
This PR fixes several typos and grammatical errors identified in the documentation files to improve clarity and professionalism.

### Changes:
- **docs/mkdocs/documentation/day1_limited_option.md**:
  - Fixed typo "functionlity" to "functionality".
  - Fixed grammar error "an functional" to "a functional".
  - Fixed typo "opensfhit.io" to "openshift.io".
  - Fixed typo "targetting" to "targeting".
- **docs/mkdocs/labsv2.md**:
  - Fixed typo "dependant" to "dependent".

No code or logic changes were made; only documentation files ([.md](cci:7://file:///c:/Users/umutk/OneDrive/Belgeler/rh-kernel_github/README.md:0:0-0:0)) were updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Resolved grammar and spelling inconsistencies across guides for improved readability
  * Corrected OpenShift MachineConfig label references to match proper technical specifications
  * Enhanced module loading documentation with additional example clarifying ordering behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->