### PR TITLE
updating ImageRebuildTriggerGeneration in module status

### DIFF
--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -547,6 +547,13 @@ func (mrh *moduleReconcilerHelper) moduleUpdateWorkerPodsStatus(ctx context.Cont
 	mod.Status.ModuleLoader.DesiredNumber = int32(len(nmcs))
 	mod.Status.ModuleLoader.AvailableNumber = int32(numAvailable)
 
+	micObj, err := mrh.micAPI.Get(ctx, mod.Name, mod.Namespace)
+	if err != nil {
+		logger.Info("Could not get MIC to update ImageRebuildTriggerGeneration status, skipping", "error", err)
+	} else {
+		mod.Status.ImageRebuildTriggerGeneration = micObj.Status.ImageRebuildTriggerGeneration
+	}
+
 	return mrh.client.Status().Patch(ctx, mod, client.MergeFrom(unmodifiedMod))
 }
 

--- a/internal/controllers/module_reconciler_test.go
+++ b/internal/controllers/module_reconciler_test.go
@@ -1028,6 +1028,7 @@ var _ = Describe("moduleUpdateWorkerPodsStatus", func() {
 		mrh          *moduleReconcilerHelper
 		helper       *nmc.MockHelper
 		statusWriter *client.MockStatusWriter
+		mockMicAPI   *mic.MockMIC
 	)
 
 	BeforeEach(func() {
@@ -1036,6 +1037,7 @@ var _ = Describe("moduleUpdateWorkerPodsStatus", func() {
 		clnt = client.NewMockClient(ctrl)
 		helper = nmc.NewMockHelper(ctrl)
 		statusWriter = client.NewMockStatusWriter(ctrl)
+		mockMicAPI = mic.NewMockMIC(ctrl)
 		mod = kmmv1beta1.Module{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "modName",
@@ -1043,7 +1045,7 @@ var _ = Describe("moduleUpdateWorkerPodsStatus", func() {
 			},
 		}
 		mockNetworkPolicyAPI := networkpolicy.NewMockNetworkPolicy(ctrl)
-		mrh = &moduleReconcilerHelper{client: clnt, nmcHelper: helper, networkPolicyAPI: mockNetworkPolicyAPI}
+		mrh = &moduleReconcilerHelper{client: clnt, nmcHelper: helper, networkPolicyAPI: mockNetworkPolicyAPI, micAPI: mockMicAPI}
 	})
 
 	It("faled to get configured NMCs", func() {
@@ -1069,6 +1071,7 @@ var _ = Describe("moduleUpdateWorkerPodsStatus", func() {
 				},
 			),
 			helper.EXPECT().GetModuleSpecEntry(&nmc1, mod.Namespace, mod.Name).Return(nil, 0),
+			mockMicAPI.EXPECT().Get(ctx, mod.Name, mod.Namespace).Return(&kmmv1beta1.ModuleImagesConfig{}, nil),
 			clnt.EXPECT().Status().Return(statusWriter),
 			statusWriter.EXPECT().Patch(ctx, expectedMod, gomock.Any()),
 		)
@@ -1118,6 +1121,7 @@ var _ = Describe("moduleUpdateWorkerPodsStatus", func() {
 		} else {
 			helper.EXPECT().GetModuleStatusEntry(&nmc1, mod.Namespace, mod.Name).Return(nil)
 		}
+		mockMicAPI.EXPECT().Get(ctx, mod.Name, mod.Namespace).Return(&kmmv1beta1.ModuleImagesConfig{}, nil)
 		clnt.EXPECT().Status().Return(statusWriter)
 		statusWriter.EXPECT().Patch(ctx, expectedMod, gomock.Any())
 
@@ -1155,12 +1159,78 @@ var _ = Describe("moduleUpdateWorkerPodsStatus", func() {
 			),
 			helper.EXPECT().GetModuleSpecEntry(&nmc1, mod.Namespace, mod.Name).Return(&nmcModuleSpec, 0),
 			helper.EXPECT().GetModuleStatusEntry(&nmc1, mod.Namespace, mod.Name).Return(&nmcModuleStatus),
+			mockMicAPI.EXPECT().Get(ctx, mod.Name, mod.Namespace).Return(&kmmv1beta1.ModuleImagesConfig{}, nil),
 			clnt.EXPECT().Status().Return(statusWriter),
 			statusWriter.EXPECT().Patch(ctx, expectedMod, gomock.Any()),
 		)
 
 		err := mrh.moduleUpdateWorkerPodsStatus(ctx, &mod, targetedNodes)
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should propagate MIC status.ImageRebuildTriggerGeneration to Module status", func() {
+		micTriggerValue := 3
+		micObj := &kmmv1beta1.ModuleImagesConfig{
+			Status: kmmv1beta1.ModuleImagesConfigStatus{
+				ImageRebuildTriggerGeneration: &micTriggerValue,
+			},
+		}
+
+		nmc1 := kmmv1beta1.NodeModulesConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "nmc1"},
+		}
+		targetedNodes := []v1.Node{{}, {}}
+		expectedMod := mod.DeepCopy()
+		expectedMod.Status.ModuleLoader.NodesMatchingSelectorNumber = int32(2)
+		expectedMod.Status.ModuleLoader.DesiredNumber = int32(1)
+		expectedMod.Status.ModuleLoader.AvailableNumber = int32(0)
+		expectedMod.Status.ImageRebuildTriggerGeneration = &micTriggerValue
+
+		gomock.InOrder(
+			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
+					list.Items = []kmmv1beta1.NodeModulesConfig{nmc1}
+					return nil
+				},
+			),
+			helper.EXPECT().GetModuleSpecEntry(&nmc1, mod.Namespace, mod.Name).Return(nil, 0),
+			mockMicAPI.EXPECT().Get(ctx, mod.Name, mod.Namespace).Return(micObj, nil),
+			clnt.EXPECT().Status().Return(statusWriter),
+			statusWriter.EXPECT().Patch(ctx, expectedMod, gomock.Any()),
+		)
+
+		err := mrh.moduleUpdateWorkerPodsStatus(ctx, &mod, targetedNodes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mod.Status.ImageRebuildTriggerGeneration).NotTo(BeNil())
+		Expect(*mod.Status.ImageRebuildTriggerGeneration).To(Equal(micTriggerValue))
+	})
+
+	It("should not fail if MIC Get returns an error", func() {
+		nmc1 := kmmv1beta1.NodeModulesConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: "nmc1"},
+		}
+		targetedNodes := []v1.Node{{}}
+		expectedMod := mod.DeepCopy()
+		expectedMod.Status.ModuleLoader.NodesMatchingSelectorNumber = int32(1)
+		expectedMod.Status.ModuleLoader.DesiredNumber = int32(1)
+		expectedMod.Status.ModuleLoader.AvailableNumber = int32(0)
+
+		gomock.InOrder(
+			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
+					list.Items = []kmmv1beta1.NodeModulesConfig{nmc1}
+					return nil
+				},
+			),
+			helper.EXPECT().GetModuleSpecEntry(&nmc1, mod.Namespace, mod.Name).Return(nil, 0),
+			mockMicAPI.EXPECT().Get(ctx, mod.Name, mod.Namespace).Return(nil, fmt.Errorf("mic not found")),
+			clnt.EXPECT().Status().Return(statusWriter),
+			statusWriter.EXPECT().Patch(ctx, expectedMod, gomock.Any()),
+		)
+
+		err := mrh.moduleUpdateWorkerPodsStatus(ctx, &mod, targetedNodes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mod.Status.ImageRebuildTriggerGeneration).To(BeNil())
 	})
 
 })


### PR DESCRIPTION
ImageRebuildTriggerGeneration field that was introduced in #1725 commit was never updated in the Module's status, even when MIC already finished to re-build the image and ImageRebuildTriggerGeneration field was updated in the MIC's status.

This commit fixes it by updating ImageRebuildTriggerGeneration in the Module's status at the end of the Module's reconciliation.


---

/cc @yevgeny-shnaidman @ybettan 

---

fixes #1755

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module status synchronization by retrieving and propagating image rebuild trigger information from related configuration objects.

* **Tests**
  * Enhanced test coverage for module status update workflows, including error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->