### PR TITLE
Add DeviceClass lifecycle management to DRA reconciler

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -5,6 +5,7 @@ const (
 	DTKImageStreamNamespace      = "openshift"
 
 	ModuleNameLabel        = "kmm.node.kubernetes.io/module.name"
+	ModuleNamespaceLabel   = "kmm.node.kubernetes.io/module.namespace"
 	NodeLabelerFinalizer   = "kmm.node.kubernetes.io/node-labeler"
 	TargetKernelTarget     = "kmm.node.kubernetes.io/target-kernel"
 	ResourceType           = "kmm.openshift.io/build.type"

--- a/internal/controllers/dra_reconciler.go
+++ b/internal/controllers/dra_reconciler.go
@@ -27,6 +27,8 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -82,16 +84,18 @@ func (r *DRAReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.Module) (
 		return res, fmt.Errorf("could not get DRA DaemonSets for module %s, namespace %s: %v", mod.Name, mod.Namespace, err)
 	}
 
+	existingDCs, err := r.reconHelperAPI.getModuleDeviceClasses(ctx, mod.Name, mod.Namespace)
+	if err != nil {
+		return res, fmt.Errorf("could not get DeviceClasses for module %s, namespace %s: %v", mod.Name, mod.Namespace, err)
+	}
+
 	if mod.GetDeletionTimestamp() != nil {
-		err = r.reconHelperAPI.deleteDRADaemonSets(ctx, existingDRADS)
-		return ctrl.Result{}, err
+		return ctrl.Result{}, r.reconHelperAPI.deleteDRAResources(ctx, mod.Name, mod.Namespace)
 	}
 
 	if mod.Spec.DRA == nil {
-		if len(existingDRADS) > 0 {
-			if err = r.reconHelperAPI.deleteDRADaemonSets(ctx, existingDRADS); err != nil {
-				return ctrl.Result{}, err
-			}
+		if err = r.reconHelperAPI.deleteDRAResources(ctx, mod.Name, mod.Namespace); err != nil {
+			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, r.reconHelperAPI.clearDRAStatus(ctx, mod)
 	}
@@ -99,6 +103,11 @@ func (r *DRAReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.Module) (
 	err = r.reconHelperAPI.handleDRA(ctx, mod, existingDRADS)
 	if err != nil {
 		return res, fmt.Errorf("could not handle DRA: %v", err)
+	}
+
+	err = r.reconHelperAPI.handleDeviceClasses(ctx, mod, existingDCs)
+	if err != nil {
+		return res, fmt.Errorf("could not handle DeviceClasses: %v", err)
 	}
 
 	err = r.reconHelperAPI.moduleUpdateDRAStatus(ctx, mod, existingDRADS)
@@ -116,9 +125,11 @@ func (r *DRAReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.Module) (
 type draReconcilerHelperAPI interface {
 	getModuleDRADaemonSets(ctx context.Context, name, namespace string) ([]appsv1.DaemonSet, error)
 	handleDRA(ctx context.Context, mod *kmmv1beta1.Module, existingDRADS []appsv1.DaemonSet) error
-	deleteDRADaemonSets(ctx context.Context, existingDRADS []appsv1.DaemonSet) error
+	deleteDRAResources(ctx context.Context, moduleName, moduleNamespace string) error
 	moduleUpdateDRAStatus(ctx context.Context, mod *kmmv1beta1.Module, existingDRADS []appsv1.DaemonSet) error
 	clearDRAStatus(ctx context.Context, mod *kmmv1beta1.Module) error
+	getModuleDeviceClasses(ctx context.Context, name, namespace string) ([]resourcev1.DeviceClass, error)
+	handleDeviceClasses(ctx context.Context, mod *kmmv1beta1.Module, existingDCs []resourcev1.DeviceClass) error
 }
 
 type draReconcilerHelper struct {
@@ -183,14 +194,32 @@ func (drh *draReconcilerHelper) handleDRA(ctx context.Context, mod *kmmv1beta1.M
 	return err
 }
 
-func (drh *draReconcilerHelper) deleteDRADaemonSets(ctx context.Context, existingDRADS []appsv1.DaemonSet) error {
-	for _, ds := range existingDRADS {
-		err := drh.client.Delete(ctx, &ds)
-		if err != nil {
-			return fmt.Errorf("failed to delete DRA DaemonSet %s/%s: %v", ds.Namespace, ds.Name, err)
-		}
+// deleteDRAResources deletes all DRA-owned DaemonSets and DeviceClasses using label-based bulk deletion.
+func (drh *draReconcilerHelper) deleteDRAResources(ctx context.Context, moduleName, moduleNamespace string) error {
+	var errs []error
+
+	dsDeleteOpts := []client.DeleteAllOfOption{
+		client.MatchingLabels{
+			constants.ModuleNameLabel: moduleName,
+			constants.DaemonSetRole:   constants.DRARoleLabelValue,
+		},
+		client.InNamespace(moduleNamespace),
 	}
-	return nil
+	if err := drh.client.DeleteAllOf(ctx, &appsv1.DaemonSet{}, dsDeleteOpts...); err != nil {
+		errs = append(errs, fmt.Errorf("failed to delete DRA DaemonSets for module %s/%s: %v", moduleNamespace, moduleName, err))
+	}
+
+	dcDeleteOpts := []client.DeleteAllOfOption{
+		client.MatchingLabels{
+			constants.ModuleNameLabel:      moduleName,
+			constants.ModuleNamespaceLabel: moduleNamespace,
+		},
+	}
+	if err := drh.client.DeleteAllOf(ctx, &resourcev1.DeviceClass{}, dcDeleteOpts...); err != nil {
+		errs = append(errs, fmt.Errorf("failed to delete DeviceClasses for module %s/%s: %v", moduleNamespace, moduleName, err))
+	}
+
+	return errors.Join(errs...)
 }
 
 func (drh *draReconcilerHelper) moduleUpdateDRAStatus(ctx context.Context,
@@ -231,6 +260,75 @@ func (drh *draReconcilerHelper) clearDRAStatus(ctx context.Context, mod *kmmv1be
 	mod.Status.DRA = kmmv1beta1.DaemonSetStatus{}
 
 	return drh.client.Status().Patch(ctx, mod, client.MergeFrom(unmodifiedMod))
+}
+
+func (drh *draReconcilerHelper) getModuleDeviceClasses(ctx context.Context, name, namespace string) ([]resourcev1.DeviceClass, error) {
+	dcList := resourcev1.DeviceClassList{}
+	opts := []client.ListOption{
+		client.MatchingLabels(map[string]string{
+			constants.ModuleNameLabel:      name,
+			constants.ModuleNamespaceLabel: namespace,
+		}),
+	}
+	if err := drh.client.List(ctx, &dcList, opts...); err != nil {
+		return nil, fmt.Errorf("could not list DeviceClasses: %v", err)
+	}
+
+	return dcList.Items, nil
+}
+
+// handleDeviceClasses reconciles cluster-scoped DeviceClass resources to match the desired state
+// declared in mod.Spec.DRA.DeviceClasses. It performs declarative convergence:
+//   - DeviceClasses present in the spec but missing from the cluster are created.
+//   - DeviceClasses present in both are patched to reflect the current spec (drift correction).
+//   - DeviceClasses present in the cluster but absent from the spec are deleted (stale cleanup).
+func (drh *draReconcilerHelper) handleDeviceClasses(ctx context.Context, mod *kmmv1beta1.Module, existingDCs []resourcev1.DeviceClass) error {
+	if mod.Spec.DRA == nil {
+		return nil
+	}
+
+	logger := log.FromContext(ctx)
+
+	existingByName := make(map[string]resourcev1.DeviceClass, len(existingDCs))
+	for _, dc := range existingDCs {
+		existingByName[dc.Name] = dc
+	}
+
+	var errs []error
+
+	// Create missing or patch existing DeviceClasses to match the desired spec.
+	for _, desired := range mod.Spec.DRA.DeviceClasses {
+		dc := &resourcev1.DeviceClass{
+			ObjectMeta: metav1.ObjectMeta{Name: desired.Name},
+		}
+		opRes, err := controllerutil.CreateOrPatch(ctx, drh.client, dc, func() error {
+			if dc.Labels == nil {
+				dc.Labels = make(map[string]string)
+			}
+			dc.Labels[constants.ModuleNameLabel] = mod.Name
+			dc.Labels[constants.ModuleNamespaceLabel] = mod.Namespace
+			dc.Spec.Selectors = desired.Selectors
+			dc.Spec.Config = desired.Config
+			return nil
+		})
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to create or patch DeviceClass %s: %v", desired.Name, err))
+		} else {
+			logger.Info("Reconciled DeviceClass", "name", desired.Name, "result", opRes)
+		}
+		delete(existingByName, desired.Name)
+	}
+
+	// Delete DeviceClasses that exist in the cluster but are no longer in the desired spec.
+	for name, dc := range existingByName {
+		if deleteErr := drh.client.Delete(ctx, &dc); deleteErr != nil && !apierrors.IsNotFound(deleteErr) {
+			errs = append(errs, fmt.Errorf("failed to delete DeviceClass %s: %v", name, deleteErr))
+		} else {
+			logger.Info("Deleted extra DeviceClass", "name", name)
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 type draDaemonSetCreator interface {

--- a/internal/controllers/dra_reconciler_test.go
+++ b/internal/controllers/dra_reconciler_test.go
@@ -31,6 +31,7 @@ import (
 	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -68,7 +69,7 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 
 	ctx := context.Background()
 
-	DescribeTable("check error flows", func(getDSError, handleDRAError bool) {
+	DescribeTable("check error flows", func(getDSError, getDCError, handleDRAError, handleDCError bool) {
 		draDS := []appsv1.DaemonSet{{}}
 		returnedError := fmt.Errorf("some error")
 		if getDSError {
@@ -76,11 +77,21 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 			goto executeTestFunction
 		}
 		mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil)
+		if getDCError {
+			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, returnedError)
+			goto executeTestFunction
+		}
+		mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil)
 		if handleDRAError {
 			mockReconHelper.EXPECT().handleDRA(ctx, mod, draDS).Return(returnedError)
 			goto executeTestFunction
 		}
 		mockReconHelper.EXPECT().handleDRA(ctx, mod, draDS).Return(nil)
+		if handleDCError {
+			mockReconHelper.EXPECT().handleDeviceClasses(ctx, mod, []resourcev1.DeviceClass(nil)).Return(returnedError)
+			goto executeTestFunction
+		}
+		mockReconHelper.EXPECT().handleDeviceClasses(ctx, mod, []resourcev1.DeviceClass(nil)).Return(nil)
 		mockReconHelper.EXPECT().moduleUpdateDRAStatus(ctx, mod, draDS).Return(returnedError)
 
 	executeTestFunction:
@@ -90,16 +101,20 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 		Expect(err).To(HaveOccurred())
 
 	},
-		Entry("getModuleDRADaemonSets failed", true, false),
-		Entry("handleDRA failed", false, true),
-		Entry("moduleUpdateDRAStatus failed", false, false),
+		Entry("getModuleDRADaemonSets failed", true, false, false, false),
+		Entry("getModuleDeviceClasses failed", false, true, false, false),
+		Entry("handleDRA failed", false, false, true, false),
+		Entry("handleDeviceClasses failed", false, false, false, true),
+		Entry("moduleUpdateDRAStatus failed", false, false, false, false),
 	)
 
 	It("Good flow", func() {
 		draDS := []appsv1.DaemonSet{{}}
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil),
+			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil),
 			mockReconHelper.EXPECT().handleDRA(ctx, mod, draDS).Return(nil),
+			mockReconHelper.EXPECT().handleDeviceClasses(ctx, mod, []resourcev1.DeviceClass(nil)).Return(nil),
 			mockReconHelper.EXPECT().moduleUpdateDRAStatus(ctx, mod, draDS).Return(nil),
 		)
 
@@ -112,21 +127,24 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 	It("module deletion flow", func() {
 		mod.SetDeletionTimestamp(&metav1.Time{})
 		draDS := []appsv1.DaemonSet{{}}
+		existingDCs := []resourcev1.DeviceClass{{ObjectMeta: metav1.ObjectMeta{Name: "gpu"}}}
 
 		By("good flow")
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil),
-			mockReconHelper.EXPECT().deleteDRADaemonSets(ctx, draDS).Return(nil),
+			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(existingDCs, nil),
+			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod.Name, mod.Namespace).Return(nil),
 		)
 
 		res, err := dr.Reconcile(ctx, mod)
 		Expect(res).To(Equal(reconcile.Result{}))
 		Expect(err).NotTo(HaveOccurred())
 
-		By("error flow - deleteDRADaemonSets fails")
+		By("error flow - deleteDRAResources fails")
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil),
-			mockReconHelper.EXPECT().deleteDRADaemonSets(ctx, draDS).Return(fmt.Errorf("some error")),
+			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(existingDCs, nil),
+			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod.Name, mod.Namespace).Return(fmt.Errorf("some error")),
 		)
 
 		res, err = dr.Reconcile(ctx, mod)
@@ -134,10 +152,12 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 		Expect(err).To(HaveOccurred())
 	})
 
-	It("no-op when spec.dra is nil and no existing DaemonSets", func() {
+	It("no-op when spec.dra is nil and no existing DaemonSets or DeviceClasses", func() {
 		mod.Spec.DRA = nil
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod.Name, mod.Namespace).Return(nil),
 			mockReconHelper.EXPECT().clearDRAStatus(ctx, mod).Return(nil),
 		)
 
@@ -147,13 +167,15 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("cleanup when spec.dra is nil but existing DaemonSets present", func() {
+	It("cleanup when spec.dra is nil but existing DaemonSets and DeviceClasses present", func() {
 		mod.Spec.DRA = nil
 		draDS := []appsv1.DaemonSet{{}}
+		existingDCs := []resourcev1.DeviceClass{{ObjectMeta: metav1.ObjectMeta{Name: "gpu"}}}
 
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil),
-			mockReconHelper.EXPECT().deleteDRADaemonSets(ctx, draDS).Return(nil),
+			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(existingDCs, nil),
+			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod.Name, mod.Namespace).Return(nil),
 			mockReconHelper.EXPECT().clearDRAStatus(ctx, mod).Return(nil),
 		)
 
@@ -168,6 +190,8 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod.Name, mod.Namespace).Return(nil),
 			mockReconHelper.EXPECT().clearDRAStatus(ctx, mod).Return(fmt.Errorf("some error")),
 		)
 
@@ -266,39 +290,6 @@ var _ = Describe("DRAReconciler_handleDRA", func() {
 		err := drh.handleDRA(ctx, &mod, []appsv1.DaemonSet{existingDS})
 
 		Expect(err).NotTo(HaveOccurred())
-	})
-})
-
-var _ = Describe("DRAReconciler_deleteDRADaemonSets", func() {
-	var (
-		ctrl *gomock.Controller
-		clnt *client.MockClient
-		drh  draReconcilerHelper
-	)
-
-	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		clnt = client.NewMockClient(ctrl)
-		drh = draReconcilerHelper{
-			client: clnt,
-		}
-	})
-
-	existingDRADS := []appsv1.DaemonSet{{}}
-	ctx := context.Background()
-
-	It("good flow", func() {
-		clnt.EXPECT().Delete(ctx, &existingDRADS[0]).Return(nil)
-
-		err := drh.deleteDRADaemonSets(ctx, existingDRADS)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("error flow", func() {
-		clnt.EXPECT().Delete(ctx, &existingDRADS[0]).Return(fmt.Errorf("some error"))
-
-		err := drh.deleteDRADaemonSets(ctx, existingDRADS)
-		Expect(err).To(HaveOccurred())
 	})
 })
 
@@ -764,5 +755,337 @@ var _ = Describe("DRAReconciler_getModuleDRADaemonSets", func() {
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(dsList).To(Equal([]appsv1.DaemonSet{ds1, ds2}))
+	})
+})
+
+var _ = Describe("DRAReconciler_getModuleDeviceClasses", func() {
+	var (
+		ctrl *gomock.Controller
+		clnt *client.MockClient
+		drh  draReconcilerHelper
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		drh = draReconcilerHelper{
+			client: clnt,
+		}
+	})
+
+	ctx := context.Background()
+
+	It("should return error when list fails", func() {
+		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("some error"))
+
+		dcList, err := drh.getModuleDeviceClasses(ctx, "name", "namespace")
+
+		Expect(err).To(HaveOccurred())
+		Expect(dcList).To(BeNil())
+	})
+
+	It("should return DeviceClasses matching ownership labels", func() {
+		dc1 := resourcev1.DeviceClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gpu",
+				Labels: map[string]string{
+					constants.ModuleNameLabel:      "my-module",
+					constants.ModuleNamespaceLabel: "my-ns",
+				},
+			},
+		}
+		dc2 := resourcev1.DeviceClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "fpga",
+				Labels: map[string]string{
+					constants.ModuleNameLabel:      "my-module",
+					constants.ModuleNamespaceLabel: "my-ns",
+				},
+			},
+		}
+		clnt.EXPECT().List(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ interface{}, list *resourcev1.DeviceClassList, _ ...interface{}) error {
+				list.Items = []resourcev1.DeviceClass{dc1, dc2}
+				return nil
+			},
+		)
+
+		dcList, err := drh.getModuleDeviceClasses(ctx, "my-module", "my-ns")
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(dcList).To(Equal([]resourcev1.DeviceClass{dc1, dc2}))
+	})
+})
+
+var _ = Describe("DRAReconciler_handleDeviceClasses", func() {
+	var (
+		ctrl *gomock.Controller
+		clnt *client.MockClient
+		drh  draReconcilerHelper
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		drh = draReconcilerHelper{
+			client: clnt,
+		}
+	})
+
+	ctx := context.Background()
+
+	It("should be a no-op when DRA is nil", func() {
+		mod := kmmv1beta1.Module{}
+		err := drh.handleDeviceClasses(ctx, &mod, nil)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should create a DeviceClass when desired but not existing", func() {
+		mod := kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-mod", Namespace: "my-ns"},
+			Spec: kmmv1beta1.ModuleSpec{
+				DRA: &kmmv1beta1.DRASpec{
+					DeviceClasses: []kmmv1beta1.DeviceClassSpec{
+						{Name: "gpu"},
+					},
+				},
+			},
+		}
+
+		clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(resourcev1.Resource("deviceclasses"), "gpu"))
+		clnt.EXPECT().Create(ctx, gomock.Any()).DoAndReturn(
+			func(_ context.Context, dc *resourcev1.DeviceClass, _ ...ctrlclient.CreateOption) error {
+				Expect(dc.Name).To(Equal("gpu"))
+				Expect(dc.Labels[constants.ModuleNameLabel]).To(Equal("my-mod"))
+				Expect(dc.Labels[constants.ModuleNamespaceLabel]).To(Equal("my-ns"))
+				return nil
+			},
+		)
+
+		err := drh.handleDeviceClasses(ctx, &mod, nil)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should patch an existing DeviceClass when spec differs", func() {
+		mod := kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-mod", Namespace: "my-ns"},
+			Spec: kmmv1beta1.ModuleSpec{
+				DRA: &kmmv1beta1.DRASpec{
+					DeviceClasses: []kmmv1beta1.DeviceClassSpec{
+						{
+							Name: "gpu",
+							Selectors: []resourcev1.DeviceSelector{
+								{CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == 'nvidia'"}},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		existingDC := resourcev1.DeviceClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gpu",
+				Labels: map[string]string{
+					constants.ModuleNameLabel:      "my-mod",
+					constants.ModuleNamespaceLabel: "my-ns",
+				},
+			},
+			Spec: resourcev1.DeviceClassSpec{},
+		}
+
+		clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ ctrlclient.ObjectKey, obj ctrlclient.Object, _ ...ctrlclient.GetOption) error {
+				existingDC.DeepCopyInto(obj.(*resourcev1.DeviceClass))
+				return nil
+			},
+		)
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, dc *resourcev1.DeviceClass, _ ctrlclient.Patch, _ ...ctrlclient.PatchOption) error {
+				Expect(dc.Name).To(Equal("gpu"))
+				Expect(dc.Spec.Selectors).To(HaveLen(1))
+				return nil
+			},
+		)
+
+		err := drh.handleDeviceClasses(ctx, &mod, []resourcev1.DeviceClass{existingDC})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should delete DeviceClasses not in the desired list", func() {
+		mod := kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-mod", Namespace: "my-ns"},
+			Spec: kmmv1beta1.ModuleSpec{
+				DRA: &kmmv1beta1.DRASpec{
+					DeviceClasses: []kmmv1beta1.DeviceClassSpec{},
+				},
+			},
+		}
+
+		extraDC := resourcev1.DeviceClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "stale-dc",
+				Labels: map[string]string{
+					constants.ModuleNameLabel:      "my-mod",
+					constants.ModuleNamespaceLabel: "my-ns",
+				},
+			},
+		}
+
+		clnt.EXPECT().Delete(ctx, &extraDC).Return(nil)
+
+		err := drh.handleDeviceClasses(ctx, &mod, []resourcev1.DeviceClass{extraDC})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should return error on create failure", func() {
+		mod := kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-mod", Namespace: "my-ns"},
+			Spec: kmmv1beta1.ModuleSpec{
+				DRA: &kmmv1beta1.DRASpec{
+					DeviceClasses: []kmmv1beta1.DeviceClassSpec{
+						{Name: "gpu"},
+					},
+				},
+			},
+		}
+
+		clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).Return(apierrors.NewNotFound(resourcev1.Resource("deviceclasses"), "gpu"))
+		clnt.EXPECT().Create(ctx, gomock.Any()).Return(fmt.Errorf("create failed"))
+
+		err := drh.handleDeviceClasses(ctx, &mod, nil)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("create failed"))
+	})
+
+	It("should return error on patch failure", func() {
+		mod := kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-mod", Namespace: "my-ns"},
+			Spec: kmmv1beta1.ModuleSpec{
+				DRA: &kmmv1beta1.DRASpec{
+					DeviceClasses: []kmmv1beta1.DeviceClassSpec{
+						{
+							Name: "gpu",
+							Selectors: []resourcev1.DeviceSelector{
+								{CEL: &resourcev1.CELDeviceSelector{Expression: "device.driver == 'nvidia'"}},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		existingDC := resourcev1.DeviceClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gpu",
+			},
+		}
+
+		clnt.EXPECT().Get(ctx, gomock.Any(), gomock.Any()).DoAndReturn(
+			func(_ context.Context, _ ctrlclient.ObjectKey, obj ctrlclient.Object, _ ...ctrlclient.GetOption) error {
+				existingDC.DeepCopyInto(obj.(*resourcev1.DeviceClass))
+				return nil
+			},
+		)
+		clnt.EXPECT().Patch(ctx, gomock.Any(), gomock.Any()).Return(fmt.Errorf("patch failed"))
+
+		err := drh.handleDeviceClasses(ctx, &mod, []resourcev1.DeviceClass{existingDC})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("patch failed"))
+	})
+
+	It("should return error on delete failure for extras", func() {
+		mod := kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-mod", Namespace: "my-ns"},
+			Spec: kmmv1beta1.ModuleSpec{
+				DRA: &kmmv1beta1.DRASpec{
+					DeviceClasses: []kmmv1beta1.DeviceClassSpec{},
+				},
+			},
+		}
+
+		extraDC := resourcev1.DeviceClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "stale-dc",
+				Labels: map[string]string{
+					constants.ModuleNameLabel:      "my-mod",
+					constants.ModuleNamespaceLabel: "my-ns",
+				},
+			},
+		}
+
+		clnt.EXPECT().Delete(ctx, &extraDC).Return(fmt.Errorf("delete failed"))
+
+		err := drh.handleDeviceClasses(ctx, &mod, []resourcev1.DeviceClass{extraDC})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("delete failed"))
+	})
+
+	It("should be a no-op when no desired and no existing DeviceClasses", func() {
+		mod := kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-mod", Namespace: "my-ns"},
+			Spec: kmmv1beta1.ModuleSpec{
+				DRA: &kmmv1beta1.DRASpec{
+					DeviceClasses: []kmmv1beta1.DeviceClassSpec{},
+				},
+			},
+		}
+
+		err := drh.handleDeviceClasses(ctx, &mod, nil)
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+var _ = Describe("DRAReconciler_deleteDRAResources", func() {
+	var (
+		ctrl *gomock.Controller
+		clnt *client.MockClient
+		drh  draReconcilerHelper
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		clnt = client.NewMockClient(ctrl)
+		drh = draReconcilerHelper{
+			client: clnt,
+		}
+	})
+
+	ctx := context.Background()
+
+	It("should delete all DaemonSets and DeviceClasses via DeleteAllOf", func() {
+		clnt.EXPECT().DeleteAllOf(ctx, &appsv1.DaemonSet{}, gomock.Any()).Return(nil)
+		clnt.EXPECT().DeleteAllOf(ctx, &resourcev1.DeviceClass{}, gomock.Any()).Return(nil)
+
+		err := drh.deleteDRAResources(ctx, "my-mod", "my-ns")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should return error when DaemonSet DeleteAllOf fails", func() {
+		clnt.EXPECT().DeleteAllOf(ctx, &appsv1.DaemonSet{}, gomock.Any()).Return(fmt.Errorf("ds delete failed"))
+		clnt.EXPECT().DeleteAllOf(ctx, &resourcev1.DeviceClass{}, gomock.Any()).Return(nil)
+
+		err := drh.deleteDRAResources(ctx, "my-mod", "my-ns")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("DaemonSets"))
+	})
+
+	It("should return error when DeviceClass DeleteAllOf fails", func() {
+		clnt.EXPECT().DeleteAllOf(ctx, &appsv1.DaemonSet{}, gomock.Any()).Return(nil)
+		clnt.EXPECT().DeleteAllOf(ctx, &resourcev1.DeviceClass{}, gomock.Any()).Return(fmt.Errorf("dc delete failed"))
+
+		err := drh.deleteDRAResources(ctx, "my-mod", "my-ns")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("DeviceClasses"))
+	})
+
+	It("should aggregate errors from both DeleteAllOf calls", func() {
+		clnt.EXPECT().DeleteAllOf(ctx, &appsv1.DaemonSet{}, gomock.Any()).Return(fmt.Errorf("ds error"))
+		clnt.EXPECT().DeleteAllOf(ctx, &resourcev1.DeviceClass{}, gomock.Any()).Return(fmt.Errorf("dc error"))
+
+		err := drh.deleteDRAResources(ctx, "my-mod", "my-ns")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("DaemonSets"))
+		Expect(err.Error()).To(ContainSubstring("DeviceClasses"))
 	})
 })

