### PR TITLE
Refactor module status update into separate concerns

### DIFF
--- a/internal/controllers/mock_module_reconciler.go
+++ b/internal/controllers/mock_module_reconciler.go
@@ -127,20 +127,6 @@ func (mr *MockmoduleReconcilerHelperAPIMockRecorder) handleNetworkPolicies(ctx, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleNetworkPolicies", reflect.TypeOf((*MockmoduleReconcilerHelperAPI)(nil).handleNetworkPolicies), ctx, mod)
 }
 
-// moduleUpdateWorkerPodsStatus mocks base method.
-func (m *MockmoduleReconcilerHelperAPI) moduleUpdateWorkerPodsStatus(ctx context.Context, mod *v1beta1.Module, targetedNodes []v1.Node) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "moduleUpdateWorkerPodsStatus", ctx, mod, targetedNodes)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// moduleUpdateWorkerPodsStatus indicates an expected call of moduleUpdateWorkerPodsStatus.
-func (mr *MockmoduleReconcilerHelperAPIMockRecorder) moduleUpdateWorkerPodsStatus(ctx, mod, targetedNodes any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "moduleUpdateWorkerPodsStatus", reflect.TypeOf((*MockmoduleReconcilerHelperAPI)(nil).moduleUpdateWorkerPodsStatus), ctx, mod, targetedNodes)
-}
-
 // prepareSchedulingData mocks base method.
 func (m *MockmoduleReconcilerHelperAPI) prepareSchedulingData(ctx context.Context, mod *v1beta1.Module, targetedNodes []v1.Node, currentNMCs sets.Set[string]) (map[string]schedulingData, []error) {
 	m.ctrl.T.Helper()
@@ -168,6 +154,20 @@ func (m *MockmoduleReconcilerHelperAPI) setFinalizerAndStatus(ctx context.Contex
 func (mr *MockmoduleReconcilerHelperAPIMockRecorder) setFinalizerAndStatus(ctx, mod any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "setFinalizerAndStatus", reflect.TypeOf((*MockmoduleReconcilerHelperAPI)(nil).setFinalizerAndStatus), ctx, mod)
+}
+
+// updateModuleStatus mocks base method.
+func (m *MockmoduleReconcilerHelperAPI) updateModuleStatus(ctx context.Context, mod *v1beta1.Module, targetedNodes []v1.Node) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "updateModuleStatus", ctx, mod, targetedNodes)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// updateModuleStatus indicates an expected call of updateModuleStatus.
+func (mr *MockmoduleReconcilerHelperAPIMockRecorder) updateModuleStatus(ctx, mod, targetedNodes any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "updateModuleStatus", reflect.TypeOf((*MockmoduleReconcilerHelperAPI)(nil).updateModuleStatus), ctx, mod, targetedNodes)
 }
 
 // MocknamespaceLabeler is a mock of namespaceLabeler interface.

--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/node"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -184,7 +185,7 @@ func (mr *ModuleReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.Modul
 		errs = append(errs, err)
 	}
 
-	err = mr.reconHelper.moduleUpdateWorkerPodsStatus(ctx, mod, targetedNodes)
+	err = mr.reconHelper.updateModuleStatus(ctx, mod, targetedNodes)
 	errs = append(errs, err)
 
 	err = errors.Join(errs...)
