### PR TITLE
Fix device plugin pod not evicted during node drain

### DIFF
--- a/internal/controllers/device_plugin_reconciler.go
+++ b/internal/controllers/device_plugin_reconciler.go
@@ -34,8 +34,10 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -74,6 +76,11 @@ func (r *DevicePluginReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kmmv1beta1.Module{}).
 		Owns(&appsv1.DaemonSet{}).
+		Watches(
+			&v1.Node{},
+			handler.EnqueueRequestsFromMapFunc(r.filter.FindModulesForNode),
+			builder.WithPredicates(filter.DevicePluginReconcilerNodePredicate()),
+		).
 		Named(DevicePluginReconcilerName).
 		Complete(
 			reconcile.AsReconciler[*kmmv1beta1.Module](r.client, r),
@@ -91,11 +98,18 @@ func (r *DevicePluginReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.
 	}
 
 	if mod.GetDeletionTimestamp() != nil {
+		if err = r.reconHelperAPI.removeDevicePluginTargetLabels(ctx, mod); err != nil {
+			return ctrl.Result{}, fmt.Errorf("could not remove device-plugin-target labels on deletion: %v", err)
+		}
 		err = r.reconHelperAPI.handleModuleDeletion(ctx, existingDevicePluginDS)
 		return ctrl.Result{}, err
 	}
 
 	r.reconHelperAPI.setKMMOMetrics(ctx)
+
+	if err = r.reconHelperAPI.handleDevicePluginTargetLabels(ctx, mod); err != nil {
+		return res, fmt.Errorf("could not reconcile device-plugin-target labels: %v", err)
+	}
 
 	err = r.reconHelperAPI.handleDevicePlugin(ctx, mod, existingDevicePluginDS)
 	if err != nil {
@@ -123,6 +137,8 @@ func (r *DevicePluginReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.
 type devicePluginReconcilerHelperAPI interface {
 	setKMMOMetrics(ctx context.Context)
 	handleDevicePlugin(ctx context.Context, mod *kmmv1beta1.Module, existingDevicePluginDS []appsv1.DaemonSet) error
+	handleDevicePluginTargetLabels(ctx context.Context, mod *kmmv1beta1.Module) error
+	removeDevicePluginTargetLabels(ctx context.Context, mod *kmmv1beta1.Module) error
 	garbageCollect(ctx context.Context, mod *kmmv1beta1.Module, existingDS []appsv1.DaemonSet) error
 	handleModuleDeletion(ctx context.Context, existingDevicePluginDS []appsv1.DaemonSet) error
 	moduleUpdateDevicePluginStatus(ctx context.Context, mod *kmmv1beta1.Module, existingDevicePluginDS []appsv1.DaemonSet) error
@@ -194,6 +210,57 @@ func (dprh *devicePluginReconcilerHelper) handleDevicePlugin(ctx context.Context
 	}
 
 	return err
+}
+
+// handleDevicePluginTargetLabels ensures the device-plugin-target label is present on schedulable
+// nodes targeted by the Module, and removed from unschedulable nodes.
+// This enables the device plugin DaemonSet to be evicted from draining nodes.
+func (dprh *devicePluginReconcilerHelper) handleDevicePluginTargetLabels(ctx context.Context, mod *kmmv1beta1.Module) error {
+	if mod.Spec.DevicePlugin == nil {
+		return nil
+	}
+
+	targetLabel := utils.GetDevicePluginTargetNodeLabel(mod.Namespace, mod.Name)
+
+	nodes, err := dprh.nodeAPI.GetAllNodesBySelector(ctx, mod.Spec.Selector)
+	if err != nil {
+		return fmt.Errorf("could not list nodes targeted by module: %v", err)
+	}
+
+	var errs []error
+	for i := range nodes {
+		node := &nodes[i]
+		if dprh.nodeAPI.IsNodeSchedulable(node, mod.Spec.Tolerations) {
+			if err := dprh.nodeAPI.UpdateLabels(ctx, node, map[string]string{targetLabel: ""}, nil); err != nil {
+				errs = append(errs, fmt.Errorf("could not add device-plugin-target label to node %s: %v", node.Name, err))
+			}
+		} else {
+			if err := dprh.nodeAPI.UpdateLabels(ctx, node, nil, map[string]string{targetLabel: ""}); err != nil {
+				errs = append(errs, fmt.Errorf("could not remove device-plugin-target label from node %s: %v", node.Name, err))
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func (dprh *devicePluginReconcilerHelper) removeDevicePluginTargetLabels(ctx context.Context, mod *kmmv1beta1.Module) error {
+	targetLabel := utils.GetDevicePluginTargetNodeLabel(mod.Namespace, mod.Name)
+
+	nodes, err := dprh.nodeAPI.GetAllNodesBySelector(ctx, map[string]string{targetLabel: ""})
+	if err != nil {
+		return fmt.Errorf("could not list nodes with device-plugin-target label: %v", err)
+	}
+
+	var errs []error
+	for i := range nodes {
+		node := &nodes[i]
+		if err := dprh.nodeAPI.UpdateLabels(ctx, node, nil, map[string]string{targetLabel: ""}); err != nil {
+			errs = append(errs, fmt.Errorf("could not remove device-plugin-target label from node %s: %v", node.Name, err))
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 func (dprh *devicePluginReconcilerHelper) garbageCollect(ctx context.Context,
@@ -413,7 +480,10 @@ func generatePodContainerSpec(containerSpec *kmmv1beta1.DevicePluginContainerSpe
 
 func generateDevicePluginLabelsAndSelector(mod *kmmv1beta1.Module) (map[string]string, map[string]string) {
 	labels := map[string]string{constants.ModuleNameLabel: mod.Name}
-	nodeSelector := map[string]string{utils.GetKernelModuleReadyNodeLabel(mod.Namespace, mod.Name): ""}
+	nodeSelector := map[string]string{
+		utils.GetKernelModuleReadyNodeLabel(mod.Namespace, mod.Name):  "",
+		utils.GetDevicePluginTargetNodeLabel(mod.Namespace, mod.Name): "",
+	}
 
 	if mod.Spec.ModuleLoader != nil && mod.Spec.ModuleLoader.Container.Version != "" {
 		versionLabel := utils.GetDevicePluginVersionLabelName(mod.Namespace, mod.Name)

--- a/internal/controllers/device_plugin_reconciler_test.go
+++ b/internal/controllers/device_plugin_reconciler_test.go
@@ -49,7 +49,7 @@ var _ = Describe("DevicePluginReconciler_Reconcile", func() {
 
 	ctx := context.Background()
 
-	DescribeTable("check error flows", func(getDSError, handlePluginError, gcError bool) {
+	DescribeTable("check error flows", func(getDSError, handleTargetLabelsError, handlePluginError, gcError bool) {
 		devicePluginDS := []appsv1.DaemonSet{appsv1.DaemonSet{}}
 		returnedError := fmt.Errorf("some error")
 		if getDSError {
@@ -58,6 +58,11 @@ var _ = Describe("DevicePluginReconciler_Reconcile", func() {
 		}
 		mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(devicePluginDS, nil)
 		mockReconHelper.EXPECT().setKMMOMetrics(ctx)
+		if handleTargetLabelsError {
+			mockReconHelper.EXPECT().handleDevicePluginTargetLabels(ctx, mod).Return(returnedError)
+			goto executeTestFunction
+		}
+		mockReconHelper.EXPECT().handleDevicePluginTargetLabels(ctx, mod).Return(nil)
 		if handlePluginError {
 			mockReconHelper.EXPECT().handleDevicePlugin(ctx, mod, devicePluginDS).Return(returnedError)
 			goto executeTestFunction
@@ -77,10 +82,11 @@ var _ = Describe("DevicePluginReconciler_Reconcile", func() {
 		Expect(err).To(HaveOccurred())
 
 	},
-		Entry("getDevicePluginDaemonSets failed", true, false, false),
-		Entry("handleDevicePlugin failed", false, true, false),
-		Entry("garbageCollect failed", false, false, true),
-		Entry("devicePluginUpdateStatus failed", false, false, false),
+		Entry("getDevicePluginDaemonSets failed", true, false, false, false),
+		Entry("handleDevicePluginTargetLabels failed", false, true, false, false),
+		Entry("handleDevicePlugin failed", false, false, true, false),
+		Entry("garbageCollect failed", false, false, false, true),
+		Entry("devicePluginUpdateStatus failed", false, false, false, false),
 	)
 
 	It("Good flow", func() {
@@ -88,6 +94,7 @@ var _ = Describe("DevicePluginReconciler_Reconcile", func() {
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(devicePluginDS, nil),
 			mockReconHelper.EXPECT().setKMMOMetrics(ctx),
+			mockReconHelper.EXPECT().handleDevicePluginTargetLabels(ctx, mod).Return(nil),
 			mockReconHelper.EXPECT().handleDevicePlugin(ctx, mod, devicePluginDS).Return(nil),
 			mockReconHelper.EXPECT().garbageCollect(ctx, mod, devicePluginDS).Return(nil),
 			mockReconHelper.EXPECT().moduleUpdateDevicePluginStatus(ctx, mod, devicePluginDS).Return(nil),
@@ -106,6 +113,7 @@ var _ = Describe("DevicePluginReconciler_Reconcile", func() {
 		By("good flow")
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(devicePluginDS, nil),
+			mockReconHelper.EXPECT().removeDevicePluginTargetLabels(ctx, mod).Return(nil),
 			mockReconHelper.EXPECT().handleModuleDeletion(ctx, devicePluginDS).Return(nil),
 		)
 
@@ -113,9 +121,20 @@ var _ = Describe("DevicePluginReconciler_Reconcile", func() {
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).NotTo(HaveOccurred())
 
-		By("error flow")
+		By("error flow - removeDevicePluginTargetLabels fails")
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(devicePluginDS, nil),
+			mockReconHelper.EXPECT().removeDevicePluginTargetLabels(ctx, mod).Return(fmt.Errorf("some error")),
+		)
+
+		res, err = dpr.Reconcile(ctx, mod)
+		Expect(res).To(Equal(reconcile.Result{}))
+		Expect(err).To(HaveOccurred())
+
+		By("error flow - handleModuleDeletion fails")
+		gomock.InOrder(
+			mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(devicePluginDS, nil),
+			mockReconHelper.EXPECT().removeDevicePluginTargetLabels(ctx, mod).Return(nil),
 			mockReconHelper.EXPECT().handleModuleDeletion(ctx, devicePluginDS).Return(fmt.Errorf("some error")),
 		)
 
@@ -857,7 +876,10 @@ var _ = Describe("DevicePluginReconciler_setDevicePluginAsDesired", func() {
 		),
 		Entry("moduleLoader is defined",
 			&kmmv1beta1.ModuleLoaderSpec{},
-			map[string]string{utils.GetKernelModuleReadyNodeLabel(namespace, moduleName): ""},
+			map[string]string{
+				utils.GetKernelModuleReadyNodeLabel(namespace, moduleName):  "",
+				utils.GetDevicePluginTargetNodeLabel(namespace, moduleName): "",
+			},
 			true,
 		),
 	)
@@ -964,5 +986,91 @@ var _ = Describe("DevicePluginReconciler_getModuleDevicePluginDaemonSets", func(
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(dsList).To(Equal([]appsv1.DaemonSet{ds1, ds3}))
+	})
+})
+
+var _ = Describe("devicePluginReconcilerHelper_handleDevicePluginTargetLabels", func() {
+	var (
+		ctrl *gomock.Controller
+		clnt *client.MockClient
+		nm   *node.MockNode
+		dprh devicePluginReconcilerHelper
+		ctx  context.Context
+		mod  *kmmv1beta1.Module
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		nm = node.NewMockNode(ctrl)
+		ctx = context.Background()
+		dprh = devicePluginReconcilerHelper{
+			client:  clnt,
+			nodeAPI: nm,
+		}
+		mod = &kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: moduleName},
+			Spec: kmmv1beta1.ModuleSpec{
+				DevicePlugin: &kmmv1beta1.DevicePluginSpec{},
+			},
+		}
+	})
+
+	It("should return nil when DevicePlugin is nil", func() {
+		mod.Spec.DevicePlugin = nil
+		err := dprh.handleDevicePluginTargetLabels(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should add target label to schedulable node", func() {
+		targetLabel := utils.GetDevicePluginTargetNodeLabel(namespace, moduleName)
+
+		schedulableNode := v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "schedulable-node"},
+		}
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{schedulableNode}, nil)
+		nm.EXPECT().IsNodeSchedulable(&schedulableNode, mod.Spec.Tolerations).Return(true)
+		nm.EXPECT().UpdateLabels(ctx, &schedulableNode, map[string]string{targetLabel: ""}, nil).Return(nil)
+
+		err := dprh.handleDevicePluginTargetLabels(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should remove target label from unschedulable node", func() {
+		targetLabel := utils.GetDevicePluginTargetNodeLabel(namespace, moduleName)
+
+		unschedulableNode := v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "unschedulable-node"},
+		}
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{unschedulableNode}, nil)
+		nm.EXPECT().IsNodeSchedulable(&unschedulableNode, mod.Spec.Tolerations).Return(false)
+		nm.EXPECT().UpdateLabels(ctx, &unschedulableNode, nil, map[string]string{targetLabel: ""}).Return(nil)
+
+		err := dprh.handleDevicePluginTargetLabels(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should continue processing nodes if one fails and return combined error", func() {
+		targetLabel := utils.GetDevicePluginTargetNodeLabel(namespace, moduleName)
+
+		node1 := v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+		}
+		node2 := v1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "node2"},
+		}
+
+		nm.EXPECT().GetAllNodesBySelector(ctx, mod.Spec.Selector).Return([]v1.Node{node1, node2}, nil)
+		nm.EXPECT().IsNodeSchedulable(&node1, mod.Spec.Tolerations).Return(true)
+		nm.EXPECT().UpdateLabels(ctx, &node1, map[string]string{targetLabel: ""}, nil).Return(fmt.Errorf("conflict"))
+		nm.EXPECT().IsNodeSchedulable(&node2, mod.Spec.Tolerations).Return(true)
+		nm.EXPECT().UpdateLabels(ctx, &node2, map[string]string{targetLabel: ""}, nil).Return(nil)
+
+		err := dprh.handleDevicePluginTargetLabels(ctx, mod)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("node1"))
+		Expect(err.Error()).NotTo(ContainSubstring("node2"))
 	})
 })

--- a/internal/controllers/mock_device_plugin_reconciler.go
+++ b/internal/controllers/mock_device_plugin_reconciler.go
@@ -83,6 +83,20 @@ func (mr *MockdevicePluginReconcilerHelperAPIMockRecorder) handleDevicePlugin(ct
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleDevicePlugin", reflect.TypeOf((*MockdevicePluginReconcilerHelperAPI)(nil).handleDevicePlugin), ctx, mod, existingDevicePluginDS)
 }
 
+// handleDevicePluginTargetLabels mocks base method.
+func (m *MockdevicePluginReconcilerHelperAPI) handleDevicePluginTargetLabels(ctx context.Context, mod *v1beta1.Module) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "handleDevicePluginTargetLabels", ctx, mod)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// handleDevicePluginTargetLabels indicates an expected call of handleDevicePluginTargetLabels.
+func (mr *MockdevicePluginReconcilerHelperAPIMockRecorder) handleDevicePluginTargetLabels(ctx, mod any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleDevicePluginTargetLabels", reflect.TypeOf((*MockdevicePluginReconcilerHelperAPI)(nil).handleDevicePluginTargetLabels), ctx, mod)
+}
+
 // handleModuleDeletion mocks base method.
 func (m *MockdevicePluginReconcilerHelperAPI) handleModuleDeletion(ctx context.Context, existingDevicePluginDS []v1.DaemonSet) error {
 	m.ctrl.T.Helper()
@@ -109,6 +123,20 @@ func (m *MockdevicePluginReconcilerHelperAPI) moduleUpdateDevicePluginStatus(ctx
 func (mr *MockdevicePluginReconcilerHelperAPIMockRecorder) moduleUpdateDevicePluginStatus(ctx, mod, existingDevicePluginDS any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "moduleUpdateDevicePluginStatus", reflect.TypeOf((*MockdevicePluginReconcilerHelperAPI)(nil).moduleUpdateDevicePluginStatus), ctx, mod, existingDevicePluginDS)
+}
+
+// removeDevicePluginTargetLabels mocks base method.
+func (m *MockdevicePluginReconcilerHelperAPI) removeDevicePluginTargetLabels(ctx context.Context, mod *v1beta1.Module) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "removeDevicePluginTargetLabels", ctx, mod)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// removeDevicePluginTargetLabels indicates an expected call of removeDevicePluginTargetLabels.
+func (mr *MockdevicePluginReconcilerHelperAPIMockRecorder) removeDevicePluginTargetLabels(ctx, mod any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "removeDevicePluginTargetLabels", reflect.TypeOf((*MockdevicePluginReconcilerHelperAPI)(nil).removeDevicePluginTargetLabels), ctx, mod)
 }
 
 // setKMMOMetrics mocks base method.

--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -156,7 +156,7 @@ func (mr *ModuleReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.Modul
 	}
 
 	// get nodes targeted by selector
-	targetedNodes, err := mr.nodeAPI.GetNodesListBySelector(ctx, mod.Spec.Selector, append(mod.Spec.Tolerations, module.InternalTolerations...))
+	targetedNodes, err := mr.nodeAPI.GetSchedulableNodesBySelector(ctx, mod.Spec.Selector, append(mod.Spec.Tolerations, module.InternalTolerations...))
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to get list of nodes by selector: %v", err)
 	}

--- a/internal/controllers/module_reconciler_test.go
+++ b/internal/controllers/module_reconciler_test.go
@@ -122,10 +122,10 @@ var _ = Describe("Reconcile", func() {
 		}
 		mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, mod).Return(nil)
 		if c.getNodesError {
-			mn.EXPECT().GetNodesListBySelector(ctx, mod.Spec.Selector, module.InternalTolerations).Return(nil, returnedError)
+			mn.EXPECT().GetSchedulableNodesBySelector(ctx, mod.Spec.Selector, module.InternalTolerations).Return(nil, returnedError)
 			goto executeTestFunction
 		}
-		mn.EXPECT().GetNodesListBySelector(ctx, mod.Spec.Selector, module.InternalTolerations).Return(targetedNodes, nil)
+		mn.EXPECT().GetSchedulableNodesBySelector(ctx, mod.Spec.Selector, module.InternalTolerations).Return(targetedNodes, nil)
 		if c.handleMICError {
 			mockReconHelper.EXPECT().handleMIC(ctx, mod, targetedNodes).Return(returnedError)
 			goto executeTestFunction
@@ -186,7 +186,7 @@ var _ = Describe("Reconcile", func() {
 			mockReconHelper.EXPECT().handleNetworkPolicies(ctx, mod).Return(nil),
 			mockNamespaceHelper.EXPECT().setLabel(ctx, mod.Namespace),
 			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, mod).Return(nil),
-			mn.EXPECT().GetNodesListBySelector(ctx, mod.Spec.Selector, module.InternalTolerations).Return(targetedNodes, nil),
+			mn.EXPECT().GetSchedulableNodesBySelector(ctx, mod.Spec.Selector, module.InternalTolerations).Return(targetedNodes, nil),
 			mockReconHelper.EXPECT().handleMIC(ctx, mod, targetedNodes).Return(nil),
 			mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, mod).Return(currentNMCs, nil),
 			mockReconHelper.EXPECT().prepareSchedulingData(ctx, mod, targetedNodes, currentNMCs).Return(nmcMLDConfigs, nil),
@@ -206,7 +206,7 @@ var _ = Describe("Reconcile", func() {
 			mockReconHelper.EXPECT().handleNetworkPolicies(ctx, mod).Return(nil),
 			mockNamespaceHelper.EXPECT().setLabel(ctx, mod.Namespace),
 			mockReconHelper.EXPECT().setFinalizerAndStatus(ctx, mod).Return(nil),
-			mn.EXPECT().GetNodesListBySelector(ctx, mod.Spec.Selector, module.InternalTolerations).Return(targetedNodes, nil),
+			mn.EXPECT().GetSchedulableNodesBySelector(ctx, mod.Spec.Selector, module.InternalTolerations).Return(targetedNodes, nil),
 			mockReconHelper.EXPECT().handleMIC(ctx, mod, targetedNodes).Return(nil),
 			mockReconHelper.EXPECT().getNMCsByModuleSet(ctx, mod).Return(currentNMCs, nil),
 			mockReconHelper.EXPECT().prepareSchedulingData(ctx, mod, targetedNodes, currentNMCs).Return(nmcMLDConfigs, nil),

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -189,6 +189,13 @@ func ModuleReconcilerNodePredicate() predicate.Predicate {
 	)
 }
 
+func DevicePluginReconcilerNodePredicate() predicate.Predicate {
+	return predicate.And(
+		skipDeletions,
+		nodeTaintsChanged,
+	)
+}
+
 func ModuleReconcileBuildPredicate() predicate.Predicate {
 	return predicate.And(
 		skipDeletions,

--- a/internal/node/mock_node.go
+++ b/internal/node/mock_node.go
@@ -39,19 +39,19 @@ func (m *MockNode) EXPECT() *MockNodeMockRecorder {
 	return m.recorder
 }
 
-// GetNodesListBySelector mocks base method.
-func (m *MockNode) GetNodesListBySelector(ctx context.Context, selector map[string]string, tolerations []v1.Toleration) ([]v1.Node, error) {
+// GetAllNodesBySelector mocks base method.
+func (m *MockNode) GetAllNodesBySelector(ctx context.Context, selector map[string]string) ([]v1.Node, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNodesListBySelector", ctx, selector, tolerations)
+	ret := m.ctrl.Call(m, "GetAllNodesBySelector", ctx, selector)
 	ret0, _ := ret[0].([]v1.Node)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetNodesListBySelector indicates an expected call of GetNodesListBySelector.
-func (mr *MockNodeMockRecorder) GetNodesListBySelector(ctx, selector, tolerations any) *gomock.Call {
+// GetAllNodesBySelector indicates an expected call of GetAllNodesBySelector.
+func (mr *MockNodeMockRecorder) GetAllNodesBySelector(ctx, selector any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNodesListBySelector", reflect.TypeOf((*MockNode)(nil).GetNodesListBySelector), ctx, selector, tolerations)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllNodesBySelector", reflect.TypeOf((*MockNode)(nil).GetAllNodesBySelector), ctx, selector)
 }
 
 // GetNumTargetedNodes mocks base method.
@@ -67,6 +67,21 @@ func (m *MockNode) GetNumTargetedNodes(ctx context.Context, selector map[string]
 func (mr *MockNodeMockRecorder) GetNumTargetedNodes(ctx, selector, tolerations any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNumTargetedNodes", reflect.TypeOf((*MockNode)(nil).GetNumTargetedNodes), ctx, selector, tolerations)
+}
+
+// GetSchedulableNodesBySelector mocks base method.
+func (m *MockNode) GetSchedulableNodesBySelector(ctx context.Context, selector map[string]string, tolerations []v1.Toleration) ([]v1.Node, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSchedulableNodesBySelector", ctx, selector, tolerations)
+	ret0, _ := ret[0].([]v1.Node)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSchedulableNodesBySelector indicates an expected call of GetSchedulableNodesBySelector.
+func (mr *MockNodeMockRecorder) GetSchedulableNodesBySelector(ctx, selector, tolerations any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSchedulableNodesBySelector", reflect.TypeOf((*MockNode)(nil).GetSchedulableNodesBySelector), ctx, selector, tolerations)
 }
 
 // IsNodeRebooted mocks base method.

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -14,7 +14,8 @@ import (
 
 type Node interface {
 	IsNodeSchedulable(node *v1.Node, tolerations []v1.Toleration) bool
-	GetNodesListBySelector(ctx context.Context, selector map[string]string, tolerations []v1.Toleration) ([]v1.Node, error)
+	GetAllNodesBySelector(ctx context.Context, selector map[string]string) ([]v1.Node, error)
+	GetSchedulableNodesBySelector(ctx context.Context, selector map[string]string, tolerations []v1.Toleration) ([]v1.Node, error)
 	GetNumTargetedNodes(ctx context.Context, selector map[string]string, tolerations []v1.Toleration) (int, error)
 	UpdateLabels(ctx context.Context, node *v1.Node, toBeAdded, toBeRemoved map[string]string) error
 	IsNodeRebooted(node *v1.Node, statusBootId string) bool
@@ -46,7 +47,7 @@ func (n *node) IsNodeSchedulable(node *v1.Node, tolerations []v1.Toleration) boo
 	return true
 }
 
-func (n *node) GetNodesListBySelector(ctx context.Context, selector map[string]string, tolerations []v1.Toleration) ([]v1.Node, error) {
+func (n *node) GetAllNodesBySelector(ctx context.Context, selector map[string]string) ([]v1.Node, error) {
 	logger := log.FromContext(ctx)
 	logger.V(1).Info("Listing nodes", "selector", selector)
 
@@ -55,18 +56,26 @@ func (n *node) GetNodesListBySelector(ctx context.Context, selector map[string]s
 	if err := n.client.List(ctx, &selectedNodes, opt); err != nil {
 		return nil, fmt.Errorf("could not list nodes: %v", err)
 	}
-	nodes := make([]v1.Node, 0, len(selectedNodes.Items))
+	return selectedNodes.Items, nil
+}
 
-	for _, node := range selectedNodes.Items {
-		if n.IsNodeSchedulable(&node, tolerations) {
-			nodes = append(nodes, node)
+func (n *node) GetSchedulableNodesBySelector(ctx context.Context, selector map[string]string, tolerations []v1.Toleration) ([]v1.Node, error) {
+	allNodes, err := n.GetAllNodesBySelector(ctx, selector)
+	if err != nil {
+		return nil, fmt.Errorf("could not get all nodes by selector: %v", err)
+	}
+
+	nodes := make([]v1.Node, 0, len(allNodes))
+	for i := range allNodes {
+		if n.IsNodeSchedulable(&allNodes[i], tolerations) {
+			nodes = append(nodes, allNodes[i])
 		}
 	}
 	return nodes, nil
 }
 
 func (n *node) GetNumTargetedNodes(ctx context.Context, selector map[string]string, tolerations []v1.Toleration) (int, error) {
-	targetedNode, err := n.GetNodesListBySelector(ctx, selector, tolerations)
+	targetedNode, err := n.GetSchedulableNodesBySelector(ctx, selector, tolerations)
 	if err != nil {
 		return 0, fmt.Errorf("could not list nodes: %v", err)
 	}

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -60,7 +60,53 @@ var _ = Describe("IsNodeSchedulable", func() {
 	})
 })
 
-var _ = Describe("GetNodesListBySelector", func() {
+var _ = Describe("GetAllNodesBySelector", func() {
+	var (
+		ctrl *gomock.Controller
+		clnt *client.MockClient
+		mn   Node
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		mn = NewNode(clnt)
+	})
+
+	It("should return error when list fails", func() {
+		clnt.EXPECT().List(context.Background(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
+
+		nodes, err := mn.GetAllNodesBySelector(context.Background(), map[string]string{})
+
+		Expect(err).To(HaveOccurred())
+		Expect(nodes).To(BeNil())
+	})
+
+	It("should return all nodes regardless of schedulability", func() {
+		node1 := v1.Node{
+			Spec: v1.NodeSpec{
+				Taints: []v1.Taint{
+					{Effect: v1.TaintEffectNoSchedule},
+				},
+			},
+		}
+		node2 := v1.Node{}
+
+		clnt.EXPECT().List(context.Background(), gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ interface{}, list *v1.NodeList, _ ...interface{}) error {
+				list.Items = []v1.Node{node1, node2}
+				return nil
+			},
+		)
+
+		nodes, err := mn.GetAllNodesBySelector(context.Background(), map[string]string{"key": "value"})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nodes).To(Equal([]v1.Node{node1, node2}))
+	})
+})
+
+var _ = Describe("GetSchedulableNodesBySelector", func() {
 	var (
 		ctrl *gomock.Controller
 		clnt *client.MockClient
@@ -76,7 +122,7 @@ var _ = Describe("GetNodesListBySelector", func() {
 	It("list failed", func() {
 		clnt.EXPECT().List(context.Background(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
 
-		nodes, err := mn.GetNodesListBySelector(context.Background(), map[string]string{}, nil)
+		nodes, err := mn.GetSchedulableNodesBySelector(context.Background(), map[string]string{}, nil)
 
 		Expect(err).To(HaveOccurred())
 		Expect(nodes).To(BeNil())
@@ -108,7 +154,7 @@ var _ = Describe("GetNodesListBySelector", func() {
 				return nil
 			},
 		)
-		nodes, err := mn.GetNodesListBySelector(context.Background(), map[string]string{}, nil)
+		nodes, err := mn.GetSchedulableNodesBySelector(context.Background(), map[string]string{}, nil)
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(nodes).To(Equal([]v1.Node{node2, node3}))
@@ -142,7 +188,7 @@ var _ = Describe("GetNodesListBySelector", func() {
 				return nil
 			},
 		)
-		nodes, err := mn.GetNodesListBySelector(context.Background(),
+		nodes, err := mn.GetSchedulableNodesBySelector(context.Background(),
 			map[string]string{},
 			[]v1.Toleration{
 				{

--- a/internal/utils/kmmlabels.go
+++ b/internal/utils/kmmlabels.go
@@ -85,6 +85,10 @@ func GetDevicePluginNodeLabel(namespace, moduleName string) string {
 	return fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.device-plugin-ready", namespace, moduleName)
 }
 
+func GetDevicePluginTargetNodeLabel(namespace, moduleName string) string {
+	return fmt.Sprintf("kmm.node.kubernetes.io/%s.%s.device-plugin-target", namespace, moduleName)
+}
+
 func IsDeprecatedKernelModuleReadyNodeLabel(label string) bool {
 	return reDeprecatedKernelModuleReadyLabel.MatchString(label)
 }


### PR DESCRIPTION
When a node is drained, the device plugin DaemonSet pod remains running because DaemonSet pods auto-tolerate NoSchedule taints and the only nodeSelector was the kmm-ready label (which stays while the kmod is loaded). This creates a deadlock: the unloader cannot run while the device plugin holds device files, and the device plugin won't leave because kmm-ready is never removed.

Introduce a new device-plugin-target node label managed by the DevicePluginReconciler. The DaemonSet nodeSelector now requires both kmm-ready AND device-plugin-target. The DevicePluginReconciler watches node taint changes: it adds device-plugin-target to schedulable nodes matching the Module selector, and removes it from unschedulable nodes. This causes the DaemonSet controller to evict the device plugin pod during drain, breaking the deadlock.



---



fixes #1801



---



/cc @yevgeny-shnaidman @ybettan 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device plugins are now automatically labeled on targeted nodes, enabling their eviction from draining nodes.
  * Device-plugin DaemonSet targeting now includes both kernel-ready and device-plugin-specific node labels.

* **Improvements**
  * Module reconciliation now exclusively targets schedulable nodes based on tolerations.
  * Device plugins monitor node taint changes for enhanced cluster responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->