### PR TITLE
Add DRA webhook validation with OpenShift version gating

### DIFF
--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2026-06-08T13:01:21Z"
+    createdAt: "2026-06-14T11:58:55Z"
     operatorframework.io/suggested-namespace: openshift-kmm-hub
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -47,7 +47,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2026-06-08T13:01:21Z"
+    createdAt: "2026-06-14T11:58:54Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -195,6 +195,12 @@ spec:
           - delete
           - patch
           - update
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusterversions
+          verbs:
+          - get
         - apiGroups:
           - image.openshift.io
           resources:

--- a/cmd/webhook-server/main.go
+++ b/cmd/webhook-server/main.go
@@ -74,7 +74,9 @@ func main() {
 	options := cg.GetManagerOptionsFromConfig(cfg, scheme)
 	options.LeaderElection = false
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
+	restCfg := ctrl.GetConfigOrDie()
+
+	mgr, err := ctrl.NewManager(restCfg, options)
 	if err != nil {
 		cmd.FatalError(setupLogger, err, "unable to create manager")
 	}
@@ -82,7 +84,13 @@ func main() {
 	if enableModule {
 		logger.Info("Enabling Module webhook")
 
-		if err = webhook.NewModuleValidator(logger).SetupWebhookWithManager(mgr); err != nil {
+		ocpVersion, err := webhook.DiscoverOCPVersion(restCfg)
+		if err != nil {
+			cmd.FatalError(setupLogger, err, "unable to discover OpenShift version")
+		}
+		setupLogger.Info("Detected OpenShift version", "major", ocpVersion.Major, "minor", ocpVersion.Minor)
+
+		if err = webhook.NewModuleValidator(logger, &ocpVersion).SetupWebhookWithManager(mgr); err != nil {
 			cmd.FatalError(setupLogger, err, "unable to create webhook", "webhook", "ModuleValidator")
 		}
 	}
@@ -90,7 +98,7 @@ func main() {
 	if enableManagedClusterModule {
 		logger.Info("Enabling ManagedClusterModule webhook")
 
-		if err = hub.NewManagedClusterModuleValidator(logger).SetupWebhookWithManager(mgr); err != nil {
+		if err = hub.NewManagedClusterModuleValidator(logger, nil).SetupWebhookWithManager(mgr); err != nil {
 			cmd.FatalError(setupLogger, err, "unable to create webhook", "webhook", "ManagedClusterModuleValidator")
 		}
 	}

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -85,6 +85,12 @@ rules:
   - patch
   - update
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+- apiGroups:
   - image.openshift.io
   resources:
   - imagestreams

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -28,4 +28,7 @@ const (
 	PrivateSignDataKey             = "key"
 
 	OperatorNamespaceEnvVar = "OPERATOR_NAMESPACE"
+
+	MinOCPMajorForDRA = 4
+	MinOCPMinorForDRA = 21
 )

--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -36,6 +36,7 @@ import (
 
 // +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=create;delete;get;list;patch;watch
 // +kubebuilder:rbac:groups=build.openshift.io,resources=builds,verbs=create;delete;get;list;patch;watch
+// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get
 // +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,resourceNames=kernel-versions.kmm.node.kubernetes.io,verbs=delete;patch;update
 // +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,verbs=create;get;list;watch
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=delete;get;list;watch

--- a/internal/webhook/hub/managedclustermodule_webhook.go
+++ b/internal/webhook/hub/managedclustermodule_webhook.go
@@ -34,10 +34,10 @@ type ManagedClusterModuleValidator struct {
 	m      admission.CustomValidator
 }
 
-func NewManagedClusterModuleValidator(logger logr.Logger) *ManagedClusterModuleValidator {
+func NewManagedClusterModuleValidator(logger logr.Logger, ocpVersion *webhook.OCPVersion) *ManagedClusterModuleValidator {
 	return &ManagedClusterModuleValidator{
 		logger: logger,
-		m:      webhook.NewModuleValidator(logger),
+		m:      webhook.NewModuleValidator(logger, ocpVersion),
 	}
 }
 

--- a/internal/webhook/module.go
+++ b/internal/webhook/module.go
@@ -20,15 +20,22 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"regexp"
+	"strconv"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/validation"
+
 	"github.com/go-logr/logr"
+	configv1 "github.com/openshift/api/config/v1"
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -36,12 +43,64 @@ import (
 // maxCombinedLength is the maximum combined length of Module name and namespace when the version field is set.
 const maxCombinedLength = 40
 
-type ModuleValidator struct {
-	logger logr.Logger
+var ocpVersionRe = regexp.MustCompile(`^v?(\d+)\.(\d+)`)
+
+// OCPVersion holds the parsed major and minor version of an OpenShift cluster.
+type OCPVersion struct {
+	Major int
+	Minor int
 }
 
-func NewModuleValidator(logger logr.Logger) *ModuleValidator {
-	return &ModuleValidator{logger: logger}
+type ModuleValidator struct {
+	logger     logr.Logger
+	ocpVersion *OCPVersion
+}
+
+func NewModuleValidator(logger logr.Logger, ocpVersion *OCPVersion) *ModuleValidator {
+	return &ModuleValidator{logger: logger, ocpVersion: ocpVersion}
+}
+
+// DiscoverOCPVersion queries the OpenShift ClusterVersion resource and returns the cluster version.
+func DiscoverOCPVersion(cfg *rest.Config) (OCPVersion, error) {
+	ocpScheme := runtime.NewScheme()
+	if err := configv1.Install(ocpScheme); err != nil {
+		return OCPVersion{}, fmt.Errorf("failed to register OpenShift config scheme: %v", err)
+	}
+
+	cfgCopy := *cfg
+	cfgCopy.GroupVersion = &schema.GroupVersion{Group: "config.openshift.io", Version: "v1"}
+	cfgCopy.APIPath = "/apis"
+	cfgCopy.NegotiatedSerializer = serializer.NewCodecFactory(ocpScheme)
+
+	client, err := rest.RESTClientFor(&cfgCopy)
+	if err != nil {
+		return OCPVersion{}, fmt.Errorf("failed to create REST client for OpenShift config API: %v", err)
+	}
+
+	cv := &configv1.ClusterVersion{}
+	if err = client.Get().Resource("clusterversions").Name("version").Do(context.Background()).Into(cv); err != nil {
+		return OCPVersion{}, fmt.Errorf("failed to get ClusterVersion: %v", err)
+	}
+
+	return parseOCPVersion(cv.Status.Desired.Version)
+}
+
+// parseOCPVersion extracts the major and minor version from an OpenShift
+// version string such as "4.21.0" or "4.21.0-rc.1".
+func parseOCPVersion(version string) (OCPVersion, error) {
+	m := ocpVersionRe.FindStringSubmatch(version)
+	if m == nil {
+		return OCPVersion{}, fmt.Errorf("cannot parse OpenShift version from %q", version)
+	}
+	major, err := strconv.Atoi(m[1])
+	if err != nil {
+		return OCPVersion{}, fmt.Errorf("cannot parse OpenShift major version from %q: %v", version, err)
+	}
+	minor, err := strconv.Atoi(m[2])
+	if err != nil {
+		return OCPVersion{}, fmt.Errorf("cannot parse OpenShift minor version from %q: %v", version, err)
+	}
+	return OCPVersion{Major: major, Minor: minor}, nil
 }
 
 func (m *ModuleValidator) SetupWebhookWithManager(mgr ctrl.Manager) error {
@@ -64,7 +123,7 @@ func (m *ModuleValidator) ValidateCreate(ctx context.Context, obj runtime.Object
 
 	m.logger.Info("Validating Module creation", "name", mod.Name, "namespace", mod.Namespace)
 
-	return validateModule(mod)
+	return validateModule(mod, m.ocpVersion)
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
@@ -88,7 +147,7 @@ func (m *ModuleValidator) ValidateUpdate(ctx context.Context, oldObj, newObj run
 		}
 	}
 
-	return validateModule(newMod)
+	return validateModule(newMod, m.ocpVersion)
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
@@ -96,7 +155,7 @@ func (m *ModuleValidator) ValidateDelete(ctx context.Context, obj runtime.Object
 	return nil, NotImplemented
 }
 
-func validateModule(mod *kmmv1beta1.Module) (admission.Warnings, error) {
+func validateModule(mod *kmmv1beta1.Module, ocpVersion *OCPVersion) (admission.Warnings, error) {
 	nameLength := len(mod.Name + mod.Namespace)
 
 	if nameLength > maxCombinedLength {
@@ -109,6 +168,10 @@ func validateModule(mod *kmmv1beta1.Module) (admission.Warnings, error) {
 
 	if err := validateTolerations(mod.Spec.Tolerations); err != nil {
 		return nil, fmt.Errorf("failed to validate Module's tolerations: %v", err)
+	}
+
+	if err := validateDRA(mod, ocpVersion); err != nil {
+		return nil, fmt.Errorf("failed to validate DRA: %v", err)
 	}
 
 	if mod.Spec.ModuleLoader == nil {
@@ -125,6 +188,47 @@ func validateModule(mod *kmmv1beta1.Module) (admission.Warnings, error) {
 	}
 
 	return nil, validateFilesToSign(mod.Spec.ModuleLoader.Container)
+}
+
+func validateDRA(mod *kmmv1beta1.Module, ocpVersion *OCPVersion) error {
+	if mod.Spec.DRA == nil {
+		return nil
+	}
+
+	if ocpVersion != nil {
+		if ocpVersion.Major < constants.MinOCPMajorForDRA || (ocpVersion.Major == constants.MinOCPMajorForDRA && ocpVersion.Minor < constants.MinOCPMinorForDRA) {
+			return fmt.Errorf(
+				"spec.dra requires OpenShift %d.%d or later; current cluster version is %d.%d",
+				constants.MinOCPMajorForDRA, constants.MinOCPMinorForDRA, ocpVersion.Major, ocpVersion.Minor,
+			)
+		}
+	}
+	driverName := mod.Spec.DRA.DriverName
+	if driverName == "" {
+		return errors.New("spec.dra.driverName is required")
+	}
+
+	if errs := validation.IsDNS1123Subdomain(driverName); len(errs) > 0 {
+		return fmt.Errorf("spec.dra.driverName %q is not a valid DNS subdomain: %s", driverName, strings.Join(errs, "; "))
+	}
+
+	seen := sets.New[string]()
+	for i, dc := range mod.Spec.DRA.DeviceClasses {
+		if dc.Name == "" {
+			return fmt.Errorf("spec.dra.deviceClasses[%d].name is required", i)
+		}
+
+		if errs := validation.IsDNS1123Subdomain(dc.Name); len(errs) > 0 {
+			return fmt.Errorf("spec.dra.deviceClasses[%d].name %q is not a valid DNS subdomain: %s", i, dc.Name, strings.Join(errs, "; "))
+		}
+
+		if seen.Has(dc.Name) {
+			return fmt.Errorf("spec.dra.deviceClasses[%d].name %q is a duplicate", i, dc.Name)
+		}
+		seen.Insert(dc.Name)
+	}
+
+	return nil
 }
 
 func validateImageFormat(img string) error {

--- a/internal/webhook/module_test.go
+++ b/internal/webhook/module_test.go
@@ -53,7 +53,7 @@ var (
 		},
 	}
 
-	moduleWebhook = NewModuleValidator(GinkgoLogr)
+	moduleWebhook = NewModuleValidator(GinkgoLogr, &OCPVersion{Major: 4, Minor: 21})
 )
 
 var _ = Describe("maxCombinedLength", func() {
@@ -411,7 +411,7 @@ var _ = Describe("validateModule", func() {
 			mod.Name = name
 			mod.Namespace = ns
 
-			_, err := validateModule(&mod)
+			_, err := validateModule(&mod, &OCPVersion{Major: 4, Minor: 21})
 			exp := Expect(err)
 
 			if errExpected {
@@ -426,7 +426,7 @@ var _ = Describe("validateModule", func() {
 	It("should pass when moduleLoader is not defined", func() {
 		mod := validModule
 		mod.Spec.ModuleLoader = nil
-		_, err := validateModule(&mod)
+		_, err := validateModule(&mod, &OCPVersion{Major: 4, Minor: 21})
 		Expect(err).NotTo(HaveOccurred())
 	})
 })
@@ -696,5 +696,135 @@ var _ = Describe("validateTolerations", func() {
 
 		err := validateTolerations(tolerations)
 		Expect(err).To(Not(HaveOccurred()))
+	})
+})
+
+var _ = Describe("parseOCPVersion", func() {
+	DescribeTable(
+		"should parse valid version strings",
+		func(version string, expectedMajor, expectedMinor int) {
+			ov, err := parseOCPVersion(version)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ov.Major).To(Equal(expectedMajor))
+			Expect(ov.Minor).To(Equal(expectedMinor))
+		},
+		Entry("standard version", "4.21.0", 4, 21),
+		Entry("release candidate", "4.21.0-rc.1", 4, 21),
+		Entry("older minor", "4.20.3", 4, 20),
+		Entry("newer minor", "4.22.1", 4, 22),
+		Entry("with v prefix", "v4.21.0", 4, 21),
+		Entry("hypothetical OCP 5.0", "5.0.0", 5, 0),
+	)
+
+	DescribeTable(
+		"should return error for invalid strings",
+		func(version string) {
+			_, err := parseOCPVersion(version)
+			Expect(err).To(HaveOccurred())
+		},
+		Entry("empty string", ""),
+		Entry("garbage", "invalid"),
+		Entry("no minor", "v4"),
+	)
+})
+
+var _ = Describe("validateDRA", func() {
+	validDRASpec := func() *kmmv1beta1.DRASpec {
+		return &kmmv1beta1.DRASpec{
+			DriverName: "example.com",
+			Container: kmmv1beta1.CommonContainerSpec{
+				Image: "driver:latest",
+			},
+		}
+	}
+
+	minValidOCPVersion := &OCPVersion{Major: 4, Minor: 21}
+
+	It("should be a no-op when spec.dra is nil", func() {
+		mod := &kmmv1beta1.Module{}
+		Expect(validateDRA(mod, minValidOCPVersion)).NotTo(HaveOccurred())
+	})
+
+	DescribeTable(
+		"OpenShift version gate",
+		func(ov *OCPVersion, shouldFail bool) {
+			mod := &kmmv1beta1.Module{
+				Spec: kmmv1beta1.ModuleSpec{
+					DRA: validDRASpec(),
+				},
+			}
+			err := validateDRA(mod, ov)
+			if shouldFail {
+				Expect(err).To(MatchError(ContainSubstring("requires OpenShift")))
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		},
+		Entry("OCP 4.20 rejects", &OCPVersion{Major: 4, Minor: 20}, true),
+		Entry("OCP 4.21 accepts", &OCPVersion{Major: 4, Minor: 21}, false),
+		Entry("OCP 4.22 accepts", &OCPVersion{Major: 4, Minor: 22}, false),
+		Entry("OCP 5.0 accepts (future major)", &OCPVersion{Major: 5, Minor: 0}, false),
+		Entry("OCP 3.11 rejects (old major)", &OCPVersion{Major: 3, Minor: 11}, true),
+		Entry("nil version skips gate (hub webhook)", nil, false),
+	)
+
+	It("should reject empty driverName", func() {
+		dra := validDRASpec()
+		dra.DriverName = ""
+		mod := &kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{DRA: dra},
+		}
+		Expect(validateDRA(mod, minValidOCPVersion)).To(MatchError(ContainSubstring("driverName is required")))
+	})
+
+	It("should reject invalid driverName", func() {
+		dra := validDRASpec()
+		dra.DriverName = "INVALID_NAME!"
+		mod := &kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{DRA: dra},
+		}
+		Expect(validateDRA(mod, minValidOCPVersion)).To(MatchError(ContainSubstring("not a valid DNS subdomain")))
+	})
+
+	It("should accept valid driverName", func() {
+		mod := &kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{DRA: validDRASpec()},
+		}
+		Expect(validateDRA(mod, minValidOCPVersion)).NotTo(HaveOccurred())
+	})
+
+	It("should reject duplicate deviceClasses names", func() {
+		dra := validDRASpec()
+		dra.DeviceClasses = []kmmv1beta1.DeviceClassSpec{
+			{Name: "gpu"},
+			{Name: "gpu"},
+		}
+		mod := &kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{DRA: dra},
+		}
+		Expect(validateDRA(mod, minValidOCPVersion)).To(MatchError(ContainSubstring("duplicate")))
+	})
+
+	It("should reject invalid deviceClasses name", func() {
+		dra := validDRASpec()
+		dra.DeviceClasses = []kmmv1beta1.DeviceClassSpec{
+			{Name: "INVALID!"},
+		}
+		mod := &kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{DRA: dra},
+		}
+		Expect(validateDRA(mod, minValidOCPVersion)).To(MatchError(ContainSubstring("not a valid DNS subdomain")))
+	})
+
+	It("should accept valid deviceClasses", func() {
+		dra := validDRASpec()
+		dra.DeviceClasses = []kmmv1beta1.DeviceClassSpec{
+			{Name: "gpu"},
+			{Name: "fpga"},
+		}
+		mod := &kmmv1beta1.Module{
+			Spec: kmmv1beta1.ModuleSpec{DRA: dra},
+		}
+		Expect(validateDRA(mod, minValidOCPVersion)).NotTo(HaveOccurred())
 	})
 })


### PR DESCRIPTION
Implement admission webhook validation for Modules with spec.dra:
- Detect cluster OpenShift version at webhook startup via ClusterVersion CR
- Gate DRA usage to OpenShift 4.21+ with major-version-aware comparison
- Validate driverName format (DNS subdomain) and presence
- Validate deviceClasses name uniqueness and format
- Add OCPVersion struct and ParseOCPVersion/DiscoverOCPVersion utilities
- Move DRA version constants to internal/constants package

---

/cc @ybettan @yevgeny-shnaidman 
/assign @ybettan @yevgeny-shnaidman 

---

fix #1814
fix #1820 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

**New Features**
* Webhook validation now detects the cluster’s OpenShift version at startup and applies minimum-version requirements for DRA settings.
* Added/strengthened DRA configuration validation, including required `driverName` and DNS-compliant device class names.
* Duplicate device class names are rejected during Module creation/update.
* DRA-related validation is now performed earlier for more consistent error reporting.

**RBAC**
* Updated permissions to allow reading OpenShift `clusterversions` to support version-aware validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->