--- a/internal/controllers/mock_dra_reconciler.go
+++ b/internal/controllers/mock_dra_reconciler.go
@@ -15,6 +15,7 @@ import (
 	v1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	gomock "go.uber.org/mock/gomock"
 	v1 "k8s.io/api/apps/v1"
+	v10 "k8s.io/api/resource/v1"
 )
 
 // MockdraReconcilerHelperAPI is a mock of draReconcilerHelperAPI interface.
@@ -54,18 +55,18 @@ func (mr *MockdraReconcilerHelperAPIMockRecorder) clearDRAStatus(ctx, mod any) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "clearDRAStatus", reflect.TypeOf((*MockdraReconcilerHelperAPI)(nil).clearDRAStatus), ctx, mod)
 }
 
-// deleteDRADaemonSets mocks base method.
-func (m *MockdraReconcilerHelperAPI) deleteDRADaemonSets(ctx context.Context, existingDRADS []v1.DaemonSet) error {
+// deleteDRAResources mocks base method.
+func (m *MockdraReconcilerHelperAPI) deleteDRAResources(ctx context.Context, moduleName, moduleNamespace string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "deleteDRADaemonSets", ctx, existingDRADS)
+	ret := m.ctrl.Call(m, "deleteDRAResources", ctx, moduleName, moduleNamespace)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// deleteDRADaemonSets indicates an expected call of deleteDRADaemonSets.
-func (mr *MockdraReconcilerHelperAPIMockRecorder) deleteDRADaemonSets(ctx, existingDRADS any) *gomock.Call {
+// deleteDRAResources indicates an expected call of deleteDRAResources.
+func (mr *MockdraReconcilerHelperAPIMockRecorder) deleteDRAResources(ctx, moduleName, moduleNamespace any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "deleteDRADaemonSets", reflect.TypeOf((*MockdraReconcilerHelperAPI)(nil).deleteDRADaemonSets), ctx, existingDRADS)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "deleteDRAResources", reflect.TypeOf((*MockdraReconcilerHelperAPI)(nil).deleteDRAResources), ctx, moduleName, moduleNamespace)
 }
 
 // getModuleDRADaemonSets mocks base method.