@@ -231,8 +232,8 @@ type moduleReconcilerHelperAPI interface {
 	prepareSchedulingData(ctx context.Context, mod *kmmv1beta1.Module, targetedNodes []v1.Node, currentNMCs sets.Set[string]) (map[string]schedulingData, []error)
 	enableModuleOnNode(ctx context.Context, mld *api.ModuleLoaderData, node *v1.Node) error
 	disableModuleOnNode(ctx context.Context, modNamespace, modName, nodeName string) error
-	moduleUpdateWorkerPodsStatus(ctx context.Context, mod *kmmv1beta1.Module, targetedNodes []v1.Node) error
 	handleNetworkPolicies(ctx context.Context, mod *kmmv1beta1.Module) error
+	updateModuleStatus(ctx context.Context, mod *kmmv1beta1.Module, targetedNodes []v1.Node) error
 }
 
 type moduleReconcilerHelper struct {
@@ -517,7 +518,27 @@ func (mrh *moduleReconcilerHelper) removeModuleFromNMC(ctx context.Context, nmcO
 	return nil
 }
 
-func (mrh *moduleReconcilerHelper) moduleUpdateWorkerPodsStatus(ctx context.Context, mod *kmmv1beta1.Module, targetedNodes []v1.Node) error {
+func (mrh *moduleReconcilerHelper) updateModuleStatus(ctx context.Context, mod *kmmv1beta1.Module, targetedNodes []v1.Node) error {
+	unmodifiedMod := mod.DeepCopy()
+
+	var errs []error
+
+	if err := mrh.updateModuleLoaderStatus(ctx, mod, targetedNodes); err != nil {
+		errs = append(errs, fmt.Errorf("failed to update module loader status for module %s/%s: %v", mod.Namespace, mod.Name, err))
+	}
+
+	if err := mrh.updateImageRebuildTriggerGenerationStatus(ctx, mod); err != nil {
+		errs = append(errs, fmt.Errorf("failed to update ImageRebuildTriggerGeneration status for module %s/%s: %v", mod.Namespace, mod.Name, err))
+	}
+
+	if err := mrh.client.Status().Patch(ctx, mod, client.MergeFrom(unmodifiedMod)); err != nil {
+		errs = append(errs, fmt.Errorf("failed to patch module status for module %s/%s: %v", mod.Namespace, mod.Name, err))
+	}
+
+	return errors.Join(errs...)
+}
+
+func (mrh *moduleReconcilerHelper) updateModuleLoaderStatus(ctx context.Context, mod *kmmv1beta1.Module, targetedNodes []v1.Node) error {
 	logger := log.FromContext(ctx)
 	// get nmcs with configured
 	nmcs, err := mrh.getNMCsForModule(ctx, mod)
@@ -541,20 +562,27 @@ func (mrh *moduleReconcilerHelper) moduleUpdateWorkerPodsStatus(ctx context.Cont
 		}
 	}
 
-	unmodifiedMod := mod.DeepCopy()
-
 	mod.Status.ModuleLoader.NodesMatchingSelectorNumber = int32(len(targetedNodes))
 	mod.Status.ModuleLoader.DesiredNumber = int32(len(nmcs))
 	mod.Status.ModuleLoader.AvailableNumber = int32(numAvailable)
 
+	return nil
+}
+
+func (mrh *moduleReconcilerHelper) updateImageRebuildTriggerGenerationStatus(ctx context.Context, mod *kmmv1beta1.Module) error {
+	logger := log.FromContext(ctx)
+
 	micObj, err := mrh.micAPI.Get(ctx, mod.Name, mod.Namespace)
 	if err != nil {
-		logger.Info("Could not get MIC to update ImageRebuildTriggerGeneration status, skipping", "error", err)
-	} else {
-		mod.Status.ImageRebuildTriggerGeneration = micObj.Status.ImageRebuildTriggerGeneration
+		if apierrors.IsNotFound(err) {
+			logger.Info("MIC not found, skipping ImageRebuildTriggerGeneration status update")
+			return nil
+		}
+		return fmt.Errorf("failed to get MIC %s/%s: %v", mod.Namespace, mod.Name, err)
 	}
 
-	return mrh.client.Status().Patch(ctx, mod, client.MergeFrom(unmodifiedMod))
+	mod.Status.ImageRebuildTriggerGeneration = micObj.Status.ImageRebuildTriggerGeneration
+	return nil
 }
 
 func (mrh *moduleReconcilerHelper) handleNetworkPolicies(ctx context.Context, mod *kmmv1beta1.Module) error {

--- a/internal/controllers/module_reconciler_test.go
+++ b/internal/controllers/module_reconciler_test.go
@@ -158,9 +158,9 @@ var _ = Describe("Reconcile", func() {
 
 	moduleStatusUpdateFunction:
 		if c.moduleUpdateStatusErr {
-			mockReconHelper.EXPECT().moduleUpdateWorkerPodsStatus(ctx, mod, targetedNodes).Return(returnedError)
+			mockReconHelper.EXPECT().updateModuleStatus(ctx, mod, targetedNodes).Return(returnedError)
 		} else {
-			mockReconHelper.EXPECT().moduleUpdateWorkerPodsStatus(ctx, mod, targetedNodes).Return(nil)
+			mockReconHelper.EXPECT().updateModuleStatus(ctx, mod, targetedNodes).Return(nil)
 		}
 
 	executeTestFunction:
@@ -176,7 +176,7 @@ var _ = Describe("Reconcile", func() {
 		Entry("prepareSchedulingData failed", errorFlowTestCase{prepareSchedulingError: true}),
 		Entry("enableModuleOnNode failed", errorFlowTestCase{shouldBeOnNode: true, disableEnableError: true}),
 		Entry("disableModuleOnNode failed", errorFlowTestCase{disableEnableError: true}),
-		Entry(".moduleUpdateWorkerPodsStatus failed", errorFlowTestCase{moduleUpdateStatusErr: true}),
+		Entry("updateModuleStatus failed", errorFlowTestCase{moduleUpdateStatusErr: true}),
 		Entry("setLabel failed", errorFlowTestCase{setLabelError: true}),
 	)
 
@@ -191,7 +191,7 @@ var _ = Describe("Reconcile", func() {
 			mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, mod).Return(currentNMCs, nil),
 			mockReconHelper.EXPECT().prepareSchedulingData(ctx, mod, targetedNodes, currentNMCs).Return(nmcMLDConfigs, nil),
 			mockReconHelper.EXPECT().enableModuleOnNode(ctx, &mld, &node).Return(nil),
-			mockReconHelper.EXPECT().moduleUpdateWorkerPodsStatus(ctx, mod, targetedNodes).Return(nil),
+			mockReconHelper.EXPECT().updateModuleStatus(ctx, mod, targetedNodes).Return(nil),
 		)
 
 		res, err := mr.Reconcile(ctx, mod)
@@ -211,7 +211,7 @@ var _ = Describe("Reconcile", func() {
 			mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, mod).Return(currentNMCs, nil),
 			mockReconHelper.EXPECT().prepareSchedulingData(ctx, mod, targetedNodes, currentNMCs).Return(nmcMLDConfigs, nil),
 			mockReconHelper.EXPECT().disableModuleOnNode(ctx, mod.Namespace, mod.Name, node.Name).Return(nil),
-			mockReconHelper.EXPECT().moduleUpdateWorkerPodsStatus(ctx, mod, targetedNodes).Return(nil),
+			mockReconHelper.EXPECT().updateModuleStatus(ctx, mod, targetedNodes).Return(nil),
 		)
 
 		res, err := mr.Reconcile(ctx, mod)
@@ -1019,16 +1019,14 @@ var _ = Describe("removeModuleFromNMC", func() {
 	})
 })
 
-var _ = Describe("moduleUpdateWorkerPodsStatus", func() {
+var _ = Describe("updateModuleLoaderStatus", func() {
 	var (
-		ctx          context.Context
-		ctrl         *gomock.Controller
-		clnt         *client.MockClient
-		mod          kmmv1beta1.Module
-		mrh          *moduleReconcilerHelper
-		helper       *nmc.MockHelper
-		statusWriter *client.MockStatusWriter
-		mockMicAPI   *mic.MockMIC
+		ctx    context.Context
+		ctrl   *gomock.Controller
+		clnt   *client.MockClient
+		mod    kmmv1beta1.Module
+		mrh    *moduleReconcilerHelper
+		helper *nmc.MockHelper
 	)
 
 	BeforeEach(func() {
@@ -1036,8 +1034,6 @@ var _ = Describe("moduleUpdateWorkerPodsStatus", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
 		helper = nmc.NewMockHelper(ctrl)
-		statusWriter = client.NewMockStatusWriter(ctrl)
-		mockMicAPI = mic.NewMockMIC(ctrl)
 		mod = kmmv1beta1.Module{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "modName",
@@ -1045,12 +1041,12 @@ var _ = Describe("moduleUpdateWorkerPodsStatus", func() {
 			},
 		}
 		mockNetworkPolicyAPI := networkpolicy.NewMockNetworkPolicy(ctrl)
-		mrh = &moduleReconcilerHelper{client: clnt, nmcHelper: helper, networkPolicyAPI: mockNetworkPolicyAPI, micAPI: mockMicAPI}
+		mrh = &moduleReconcilerHelper{client: clnt, nmcHelper: helper, networkPolicyAPI: mockNetworkPolicyAPI}
 	})
 
 	It("faled to get configured NMCs", func() {
 		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
-		err := mrh.moduleUpdateWorkerPodsStatus(ctx, &mod, nil)
+		err := mrh.updateModuleLoaderStatus(ctx, &mod, nil)
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -1059,25 +1055,19 @@ var _ = Describe("moduleUpdateWorkerPodsStatus", func() {
 			ObjectMeta: metav1.ObjectMeta{Name: "nmc1"},
 		}
 		targetedNodes := []v1.Node{v1.Node{}, v1.Node{}}
-		expectedMod := mod.DeepCopy()
-		expectedMod.Status.ModuleLoader.NodesMatchingSelectorNumber = int32(2)
-		expectedMod.Status.ModuleLoader.DesiredNumber = int32(1)
-		expectedMod.Status.ModuleLoader.AvailableNumber = int32(0)
-		gomock.InOrder(
-			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-				func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
-					list.Items = []kmmv1beta1.NodeModulesConfig{nmc1}
-					return nil
-				},
-			),
-			helper.EXPECT().GetModuleSpecEntry(&nmc1, mod.Namespace, mod.Name).Return(nil, 0),
-			mockMicAPI.EXPECT().Get(ctx, mod.Name, mod.Namespace).Return(&kmmv1beta1.ModuleImagesConfig{}, nil),
-			clnt.EXPECT().Status().Return(statusWriter),
-			statusWriter.EXPECT().Patch(ctx, expectedMod, gomock.Any()),
+		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
+				list.Items = []kmmv1beta1.NodeModulesConfig{nmc1}
+				return nil
+			},
 		)
+		helper.EXPECT().GetModuleSpecEntry(&nmc1, mod.Namespace, mod.Name).Return(nil, 0)
 
-		err := mrh.moduleUpdateWorkerPodsStatus(ctx, &mod, targetedNodes)
+		err := mrh.updateModuleLoaderStatus(ctx, &mod, targetedNodes)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(mod.Status.ModuleLoader.NodesMatchingSelectorNumber).To(Equal(int32(2)))
+		Expect(mod.Status.ModuleLoader.DesiredNumber).To(Equal(int32(1)))
+		Expect(mod.Status.ModuleLoader.AvailableNumber).To(Equal(int32(0)))
 	})
 
 	DescribeTable("module present in spec", func(numTargetedNodes int,
@@ -1086,10 +1076,6 @@ var _ = Describe("moduleUpdateWorkerPodsStatus", func() {
 		expectedNodesMatchingSelectorNumber,
 		expectedDesiredNumber,
 		expectedAvailableNumber int) {
-		expectedMod := mod.DeepCopy()
-		expectedMod.Status.ModuleLoader.NodesMatchingSelectorNumber = int32(expectedNodesMatchingSelectorNumber)
-		expectedMod.Status.ModuleLoader.DesiredNumber = int32(expectedDesiredNumber)
-		expectedMod.Status.ModuleLoader.AvailableNumber = int32(expectedAvailableNumber)
 
 		targetedNodes := []v1.Node{}
 		for i := 0; i < numTargetedNodes; i++ {
@@ -1121,12 +1107,12 @@ var _ = Describe("moduleUpdateWorkerPodsStatus", func() {
 		} else {
 			helper.EXPECT().GetModuleStatusEntry(&nmc1, mod.Namespace, mod.Name).Return(nil)
 		}
-		mockMicAPI.EXPECT().Get(ctx, mod.Name, mod.Namespace).Return(&kmmv1beta1.ModuleImagesConfig{}, nil)
-		clnt.EXPECT().Status().Return(statusWriter)
-		statusWriter.EXPECT().Patch(ctx, expectedMod, gomock.Any())
 
-		err := mrh.moduleUpdateWorkerPodsStatus(ctx, &mod, targetedNodes)
+		err := mrh.updateModuleLoaderStatus(ctx, &mod, targetedNodes)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(mod.Status.ModuleLoader.NodesMatchingSelectorNumber).To(Equal(int32(expectedNodesMatchingSelectorNumber)))
+		Expect(mod.Status.ModuleLoader.DesiredNumber).To(Equal(int32(expectedDesiredNumber)))
+		Expect(mod.Status.ModuleLoader.AvailableNumber).To(Equal(int32(expectedAvailableNumber)))
 	},
 		Entry("2 targeted nodes, module not in status", 2, false, false, 2, 1, 0),
 		Entry("3 targeted nodes, module in status, configs not equal", 2, true, false, 2, 1, 0),
@@ -1146,26 +1132,43 @@ var _ = Describe("moduleUpdateWorkerPodsStatus", func() {
 			ObjectMeta: metav1.ObjectMeta{Name: "nmc1"},
 		}
 		targetedNodes := []v1.Node{v1.Node{}, v1.Node{}}
-		expectedMod := mod.DeepCopy()
-		expectedMod.Status.ModuleLoader.NodesMatchingSelectorNumber = int32(2)
-		expectedMod.Status.ModuleLoader.DesiredNumber = int32(1)
-		expectedMod.Status.ModuleLoader.AvailableNumber = int32(1)
-		gomock.InOrder(
-			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-				func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
-					list.Items = []kmmv1beta1.NodeModulesConfig{nmc1}
-					return nil
-				},
-			),
-			helper.EXPECT().GetModuleSpecEntry(&nmc1, mod.Namespace, mod.Name).Return(&nmcModuleSpec, 0),
-			helper.EXPECT().GetModuleStatusEntry(&nmc1, mod.Namespace, mod.Name).Return(&nmcModuleStatus),
-			mockMicAPI.EXPECT().Get(ctx, mod.Name, mod.Namespace).Return(&kmmv1beta1.ModuleImagesConfig{}, nil),
-			clnt.EXPECT().Status().Return(statusWriter),
-			statusWriter.EXPECT().Patch(ctx, expectedMod, gomock.Any()),
+		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
+				list.Items = []kmmv1beta1.NodeModulesConfig{nmc1}
+				return nil
+			},
 		)
+		helper.EXPECT().GetModuleSpecEntry(&nmc1, mod.Namespace, mod.Name).Return(&nmcModuleSpec, 0)
+		helper.EXPECT().GetModuleStatusEntry(&nmc1, mod.Namespace, mod.Name).Return(&nmcModuleStatus)
 
-		err := mrh.moduleUpdateWorkerPodsStatus(ctx, &mod, targetedNodes)
+		err := mrh.updateModuleLoaderStatus(ctx, &mod, targetedNodes)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(mod.Status.ModuleLoader.NodesMatchingSelectorNumber).To(Equal(int32(2)))
+		Expect(mod.Status.ModuleLoader.DesiredNumber).To(Equal(int32(1)))
+		Expect(mod.Status.ModuleLoader.AvailableNumber).To(Equal(int32(1)))
+	})
+})
+
+var _ = Describe("updateImageRebuildTriggerGenerationStatus", func() {
+	var (
+		ctx        context.Context
+		ctrl       *gomock.Controller
+		mod        kmmv1beta1.Module
+		mrh        *moduleReconcilerHelper
+		mockMicAPI *mic.MockMIC
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		ctrl = gomock.NewController(GinkgoT())
+		mockMicAPI = mic.NewMockMIC(ctrl)
+		mod = kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "modName",
+				Namespace: "modNamespace",
+			},
+		}
+		mrh = &moduleReconcilerHelper{micAPI: mockMicAPI}
 	})
 
 	It("should propagate MIC status.ImageRebuildTriggerGeneration to Module status", func() {
@@ -1176,63 +1179,29 @@ var _ = Describe("moduleUpdateWorkerPodsStatus", func() {
 			},
 		}
 
-		nmc1 := kmmv1beta1.NodeModulesConfig{
-			ObjectMeta: metav1.ObjectMeta{Name: "nmc1"},
-		}
-		targetedNodes := []v1.Node{{}, {}}
-		expectedMod := mod.DeepCopy()
-		expectedMod.Status.ModuleLoader.NodesMatchingSelectorNumber = int32(2)
-		expectedMod.Status.ModuleLoader.DesiredNumber = int32(1)
-		expectedMod.Status.ModuleLoader.AvailableNumber = int32(0)
-		expectedMod.Status.ImageRebuildTriggerGeneration = &micTriggerValue
+		mockMicAPI.EXPECT().Get(ctx, mod.Name, mod.Namespace).Return(micObj, nil)
 
-		gomock.InOrder(
-			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-				func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
-					list.Items = []kmmv1beta1.NodeModulesConfig{nmc1}
-					return nil
-				},
-			),
-			helper.EXPECT().GetModuleSpecEntry(&nmc1, mod.Namespace, mod.Name).Return(nil, 0),
-			mockMicAPI.EXPECT().Get(ctx, mod.Name, mod.Namespace).Return(micObj, nil),
-			clnt.EXPECT().Status().Return(statusWriter),
-			statusWriter.EXPECT().Patch(ctx, expectedMod, gomock.Any()),
-		)
-
-		err := mrh.moduleUpdateWorkerPodsStatus(ctx, &mod, targetedNodes)
+		err := mrh.updateImageRebuildTriggerGenerationStatus(ctx, &mod)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(mod.Status.ImageRebuildTriggerGeneration).NotTo(BeNil())
 		Expect(*mod.Status.ImageRebuildTriggerGeneration).To(Equal(micTriggerValue))
 	})
 
-	It("should not fail if MIC Get returns an error", func() {
-		nmc1 := kmmv1beta1.NodeModulesConfig{
-			ObjectMeta: metav1.ObjectMeta{Name: "nmc1"},
-		}
-		targetedNodes := []v1.Node{{}}
-		expectedMod := mod.DeepCopy()
-		expectedMod.Status.ModuleLoader.NodesMatchingSelectorNumber = int32(1)
-		expectedMod.Status.ModuleLoader.DesiredNumber = int32(1)
-		expectedMod.Status.ModuleLoader.AvailableNumber = int32(0)
+	It("should skip if MIC is not found", func() {
+		mockMicAPI.EXPECT().Get(ctx, mod.Name, mod.Namespace).Return(nil, apierrors.NewNotFound(schema.GroupResource{}, "test-module"))
 
-		gomock.InOrder(
-			clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
-				func(_ interface{}, list *kmmv1beta1.NodeModulesConfigList, _ ...interface{}) error {
-					list.Items = []kmmv1beta1.NodeModulesConfig{nmc1}
-					return nil
-				},
-			),
-			helper.EXPECT().GetModuleSpecEntry(&nmc1, mod.Namespace, mod.Name).Return(nil, 0),
-			mockMicAPI.EXPECT().Get(ctx, mod.Name, mod.Namespace).Return(nil, fmt.Errorf("mic not found")),
-			clnt.EXPECT().Status().Return(statusWriter),
-			statusWriter.EXPECT().Patch(ctx, expectedMod, gomock.Any()),
-		)
-
-		err := mrh.moduleUpdateWorkerPodsStatus(ctx, &mod, targetedNodes)
+		err := mrh.updateImageRebuildTriggerGenerationStatus(ctx, &mod)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(mod.Status.ImageRebuildTriggerGeneration).To(BeNil())
 	})
 
+	It("should return an error if MIC Get fails with a non-NotFound error", func() {
+		mockMicAPI.EXPECT().Get(ctx, mod.Name, mod.Namespace).Return(nil, fmt.Errorf("api server unreachable"))
+
+		err := mrh.updateImageRebuildTriggerGenerationStatus(ctx, &mod)
+		Expect(err).To(HaveOccurred())
+		Expect(mod.Status.ImageRebuildTriggerGeneration).To(BeNil())
+	})
 })
 
 var _ = Describe("namespaceHelper_setLabel", func() {


### PR DESCRIPTION
The previous moduleUpdateWorkerPodsStatus mixed unrelated responsibilities: updating ModuleLoader status fields and propagating ImageRebuildTriggerGeneration from MIC status.

Introducing updateModuleStatus function that:
- calls updateModuleLoaderStatus to compute ModuleLoader fields.
- calls updateImageRebuildTriggerGenerationStatus to propagate ImageRebuildTriggerGeneration from MIC's status.
- Patching Module's status.

---

fix #1757

---

/cc @ybettan @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal module status update logic for improved code organization and maintainability. Status tracking for module loaders and image rebuild triggers has been restructured with clearer separation of concerns.

---

**Note:** This release contains internal improvements with no direct user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->