### PR TITLE
Add DeviceClass watch to DRA reconciler

### DIFF
--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2026-06-14T11:58:55Z"
+    createdAt: "2026-06-22T10:01:22Z"
     operatorframework.io/suggested-namespace: openshift-kmm-hub
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -47,7 +47,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2026-06-14T11:58:54Z"
+    createdAt: "2026-06-22T10:01:21Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -161,6 +161,7 @@ spec:
           verbs:
           - create
           - delete
+          - deletecollection
           - get
           - list
           - patch
@@ -319,6 +320,19 @@ spec:
           verbs:
           - create
           - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - resource.k8s.io
+          resources:
+          - deviceclasses
+          verbs:
+          - create
+          - delete
+          - deletecollection
           - get
           - list
           - patch

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -50,6 +50,7 @@ rules:
   verbs:
   - create
   - delete
+  - deletecollection
   - get
   - list
   - patch
@@ -208,6 +209,19 @@ rules:
   verbs:
   - create
   - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - deviceclasses
+  verbs:
+  - create
+  - delete
+  - deletecollection
   - get
   - list
   - patch

--- a/internal/controllers/dra_reconciler.go
+++ b/internal/controllers/dra_reconciler.go
@@ -23,6 +23,7 @@ import (
 
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/filter"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/node"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	appsv1 "k8s.io/api/apps/v1"
@@ -32,8 +33,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -68,6 +71,11 @@ func (r *DRAReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&kmmv1beta1.Module{}).
 		Owns(&appsv1.DaemonSet{}).
+		Watches(
+			&resourcev1.DeviceClass{},
+			handler.EnqueueRequestsFromMapFunc(filter.DeviceClassToModuleReconcileRequest),
+			builder.WithPredicates(filter.HasLabel(constants.ModuleNameLabel)),
+		).
 		Named(DRAReconcilerName).
 		Complete(
 			reconcile.AsReconciler[*kmmv1beta1.Module](r.client, r),

--- a/internal/controllers/module_reconciler.go
+++ b/internal/controllers/module_reconciler.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-// +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=create;delete;get;list;patch;watch
+// +kubebuilder:rbac:groups=apps,resources=daemonsets,verbs=create;delete;deletecollection;get;list;patch;watch
 // +kubebuilder:rbac:groups=build.openshift.io,resources=builds,verbs=create;delete;get;list;patch;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get
 // +kubebuilder:rbac:groups=cluster.open-cluster-management.io,resources=clusterclaims,resourceNames=kernel-versions.kmm.node.kubernetes.io,verbs=delete;patch;update
@@ -71,6 +71,7 @@ import (
 // +kubebuilder:rbac:groups=operator.openshift.io,resources=machineconfigurations,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=create;delete;get;list;patch;watch
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies/finalizers,verbs=update;patch
+//+kubebuilder:rbac:groups=resource.k8s.io,resources=deviceclasses,verbs=create;delete;deletecollection;get;list;patch;update;watch
 
 const (
 	ModuleReconcilerName = "ModuleReconciler"

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -30,6 +30,18 @@ func HasLabel(label string) predicate.Predicate {
 	})
 }
 
+func DeviceClassToModuleReconcileRequest(_ context.Context, obj client.Object) []reconcile.Request {
+	labels := obj.GetLabels()
+	modName := labels[constants.ModuleNameLabel]
+	modNs := labels[constants.ModuleNamespaceLabel]
+	if modName == "" || modNs == "" {
+		return nil
+	}
+	return []reconcile.Request{
+		{NamespacedName: types.NamespacedName{Name: modName, Namespace: modNs}},
+	}
+}
+
 var skipDeletions predicate.Predicate = predicate.Funcs{
 	DeleteFunc: func(_ event.DeleteEvent) bool { return false },
 }


### PR DESCRIPTION
Watch DeviceClass resources so the controller reacts to external drift (e.g. manual deletion). Uses filter.HasLabel predicate to only process KMM-managed DeviceClasses. Also adds list, watch, and deletecollection RBAC verbs for the deviceclasses resource.

---

/cc @ybettan @yevgeny-shnaidman 
/assign @ybettan @yevgeny-shnaidman 

---

fixes #1823

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced device class lifecycle handling by extending controller event watching to device class objects, so module reconciliation now triggers when device class changes occur.

* **Chores**
  * Expanded authorization scope to include additional required permissions for device class operations and daemonset collection deletion, improving safe handling of device class and daemonset updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->