### PR TITLE
Fix duplicate build/sign pod race with deterministic naming

### DIFF
--- a/internal/buildsign/manager.go
+++ b/internal/buildsign/manager.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,7 +41,7 @@ func NewManager(client client.Client, resourceManager ResourceManager, scheme *r
 func (m *manager) GetStatus(ctx context.Context, name, namespace, kernelVersion string,
 	action kmmv1beta1.BuildOrSignAction, owner metav1.Object) (kmmv1beta1.BuildOrSignStatus, error) {
 
-	normalizedKernel := kernel.NormalizeVersion(kernelVersion)
+	normalizedKernel := kernel.DNSSafeKernelVersion(kernelVersion)
 	foundResource, err := m.resourceManager.GetResourceByKernel(ctx, name, namespace, normalizedKernel, action, owner)
 	if err != nil {
 		if !errors.Is(err, ErrNoMatchingBuildSignResource) {
@@ -92,6 +93,10 @@ func (m *manager) Sync(ctx context.Context, mld *api.ModuleLoaderData, pushImage
 		logger.Info("Creating resource")
 		err = m.resourceManager.CreateResource(ctx, resourceTemplate)
 		if err != nil {
+			if k8serrors.IsAlreadyExists(err) {
+				logger.Info("Resource already exists, skipping creation (likely the client cache didn't update yet)")
+				return nil
+			}
 			return fmt.Errorf("could not create resource: %v", err)
 		}
 

--- a/internal/buildsign/manager_test.go
+++ b/internal/buildsign/manager_test.go
@@ -8,7 +8,9 @@ import (
 	. "github.com/onsi/gomega"
 	buildv1 "github.com/openshift/api/build/v1"
 	"go.uber.org/mock/gomock"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/api"
@@ -41,7 +43,7 @@ var _ = Describe("GetStatus", func() {
 	testMBSC := kmmv1beta1.ModuleBuildSignConfig{}
 
 	It("failed flow, GetResourceByKernel fails", func() {
-		normalizedKernel := kernel.NormalizeVersion(kernelVersion)
+		normalizedKernel := kernel.DNSSafeKernelVersion(kernelVersion)
 		mockResourceManager.EXPECT().GetResourceByKernel(ctx, mbscName, mbscNamespace, normalizedKernel,
 			kmmv1beta1.BuildImage, &testMBSC).
 			Return(nil, fmt.Errorf("some error"))
@@ -52,7 +54,7 @@ var _ = Describe("GetStatus", func() {
 	})
 
 	It("GetResourceByKernel returns pod does not exists", func() {
-		normalizedKernel := kernel.NormalizeVersion(kernelVersion)
+		normalizedKernel := kernel.DNSSafeKernelVersion(kernelVersion)
 		mockResourceManager.EXPECT().GetResourceByKernel(ctx, mbscName, mbscNamespace, normalizedKernel,
 			kmmv1beta1.BuildImage, &testMBSC).
 			Return(nil, ErrNoMatchingBuildSignResource)
@@ -64,7 +66,7 @@ var _ = Describe("GetStatus", func() {
 
 	It("failed flow, GetResourceStatus fails", func() {
 		foundBuild := buildv1.Build{}
-		normalizedKernel := kernel.NormalizeVersion(kernelVersion)
+		normalizedKernel := kernel.DNSSafeKernelVersion(kernelVersion)
 		gomock.InOrder(
 			mockResourceManager.EXPECT().GetResourceByKernel(ctx, mbscName, mbscNamespace, normalizedKernel,
 				kmmv1beta1.BuildImage, &testMBSC).
@@ -79,7 +81,7 @@ var _ = Describe("GetStatus", func() {
 
 	DescribeTable("check good flow and returned statuses", func(buildStatus Status, expectedStatus kmmv1beta1.BuildOrSignStatus) {
 		foundBuild := buildv1.Build{}
-		normalizedKernel := kernel.NormalizeVersion(kernelVersion)
+		normalizedKernel := kernel.DNSSafeKernelVersion(kernelVersion)
 		gomock.InOrder(
 			mockResourceManager.EXPECT().GetResourceByKernel(ctx, mbscName, mbscNamespace, normalizedKernel,
 				kmmv1beta1.BuildImage, &testMBSC).
@@ -164,6 +166,22 @@ var _ = Describe("Sync", func() {
 		)
 		err := mgr.Sync(ctx, testMLD, true, kmmv1beta1.BuildImage, &testMBSC)
 		Expect(err).To(HaveOccurred())
+	})
+
+	It("should treat AlreadyExists as success when creating a resource", func() {
+		testTemplate := buildv1.Build{}
+		alreadyExistsErr := k8serrors.NewAlreadyExists(
+			schema.GroupResource{Group: "build.openshift.io", Resource: "builds"}, "test-build")
+		gomock.InOrder(
+			mockResourceManager.EXPECT().MakeResourceTemplate(ctx, testMLD, &testMBSC, true, kmmv1beta1.BuildImage).
+				Return(&testTemplate, nil),
+			mockResourceManager.EXPECT().GetResourceByKernel(ctx, mbscName, mbscNamespace, kernelVersion,
+				kmmv1beta1.BuildImage, &testMBSC).
+				Return(nil, ErrNoMatchingBuildSignResource),
+			mockResourceManager.EXPECT().CreateResource(ctx, &testTemplate).Return(alreadyExistsErr),
+		)
+		err := mgr.Sync(ctx, testMLD, true, kmmv1beta1.BuildImage, &testMBSC)
+		Expect(err).To(BeNil())
 	})
 
 	It("IsResourceChanged failed", func() {

--- a/internal/buildsign/resource/common.go
+++ b/internal/buildsign/resource/common.go
@@ -288,11 +288,11 @@ func (rm *resourceManager) makeBuildTemplate(ctx context.Context, mld *api.Modul
 
 	build := &buildv1.Build{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: mld.Name + "-build-",
-			Namespace:    mld.Namespace,
-			Labels:       resourceLabels(mld.Name, mld.KernelNormalizedVersion, kmmv1beta1.BuildImage),
-			Annotations:  map[string]string{constants.ResourceHashAnnotation: fmt.Sprintf("%d", sourceConfigHash)},
-			Finalizers:   []string{constants.GCDelayFinalizer, constants.JobEventFinalizer},
+			Name:        mld.Name + "-build-" + mld.KernelNormalizedVersion,
+			Namespace:   mld.Namespace,
+			Labels:      resourceLabels(mld.Name, mld.KernelNormalizedVersion, kmmv1beta1.BuildImage),
+			Annotations: map[string]string{constants.ResourceHashAnnotation: fmt.Sprintf("%d", sourceConfigHash)},
+			Finalizers:  []string{constants.GCDelayFinalizer, constants.JobEventFinalizer},
 		},
 		Spec: *buildSpec,
 	}
@@ -344,9 +344,9 @@ func (rm *resourceManager) makeSignTemplate(ctx context.Context, mld *api.Module
 
 	sign := &buildv1.Build{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: mld.Name + "-sign-",
-			Namespace:    mld.Namespace,
-			Labels:       resourceLabels(mld.Name, mld.KernelNormalizedVersion, kmmv1beta1.SignImage),
+			Name:      mld.Name + "-sign-" + mld.KernelNormalizedVersion,
+			Namespace: mld.Namespace,
+			Labels:    resourceLabels(mld.Name, mld.KernelNormalizedVersion, kmmv1beta1.SignImage),
 			Annotations: map[string]string{
 				constants.ResourceHashAnnotation: fmt.Sprintf("%d", signSpecHash),
 			},

--- a/internal/buildsign/resource/common_test.go
+++ b/internal/buildsign/resource/common_test.go
@@ -118,8 +118,8 @@ var _ = Describe("makeBuildTemplate", func() {
 
 		expected := buildv1.Build{
 			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: moduleName + "-build-",
-				Namespace:    namespace,
+				Name:      mld.Name + "-build-" + mld.KernelNormalizedVersion,
+				Namespace: namespace,
 				OwnerReferences: []metav1.OwnerReference{
 					{
 						APIVersion:         "kmm.sigs.x-k8s.io/v1beta1",
@@ -386,9 +386,9 @@ COPY --from=signimage /opt/modules /modules
 `
 		expected := &buildv1.Build{
 			ObjectMeta: metav1.ObjectMeta{
-				Namespace:    namespace,
-				GenerateName: moduleName + "-sign-",
-				Labels:       resourceLabels(moduleName, kernelVersion, kmmv1beta1.SignImage),
+				Name:      mld.Name + "-sign-" + mld.KernelNormalizedVersion,
+				Namespace: namespace,
+				Labels:    resourceLabels(mld.Name, mld.KernelNormalizedVersion, kmmv1beta1.SignImage),
 				OwnerReferences: []metav1.OwnerReference{
 					{
 						APIVersion:         "kmm.sigs.x-k8s.io/v1beta1",

--- a/internal/buildsign/resource/resourcemanager_test.go
+++ b/internal/buildsign/resource/resourcemanager_test.go
@@ -54,12 +54,12 @@ var _ = Describe("GetResourceByKernel", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
-	It("should return an error if there are two Builds with the same labels and owner", func() {
+	It("should return error if more than 1 build exists", func() {
 		build1 := buildv1.Build{
-			ObjectMeta: metav1.ObjectMeta{Name: "buildName", Namespace: "moduleNamespace"},
+			ObjectMeta: metav1.ObjectMeta{Name: "buildName1", Namespace: "moduleNamespace"},
 		}
 		build2 := buildv1.Build{
-			ObjectMeta: metav1.ObjectMeta{Name: "buildName", Namespace: "moduleNamespace"},
+			ObjectMeta: metav1.ObjectMeta{Name: "buildName2", Namespace: "moduleNamespace"},
 		}
 
 		err := controllerutil.SetControllerReference(&mod, &build1, scheme)
@@ -71,12 +71,14 @@ var _ = Describe("GetResourceByKernel", func() {
 			EXPECT().
 			List(ctx, &buildv1.BuildList{}, gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, bcs *buildv1.BuildList, _ ...ctrlclient.ListOption) {
-				bcs.Items = make([]buildv1.Build, 2)
+				bcs.Items = []buildv1.Build{build1, build2}
 			})
 
-		_, err = rm.GetResourceByKernel(ctx, "moduleName", "moduleNamespace", targetKernel, kmmv1beta1.SignImage, &mod)
+		res, err := rm.GetResourceByKernel(ctx, mod.Name, mod.Namespace, "targetKernel", "resourceType", &mod)
 
 		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("expected 0 or 1"))
+		Expect(res).To(BeNil())
 	})
 
 	It("should work as expected", func() {

--- a/internal/controllers/mbsc_reconciler.go
+++ b/internal/controllers/mbsc_reconciler.go
@@ -184,7 +184,7 @@ func createMLD(mbscObj *kmmv1beta1.ModuleBuildSignConfig, imageSpec *kmmv1beta1.
 		Sign:                    imageSpec.Sign,
 		Owner:                   mbscObj,
 		KernelVersion:           imageSpec.KernelVersion,
-		KernelNormalizedVersion: kernel.NormalizeVersion(imageSpec.KernelVersion),
+		KernelNormalizedVersion: kernel.DNSSafeKernelVersion(imageSpec.KernelVersion),
 		ImageRepoSecret:         mbscObj.Spec.ImageRepoSecret,
 		RegistryTLS:             imageSpec.RegistryTLS,
 		Tolerations:             mbscObj.Spec.Tolerations,

--- a/internal/kernel/kernel.go
+++ b/internal/kernel/kernel.go
@@ -13,3 +13,9 @@ func replaceInvalidChar(r rune) rune {
 func NormalizeVersion(version string) string {
 	return strings.Map(replaceInvalidChar, version)
 }
+
+func DNSSafeKernelVersion(version string) string {
+	normalizedVersion := NormalizeVersion(version)
+	dns := strings.NewReplacer("_", "-", ".", "-").Replace(strings.ToLower(normalizedVersion))
+	return strings.Trim(dns, "-")
+}


### PR DESCRIPTION
Replace GenerateName with a deterministic Name for build and sign pods. The name is computed as {name}-{build|sign}-{KernelVersion}.

This addresses the root cause of a race between
the informer cache read (GetResourceByKernel returns 0 results because the cache is stale) and the API server write (Create) that allowed two fast reconcile events, each creating a pod, leaving the operator stuck
in an infinite "expected 0 or 1 … resources, got 2" error loop.

With deterministic names, both reconciles attempt to create the exact same pod name. The first succeeds, the second receives AlreadyExists from the API server and treats it as a successful no-op.

---

fixes #1796

---

/cc @yevgeny-shnaidman @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build and sign resources now use deterministic, predictable names based on module and kernel version.
  * Kernel versions are normalized to be DNS-compliant.

* **Bug Fixes**
  * Resources that already exist no longer cause failures; the system now logs the existing resource and continues successfully instead.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rh-ecosystem-edge/kernel-module-management/pull/1797)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->