### PR TITLE
Bump origin-cli base image from 4.20 to 4.22 in must-gather

### DIFF
--- a/Dockerfile.must-gather
+++ b/Dockerfile.must-gather
@@ -1,4 +1,4 @@
-FROM quay.io/openshift/origin-cli:4.20 as builder
+FROM quay.io/openshift/origin-cli:4.22 as builder
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4
 


### PR DESCRIPTION
/cc @ybettan @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated base container image to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->