### PR TITLE
Add NetworkPolicy for device plugin pods

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -154,6 +154,7 @@ func main() {
 		metricsAPI,
 		filterAPI,
 		nodeAPI,
+		networkPolicyAPI,
 		scheme,
 		operatorNamespace)
 	if err = dpc.SetupWithManager(mgr); err != nil {

--- a/internal/controllers/device_plugin_reconciler.go
+++ b/internal/controllers/device_plugin_reconciler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/filter"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/metrics"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/networkpolicy"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/node"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	appsv1 "k8s.io/api/apps/v1"
@@ -60,10 +61,11 @@ func NewDevicePluginReconciler(
 	metricsAPI metrics.Metrics,
 	filter *filter.Filter,
 	nodeAPI node.Node,
+	networkPolicyAPI networkpolicy.NetworkPolicy,
 	scheme *runtime.Scheme,
 	operatorNamespace string,
 ) *DevicePluginReconciler {
-	reconHelperAPI := newDevicePluginReconcilerHelper(client, metricsAPI, nodeAPI, scheme, operatorNamespace)
+	reconHelperAPI := newDevicePluginReconcilerHelper(client, metricsAPI, nodeAPI, networkPolicyAPI, scheme, operatorNamespace)
 	return &DevicePluginReconciler{
 		client:         client,
 		reconHelperAPI: reconHelperAPI,
@@ -103,6 +105,10 @@ func (r *DevicePluginReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.
 		}
 		err = r.reconHelperAPI.deleteDevicePluginDaemonSets(ctx, existingDevicePluginDS)
 		return ctrl.Result{}, err
+	}
+
+	if err = r.reconHelperAPI.handleDevicePluginNetworkPolicy(ctx, mod); err != nil {
+		return res, fmt.Errorf("failed to handle device plugin NetworkPolicy: %v", err)
 	}
 
 	r.reconHelperAPI.setKMMOMetrics(ctx)
@@ -147,6 +153,7 @@ type devicePluginReconcilerHelperAPI interface {
 	setKMMOMetrics(ctx context.Context)
 	handleDevicePlugin(ctx context.Context, mod *kmmv1beta1.Module, existingDevicePluginDS []appsv1.DaemonSet) error
 	handleDevicePluginTargetLabels(ctx context.Context, mod *kmmv1beta1.Module) error
+	handleDevicePluginNetworkPolicy(ctx context.Context, mod *kmmv1beta1.Module) error
 	removeDevicePluginTargetLabels(ctx context.Context, mod *kmmv1beta1.Module) error
 	garbageCollect(ctx context.Context, mod *kmmv1beta1.Module, existingDS []appsv1.DaemonSet) error
 	deleteDevicePluginDaemonSets(ctx context.Context, existingDevicePluginDS []appsv1.DaemonSet) error
@@ -156,23 +163,26 @@ type devicePluginReconcilerHelperAPI interface {
 }
 
 type devicePluginReconcilerHelper struct {
-	client          client.Client
-	metricsAPI      metrics.Metrics
-	daemonSetHelper daemonSetCreator
-	nodeAPI         node.Node
+	client           client.Client
+	metricsAPI       metrics.Metrics
+	daemonSetHelper  daemonSetCreator
+	networkPolicyAPI networkpolicy.NetworkPolicy
+	nodeAPI          node.Node
 }
 
 func newDevicePluginReconcilerHelper(client client.Client,
 	metricsAPI metrics.Metrics,
 	nodeAPI node.Node,
+	networkPolicyAPI networkpolicy.NetworkPolicy,
 	scheme *runtime.Scheme,
 	operatorNamespace string) devicePluginReconcilerHelperAPI {
 	daemonSetHelper := newDaemonSetCreator(scheme, operatorNamespace)
 	return &devicePluginReconcilerHelper{
-		client:          client,
-		metricsAPI:      metricsAPI,
-		daemonSetHelper: daemonSetHelper,
-		nodeAPI:         nodeAPI,
+		client:           client,
+		metricsAPI:       metricsAPI,
+		daemonSetHelper:  daemonSetHelper,
+		networkPolicyAPI: networkPolicyAPI,
+		nodeAPI:          nodeAPI,
 	}
 }
 
@@ -253,6 +263,23 @@ func (dprh *devicePluginReconcilerHelper) handleDevicePluginTargetLabels(ctx con
 	}
 
 	return errors.Join(errs...)
+}
+
+func (dprh *devicePluginReconcilerHelper) handleDevicePluginNetworkPolicy(ctx context.Context, mod *kmmv1beta1.Module) error {
+	if mod.Spec.DevicePlugin == nil {
+		return nil
+	}
+
+	logger := log.FromContext(ctx)
+	logger.Info("Handling DevicePlugin NetworkPolicy", "module", mod.Name, "namespace", mod.Namespace)
+
+	devicePluginPolicy := dprh.networkPolicyAPI.DevicePluginNetworkPolicy(mod.Namespace)
+	if err := dprh.networkPolicyAPI.CreateOrAddOwnerReference(ctx, devicePluginPolicy, mod); err != nil {
+		return fmt.Errorf("failed to ensure DevicePlugin NetworkPolicy %s/%s: %v", devicePluginPolicy.Namespace, devicePluginPolicy.Name, err)
+	}
+
+	logger.Info("Successfully handled DevicePlugin NetworkPolicy")
+	return nil
 }
 
 func (dprh *devicePluginReconcilerHelper) removeDevicePluginTargetLabels(ctx context.Context, mod *kmmv1beta1.Module) error {
@@ -444,6 +471,14 @@ func (dsci *daemonSetCreatorImpl) setDevicePluginAsDesired(
 
 	standardLabels, nodeSelector := generateDevicePluginLabelsAndSelector(mod)
 
+	podTemplateLabels := make(map[string]string, len(standardLabels)+3)
+	for k, v := range standardLabels {
+		podTemplateLabels[k] = v
+	}
+	podTemplateLabels["app.kubernetes.io/name"] = "kmm"
+	podTemplateLabels["app.kubernetes.io/component"] = "device-plugin"
+	podTemplateLabels["app.kubernetes.io/part-of"] = "kmm"
+
 	ds.SetLabels(
 		overrideLabels(ds.GetLabels(), standardLabels),
 	)
@@ -461,7 +496,7 @@ func (dsci *daemonSetCreatorImpl) setDevicePluginAsDesired(
 		Selector: &metav1.LabelSelector{MatchLabels: standardLabels},
 		Template: v1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels:     standardLabels,
+				Labels:     podTemplateLabels,
 				Finalizers: []string{constants.NodeLabelerFinalizer},
 			},
 			Spec: v1.PodSpec{

--- a/internal/controllers/device_plugin_reconciler_test.go
+++ b/internal/controllers/device_plugin_reconciler_test.go
@@ -13,11 +13,13 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/metrics"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/networkpolicy"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/node"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,7 +55,7 @@ var _ = Describe("DevicePluginReconciler_Reconcile", func() {
 
 	ctx := context.Background()
 
-	DescribeTable("check error flows", func(getDSError, handleTargetLabelsError, handlePluginError, gcError bool) {
+	DescribeTable("check error flows", func(getDSError, handleNetworkPolicyError, handleTargetLabelsError, handlePluginError, gcError bool) {
 		devicePluginDS := []appsv1.DaemonSet{appsv1.DaemonSet{}}
 		returnedError := fmt.Errorf("some error")
 		if getDSError {
@@ -61,6 +63,11 @@ var _ = Describe("DevicePluginReconciler_Reconcile", func() {
 			goto executeTestFunction
 		}
 		mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(devicePluginDS, nil)
+		if handleNetworkPolicyError {
+			mockReconHelper.EXPECT().handleDevicePluginNetworkPolicy(ctx, mod).Return(returnedError)
+			goto executeTestFunction
+		}
+		mockReconHelper.EXPECT().handleDevicePluginNetworkPolicy(ctx, mod).Return(nil)
 		mockReconHelper.EXPECT().setKMMOMetrics(ctx)
 		if handleTargetLabelsError {
 			mockReconHelper.EXPECT().handleDevicePluginTargetLabels(ctx, mod).Return(returnedError)
@@ -86,17 +93,19 @@ var _ = Describe("DevicePluginReconciler_Reconcile", func() {
 		Expect(err).To(HaveOccurred())
 
 	},
-		Entry("getDevicePluginDaemonSets failed", true, false, false, false),
-		Entry("handleDevicePluginTargetLabels failed", false, true, false, false),
-		Entry("handleDevicePlugin failed", false, false, true, false),
-		Entry("garbageCollect failed", false, false, false, true),
-		Entry("devicePluginUpdateStatus failed", false, false, false, false),
+		Entry("getDevicePluginDaemonSets failed", true, false, false, false, false),
+		Entry("handleDevicePluginNetworkPolicy failed", false, true, false, false, false),
+		Entry("handleDevicePluginTargetLabels failed", false, false, true, false, false),
+		Entry("handleDevicePlugin failed", false, false, false, true, false),
+		Entry("garbageCollect failed", false, false, false, false, true),
+		Entry("devicePluginUpdateStatus failed", false, false, false, false, false),
 	)
 
 	It("Good flow", func() {
 		devicePluginDS := []appsv1.DaemonSet{appsv1.DaemonSet{}}
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(devicePluginDS, nil),
+			mockReconHelper.EXPECT().handleDevicePluginNetworkPolicy(ctx, mod).Return(nil),
 			mockReconHelper.EXPECT().setKMMOMetrics(ctx),
 			mockReconHelper.EXPECT().handleDevicePluginTargetLabels(ctx, mod).Return(nil),
 			mockReconHelper.EXPECT().handleDevicePlugin(ctx, mod, devicePluginDS).Return(nil),
@@ -151,6 +160,7 @@ var _ = Describe("DevicePluginReconciler_Reconcile", func() {
 		mod.Spec.DevicePlugin = nil
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().handleDevicePluginNetworkPolicy(ctx, mod).Return(nil),
 			mockReconHelper.EXPECT().setKMMOMetrics(ctx),
 			mockReconHelper.EXPECT().clearDevicePluginStatus(ctx, mod).Return(nil),
 		)
@@ -167,6 +177,7 @@ var _ = Describe("DevicePluginReconciler_Reconcile", func() {
 
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(devicePluginDS, nil),
+			mockReconHelper.EXPECT().handleDevicePluginNetworkPolicy(ctx, mod).Return(nil),
 			mockReconHelper.EXPECT().setKMMOMetrics(ctx),
 			mockReconHelper.EXPECT().deleteDevicePluginDaemonSets(ctx, devicePluginDS).Return(nil),
 			mockReconHelper.EXPECT().clearDevicePluginStatus(ctx, mod).Return(nil),
@@ -183,6 +194,7 @@ var _ = Describe("DevicePluginReconciler_Reconcile", func() {
 
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getModuleDevicePluginDaemonSets(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().handleDevicePluginNetworkPolicy(ctx, mod).Return(nil),
 			mockReconHelper.EXPECT().setKMMOMetrics(ctx),
 			mockReconHelper.EXPECT().clearDevicePluginStatus(ctx, mod).Return(fmt.Errorf("some error")),
 		)
@@ -300,7 +312,7 @@ var _ = Describe("DevicePluginReconciler_garbageCollect", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
 		mn = node.NewMockNode(ctrl)
-		dprh = newDevicePluginReconcilerHelper(clnt, nil, mn, nil, "")
+		dprh = newDevicePluginReconcilerHelper(clnt, nil, mn, networkpolicy.NewMockNetworkPolicy(ctrl), nil, "")
 	})
 
 	mod := &kmmv1beta1.Module{
@@ -398,7 +410,7 @@ var _ = Describe("DevicePluginReconciler_deleteDevicePluginDaemonSets", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		clnt = client.NewMockClient(ctrl)
 		mn = node.NewMockNode(ctrl)
-		dprh = newDevicePluginReconcilerHelper(clnt, nil, mn, nil, "")
+		dprh = newDevicePluginReconcilerHelper(clnt, nil, mn, networkpolicy.NewMockNetworkPolicy(ctrl), nil, "")
 	})
 
 	existingDevicePluginDS := []appsv1.DaemonSet{appsv1.DaemonSet{}}
@@ -433,7 +445,7 @@ var _ = Describe("DevicePluginReconciler_setKMMOMetrics", func() {
 		clnt = client.NewMockClient(ctrl)
 		mockMetrics = metrics.NewMockMetrics(ctrl)
 		mn = node.NewMockNode(ctrl)
-		dprh = newDevicePluginReconcilerHelper(clnt, mockMetrics, mn, nil, "")
+		dprh = newDevicePluginReconcilerHelper(clnt, mockMetrics, mn, networkpolicy.NewMockNetworkPolicy(ctrl), nil, "")
 	})
 
 	ctx := context.Background()
@@ -544,7 +556,7 @@ var _ = Describe("DevicePluginReconciler_moduleUpdateDevicePluginStatus", func()
 		clnt = client.NewMockClient(ctrl)
 		statusWriter = client.NewMockStatusWriter(ctrl)
 		mn = node.NewNode(clnt)
-		dprh = newDevicePluginReconcilerHelper(clnt, nil, mn, nil, "")
+		dprh = newDevicePluginReconcilerHelper(clnt, nil, mn, networkpolicy.NewMockNetworkPolicy(ctrl), nil, "")
 	})
 
 	ctx := context.Background()
@@ -873,6 +885,13 @@ var _ = Describe("DevicePluginReconciler_setDevicePluginAsDesired", func() {
 				constants.ModuleNameLabel: moduleName,
 				constants.DaemonSetRole:   constants.DevicePluginRoleLabelValue,
 			}
+			podTemplateLabels := map[string]string{
+				constants.ModuleNameLabel:     moduleName,
+				constants.DaemonSetRole:       constants.DevicePluginRoleLabelValue,
+				"app.kubernetes.io/name":      "kmm",
+				"app.kubernetes.io/component": "device-plugin",
+				"app.kubernetes.io/part-of":   "kmm",
+			}
 
 			expectedInitContainer := []v1.Container{
 				{
@@ -915,7 +934,7 @@ var _ = Describe("DevicePluginReconciler_setDevicePluginAsDesired", func() {
 					Selector: &metav1.LabelSelector{MatchLabels: podLabels},
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Labels:     podLabels,
+							Labels:     podTemplateLabels,
 							Finalizers: []string{constants.NodeLabelerFinalizer},
 						},
 						Spec: v1.PodSpec{
@@ -1174,6 +1193,56 @@ var _ = Describe("devicePluginReconcilerHelper_handleDevicePluginTargetLabels", 
 		Expect(err.Error()).NotTo(ContainSubstring("node2"))
 	})
 })
+var _ = Describe("devicePluginReconcilerHelper_handleDevicePluginNetworkPolicy", func() {
+	var (
+		ctrl   *gomock.Controller
+		mockNP *networkpolicy.MockNetworkPolicy
+		dprh   devicePluginReconcilerHelper
+		ctx    context.Context
+		mod    *kmmv1beta1.Module
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockNP = networkpolicy.NewMockNetworkPolicy(ctrl)
+		ctx = context.Background()
+		dprh = devicePluginReconcilerHelper{
+			networkPolicyAPI: mockNP,
+		}
+		mod = &kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: moduleName},
+			Spec: kmmv1beta1.ModuleSpec{
+				DevicePlugin: &kmmv1beta1.DevicePluginSpec{},
+			},
+		}
+	})
+
+	It("should return nil when DevicePlugin is nil", func() {
+		mod.Spec.DevicePlugin = nil
+		err := dprh.handleDevicePluginNetworkPolicy(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should create the device plugin NetworkPolicy", func() {
+		policy := &networkingv1.NetworkPolicy{}
+		mockNP.EXPECT().DevicePluginNetworkPolicy(mod.Namespace).Return(policy)
+		mockNP.EXPECT().CreateOrAddOwnerReference(ctx, policy, mod).Return(nil)
+
+		err := dprh.handleDevicePluginNetworkPolicy(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should return error if CreateOrAddOwnerReference fails", func() {
+		policy := &networkingv1.NetworkPolicy{}
+		mockNP.EXPECT().DevicePluginNetworkPolicy(mod.Namespace).Return(policy)
+		mockNP.EXPECT().CreateOrAddOwnerReference(ctx, policy, mod).Return(fmt.Errorf("some error"))
+
+		err := dprh.handleDevicePluginNetworkPolicy(ctx, mod)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to ensure DevicePlugin NetworkPolicy"))
+	})
+})
+
 var _ = Describe("DevicePluginSpec backward compatibility", func() {
 	It("should serialize JSON with the same field names as before the type refactoring", func() {
 		spec := kmmv1beta1.DevicePluginSpec{

--- a/internal/controllers/mock_device_plugin_reconciler.go
+++ b/internal/controllers/mock_device_plugin_reconciler.go
@@ -111,6 +111,20 @@ func (mr *MockdevicePluginReconcilerHelperAPIMockRecorder) handleDevicePlugin(ct
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleDevicePlugin", reflect.TypeOf((*MockdevicePluginReconcilerHelperAPI)(nil).handleDevicePlugin), ctx, mod, existingDevicePluginDS)
 }
 
+// handleDevicePluginNetworkPolicy mocks base method.
+func (m *MockdevicePluginReconcilerHelperAPI) handleDevicePluginNetworkPolicy(ctx context.Context, mod *v1beta1.Module) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "handleDevicePluginNetworkPolicy", ctx, mod)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// handleDevicePluginNetworkPolicy indicates an expected call of handleDevicePluginNetworkPolicy.
+func (mr *MockdevicePluginReconcilerHelperAPIMockRecorder) handleDevicePluginNetworkPolicy(ctx, mod any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleDevicePluginNetworkPolicy", reflect.TypeOf((*MockdevicePluginReconcilerHelperAPI)(nil).handleDevicePluginNetworkPolicy), ctx, mod)
+}
+
 // handleDevicePluginTargetLabels mocks base method.
 func (m *MockdevicePluginReconcilerHelperAPI) handleDevicePluginTargetLabels(ctx context.Context, mod *v1beta1.Module) error {
 	m.ctrl.T.Helper()

--- a/internal/networkpolicy/mock_networkpolicy.go
+++ b/internal/networkpolicy/mock_networkpolicy.go
@@ -68,6 +68,20 @@ func (mr *MockNetworkPolicyMockRecorder) CreateOrAddOwnerReference(ctx, np, owne
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrAddOwnerReference", reflect.TypeOf((*MockNetworkPolicy)(nil).CreateOrAddOwnerReference), ctx, np, owner)
 }
 
+// DevicePluginNetworkPolicy mocks base method.
+func (m *MockNetworkPolicy) DevicePluginNetworkPolicy(namespace string) *v1.NetworkPolicy {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DevicePluginNetworkPolicy", namespace)
+	ret0, _ := ret[0].(*v1.NetworkPolicy)
+	return ret0
+}
+
+// DevicePluginNetworkPolicy indicates an expected call of DevicePluginNetworkPolicy.
+func (mr *MockNetworkPolicyMockRecorder) DevicePluginNetworkPolicy(namespace any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DevicePluginNetworkPolicy", reflect.TypeOf((*MockNetworkPolicy)(nil).DevicePluginNetworkPolicy), namespace)
+}
+
 // PullPodNetworkPolicy mocks base method.
 func (m *MockNetworkPolicy) PullPodNetworkPolicy(namespace string) *v1.NetworkPolicy {
 	m.ctrl.T.Helper()

--- a/internal/networkpolicy/networkpolicy.go
+++ b/internal/networkpolicy/networkpolicy.go
@@ -21,6 +21,7 @@ type NetworkPolicy interface {
 	WorkerPodNetworkPolicy(namespace string) *networkingv1.NetworkPolicy
 	BuildSignPodsNetworkPolicy(namespace string) *networkingv1.NetworkPolicy
 	PullPodNetworkPolicy(namespace string) *networkingv1.NetworkPolicy
+	DevicePluginNetworkPolicy(namespace string) *networkingv1.NetworkPolicy
 }
 
 type networkPolicy struct {
@@ -39,6 +40,7 @@ const (
 	workerPodNetworkPolicyName     = "kmm-worker"
 	buildSignPodsNetworkPolicyName = "kmm-build-and-sign"
 	pullPodNetworkPolicyName       = "kmm-pull"
+	devicePluginNetworkPolicyName  = "kmm-device-plugin"
 	defaultNamespace               = "default"
 )
 
@@ -155,6 +157,26 @@ func (np *networkPolicy) PullPodNetworkPolicy(namespace string) *networkingv1.Ne
 						Key:      pod.PullPodTypeLabelKey,
 						Operator: metav1.LabelSelectorOpExists,
 					},
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeIngress,
+				networkingv1.PolicyTypeEgress,
+			},
+		},
+	}
+}
+
+func (np *networkPolicy) DevicePluginNetworkPolicy(namespace string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      devicePluginNetworkPolicyName,
+			Namespace: normalizeNamespace(namespace),
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app.kubernetes.io/component": "device-plugin",
 				},
 			},
 			PolicyTypes: []networkingv1.PolicyType{

--- a/internal/networkpolicy/networkpolicy_test.go
+++ b/internal/networkpolicy/networkpolicy_test.go
@@ -227,6 +227,31 @@ var _ = Describe("NetworkPolicy", func() {
 		})
 	})
 
+	Describe("DevicePluginNetworkPolicy", func() {
+		It("should return correct NetworkPolicy for device plugin pods", func() {
+			result := np.DevicePluginNetworkPolicy(testNamespace)
+
+			Expect(result).NotTo(BeNil())
+			Expect(result.Name).To(Equal(devicePluginNetworkPolicyName))
+			Expect(result.Namespace).To(Equal(testNamespace))
+
+			Expect(result.Spec.PodSelector.MatchLabels).To(HaveKeyWithValue("app.kubernetes.io/component", "device-plugin"))
+
+			Expect(result.Spec.PolicyTypes).To(ContainElements(
+				networkingv1.PolicyTypeIngress,
+				networkingv1.PolicyTypeEgress,
+			))
+
+			Expect(result.Spec.Ingress).To(BeEmpty())
+			Expect(result.Spec.Egress).To(BeEmpty())
+		})
+
+		It("should use default namespace when empty namespace is provided", func() {
+			result := np.DevicePluginNetworkPolicy("")
+			Expect(result.Namespace).To(Equal("default"))
+		})
+	})
+
 	Describe("ensureOwnerReference", func() {
 		var policy *networkingv1.NetworkPolicy
 


### PR DESCRIPTION
Device plugin pods were the only KMM operand without a NetworkPolicy. Add a deny-all NetworkPolicy (kmm-device-plugin) for them, matching the existing pattern used by worker, build/sign, and pull pods.

---

/cc @ybettan @yevgeny-shnaidman 
/assign @ybettan @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added device plugin network policy management to ensure proper network isolation and access control.

* **Refactor**
  * Enhanced device plugin pod labeling with additional Kubernetes standard labels for improved pod identification and selection.
  * Restructured device plugin reconciliation workflow to prioritize network policy creation during module reconciliation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->