@@ -83,6 +84,21 @@ func (mr *MockdraReconcilerHelperAPIMockRecorder) getModuleDRADaemonSets(ctx, na
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getModuleDRADaemonSets", reflect.TypeOf((*MockdraReconcilerHelperAPI)(nil).getModuleDRADaemonSets), ctx, name, namespace)
 }
 
+// getModuleDeviceClasses mocks base method.
+func (m *MockdraReconcilerHelperAPI) getModuleDeviceClasses(ctx context.Context, name, namespace string) ([]v10.DeviceClass, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "getModuleDeviceClasses", ctx, name, namespace)
+	ret0, _ := ret[0].([]v10.DeviceClass)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// getModuleDeviceClasses indicates an expected call of getModuleDeviceClasses.
+func (mr *MockdraReconcilerHelperAPIMockRecorder) getModuleDeviceClasses(ctx, name, namespace any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getModuleDeviceClasses", reflect.TypeOf((*MockdraReconcilerHelperAPI)(nil).getModuleDeviceClasses), ctx, name, namespace)
+}
+
 // handleDRA mocks base method.
 func (m *MockdraReconcilerHelperAPI) handleDRA(ctx context.Context, mod *v1beta1.Module, existingDRADS []v1.DaemonSet) error {
 	m.ctrl.T.Helper()
@@ -95,6 +111,20 @@ func (m *MockdraReconcilerHelperAPI) handleDRA(ctx context.Context, mod *v1beta1
 func (mr *MockdraReconcilerHelperAPIMockRecorder) handleDRA(ctx, mod, existingDRADS any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleDRA", reflect.TypeOf((*MockdraReconcilerHelperAPI)(nil).handleDRA), ctx, mod, existingDRADS)
+}
+
+// handleDeviceClasses mocks base method.
+func (m *MockdraReconcilerHelperAPI) handleDeviceClasses(ctx context.Context, mod *v1beta1.Module, existingDCs []v10.DeviceClass) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "handleDeviceClasses", ctx, mod, existingDCs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// handleDeviceClasses indicates an expected call of handleDeviceClasses.
+func (mr *MockdraReconcilerHelperAPIMockRecorder) handleDeviceClasses(ctx, mod, existingDCs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleDeviceClasses", reflect.TypeOf((*MockdraReconcilerHelperAPI)(nil).handleDeviceClasses), ctx, mod, existingDCs)
 }
 
 // moduleUpdateDRAStatus mocks base method.


### PR DESCRIPTION
Extend the DRAReconciler to manage cluster-scoped DeviceClass resources declared in spec.dra.deviceClasses. DeviceClasses use label-based ownership (ModuleNameLabel + ModuleNamespaceLabel) since ownerReferences cannot reference namespaced resources from cluster-scoped objects.

The reconciler performs declarative convergence on each cycle:
- Creates missing DeviceClasses with ownership labels
- Patches existing DeviceClasses to correct spec drift
- Deletes stale DeviceClasses no longer in the desired list
- Cleans up all DeviceClasses on Module deletion or DRA removal

Errors are aggregated via errors.Join to attempt all operations before requeueing. NotFound errors on delete are tolerated to handle races.

Fix  #1821


---

/cc @ybettan @yevgeny-shnaidman 

---

/assign @yevgeny-shnaidman @ybettan 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DRA reconciliation now automatically manages device classes alongside daemon sets, including creation, updating, and cleanup when modules are deleted or DRA configuration is removed.
* **Tests**
  * Expanded test coverage for device-class reconciliation, bulk resource deletion, and updated reconcile/cleanup flows.  
* **Chores**
  * Added a public constant for the module namespace label used in label-based reconciliation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->