### PR TITLE
Add NetworkPolicy for DRA pods

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -195,7 +195,7 @@ func main() {
 		cmd.FatalError(setupLogger, err, "unable to create controller", "name", controllers.PodNodeLabelReconcilerName)
 	}
 
-	if err = controllers.NewDRAReconciler(client, nodeAPI, scheme).SetupWithManager(mgr); err != nil {
+	if err = controllers.NewDRAReconciler(client, nodeAPI, networkPolicyAPI, scheme).SetupWithManager(mgr); err != nil {
 		cmd.FatalError(setupLogger, err, "unable to create controller", "name", controllers.DRAReconcilerName)
 	}
 

--- a/internal/controllers/dra_reconciler.go
+++ b/internal/controllers/dra_reconciler.go
@@ -24,6 +24,7 @@ import (
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/filter"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/networkpolicy"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/node"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	appsv1 "k8s.io/api/apps/v1"
@@ -58,9 +59,10 @@ type DRAReconciler struct {
 func NewDRAReconciler(
 	client client.Client,
 	nodeAPI node.Node,
+	networkPolicyAPI networkpolicy.NetworkPolicy,
 	scheme *runtime.Scheme,
 ) *DRAReconciler {
-	reconHelperAPI := newDRAReconcilerHelper(client, nodeAPI, scheme)
+	reconHelperAPI := newDRAReconcilerHelper(client, nodeAPI, networkPolicyAPI, scheme)
 	return &DRAReconciler{
 		client:         client,
 		reconHelperAPI: reconHelperAPI,
@@ -101,6 +103,10 @@ func (r *DRAReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.Module) (
 		return ctrl.Result{}, r.reconHelperAPI.deleteDRAResources(ctx, mod.Name, mod.Namespace)
 	}
 
+	if err = r.reconHelperAPI.handleDRANetworkPolicy(ctx, mod); err != nil {
+		return res, fmt.Errorf("failed to handle DRA NetworkPolicy: %v", err)
+	}
+
 	if mod.Spec.DRA == nil {
 		if err = r.reconHelperAPI.deleteDRAResources(ctx, mod.Name, mod.Namespace); err != nil {
 			return ctrl.Result{}, err
@@ -138,6 +144,7 @@ func (r *DRAReconciler) Reconcile(ctx context.Context, mod *kmmv1beta1.Module) (
 type draReconcilerHelperAPI interface {
 	getModuleDRADaemonSets(ctx context.Context, name, namespace string) ([]appsv1.DaemonSet, error)
 	handleDRA(ctx context.Context, mod *kmmv1beta1.Module, existingDRADS []appsv1.DaemonSet) error
+	handleDRANetworkPolicy(ctx context.Context, mod *kmmv1beta1.Module) error
 	garbageCollectDRADaemonSets(ctx context.Context, mod *kmmv1beta1.Module, existingDS []appsv1.DaemonSet) error
 	deleteDRAResources(ctx context.Context, moduleName, moduleNamespace string) error
 	moduleUpdateDRAStatus(ctx context.Context, mod *kmmv1beta1.Module, existingDRADS []appsv1.DaemonSet) error
@@ -147,20 +154,23 @@ type draReconcilerHelperAPI interface {
 }
 
 type draReconcilerHelper struct {
-	client          client.Client
-	daemonSetHelper draDaemonSetCreator
-	nodeAPI         node.Node
+	client           client.Client
+	daemonSetHelper  draDaemonSetCreator
+	networkPolicyAPI networkpolicy.NetworkPolicy
+	nodeAPI          node.Node
 }
 
 func newDRAReconcilerHelper(client client.Client,
 	nodeAPI node.Node,
+	networkPolicyAPI networkpolicy.NetworkPolicy,
 	scheme *runtime.Scheme,
 ) draReconcilerHelperAPI {
 	daemonSetHelper := newDRADaemonSetCreator(scheme)
 	return &draReconcilerHelper{
-		client:          client,
-		daemonSetHelper: daemonSetHelper,
-		nodeAPI:         nodeAPI,
+		client:           client,
+		daemonSetHelper:  daemonSetHelper,
+		networkPolicyAPI: networkPolicyAPI,
+		nodeAPI:          nodeAPI,
 	}
 }
 
@@ -204,6 +214,23 @@ func (drh *draReconcilerHelper) handleDRA(ctx context.Context, mod *kmmv1beta1.M
 	}
 
 	return err
+}
+
+func (drh *draReconcilerHelper) handleDRANetworkPolicy(ctx context.Context, mod *kmmv1beta1.Module) error {
+	if mod.Spec.DRA == nil {
+		return nil
+	}
+
+	logger := log.FromContext(ctx)
+	logger.Info("Handling DRA NetworkPolicy", "module", mod.Name, "namespace", mod.Namespace)
+
+	draPolicy := drh.networkPolicyAPI.DRANetworkPolicy(mod.Namespace)
+	if err := drh.networkPolicyAPI.CreateOrAddOwnerReference(ctx, draPolicy, mod); err != nil {
+		return fmt.Errorf("failed to ensure DRA NetworkPolicy %s/%s: %v", draPolicy.Namespace, draPolicy.Name, err)
+	}
+
+	logger.Info("Successfully handled DRA NetworkPolicy")
+	return nil
 }
 
 func (drh *draReconcilerHelper) garbageCollectDRADaemonSets(ctx context.Context, mod *kmmv1beta1.Module, existingDS []appsv1.DaemonSet) error {
@@ -462,11 +489,19 @@ func (dsci *draDaemonSetCreatorImpl) setDRAAsDesired(
 		overrideLabels(ds.GetLabels(), standardLabels),
 	)
 
+	podTemplateLabels := make(map[string]string, len(standardLabels)+3)
+	for k, v := range standardLabels {
+		podTemplateLabels[k] = v
+	}
+	podTemplateLabels["app.kubernetes.io/name"] = "kmm"
+	podTemplateLabels["app.kubernetes.io/component"] = "dra"
+	podTemplateLabels["app.kubernetes.io/part-of"] = "kmm"
+
 	ds.Spec = appsv1.DaemonSetSpec{
 		Selector: &metav1.LabelSelector{MatchLabels: standardLabels},
 		Template: v1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels:     standardLabels,
+				Labels:     podTemplateLabels,
 				Finalizers: []string{constants.NodeLabelerFinalizer},
 			},
 			Spec: v1.PodSpec{

--- a/internal/controllers/dra_reconciler_test.go
+++ b/internal/controllers/dra_reconciler_test.go
@@ -26,11 +26,13 @@ import (
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/networkpolicy"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/node"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
 	"go.uber.org/mock/gomock"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -69,7 +71,7 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 
 	ctx := context.Background()
 
-	DescribeTable("check error flows", func(getDSError, getDCError, handleDRAError, gcError, handleDCError bool) {
+	DescribeTable("check error flows", func(getDSError, getDCError, handleNPError, handleDRAError, gcError, handleDCError bool) {
 		draDS := []appsv1.DaemonSet{{}}
 		returnedError := fmt.Errorf("some error")
 		if getDSError {
@@ -82,6 +84,11 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 			goto executeTestFunction
 		}
 		mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil)
+		if handleNPError {
+			mockReconHelper.EXPECT().handleDRANetworkPolicy(ctx, mod).Return(returnedError)
+			goto executeTestFunction
+		}
+		mockReconHelper.EXPECT().handleDRANetworkPolicy(ctx, mod).Return(nil)
 		if handleDRAError {
 			mockReconHelper.EXPECT().handleDRA(ctx, mod, draDS).Return(returnedError)
 			goto executeTestFunction
@@ -106,12 +113,13 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 		Expect(err).To(HaveOccurred())
 
 	},
-		Entry("getModuleDRADaemonSets failed", true, false, false, false, false),
-		Entry("getModuleDeviceClasses failed", false, true, false, false, false),
-		Entry("handleDRA failed", false, false, true, false, false),
-		Entry("garbageCollectDRADaemonSets failed", false, false, false, true, false),
-		Entry("handleDeviceClasses failed", false, false, false, false, true),
-		Entry("moduleUpdateDRAStatus failed", false, false, false, false, false),
+		Entry("getModuleDRADaemonSets failed", true, false, false, false, false, false),
+		Entry("getModuleDeviceClasses failed", false, true, false, false, false, false),
+		Entry("handleDRANetworkPolicy failed", false, false, true, false, false, false),
+		Entry("handleDRA failed", false, false, false, true, false, false),
+		Entry("garbageCollectDRADaemonSets failed", false, false, false, false, true, false),
+		Entry("handleDeviceClasses failed", false, false, false, false, false, true),
+		Entry("moduleUpdateDRAStatus failed", false, false, false, false, false, false),
 	)
 
 	It("Good flow", func() {
@@ -119,6 +127,7 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil),
 			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().handleDRANetworkPolicy(ctx, mod).Return(nil),
 			mockReconHelper.EXPECT().handleDRA(ctx, mod, draDS).Return(nil),
 			mockReconHelper.EXPECT().garbageCollectDRADaemonSets(ctx, mod, draDS).Return(nil),
 			mockReconHelper.EXPECT().handleDeviceClasses(ctx, mod, []resourcev1.DeviceClass(nil)).Return(nil),
@@ -164,6 +173,7 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(nil, nil),
 			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().handleDRANetworkPolicy(ctx, mod).Return(nil),
 			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod.Name, mod.Namespace).Return(nil),
 			mockReconHelper.EXPECT().clearDRAStatus(ctx, mod).Return(nil),
 		)
@@ -182,6 +192,7 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(draDS, nil),
 			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(existingDCs, nil),
+			mockReconHelper.EXPECT().handleDRANetworkPolicy(ctx, mod).Return(nil),
 			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod.Name, mod.Namespace).Return(nil),
 			mockReconHelper.EXPECT().clearDRAStatus(ctx, mod).Return(nil),
 		)
@@ -198,6 +209,7 @@ var _ = Describe("DRAReconciler_Reconcile", func() {
 		gomock.InOrder(
 			mockReconHelper.EXPECT().getModuleDRADaemonSets(ctx, mod.Name, mod.Namespace).Return(nil, nil),
 			mockReconHelper.EXPECT().getModuleDeviceClasses(ctx, mod.Name, mod.Namespace).Return(nil, nil),
+			mockReconHelper.EXPECT().handleDRANetworkPolicy(ctx, mod).Return(nil),
 			mockReconHelper.EXPECT().deleteDRAResources(ctx, mod.Name, mod.Namespace).Return(nil),
 			mockReconHelper.EXPECT().clearDRAStatus(ctx, mod).Return(fmt.Errorf("some error")),
 		)
@@ -314,7 +326,7 @@ var _ = Describe("DRAReconciler_moduleUpdateDRAStatus", func() {
 		clnt = client.NewMockClient(ctrl)
 		statusWriter = client.NewMockStatusWriter(ctrl)
 		mn = node.NewNode(clnt)
-		drh = newDRAReconcilerHelper(clnt, mn, nil)
+		drh = newDRAReconcilerHelper(clnt, mn, nil, nil)
 	})
 
 	ctx := context.Background()
@@ -585,9 +597,17 @@ var _ = Describe("DRAReconciler_setDRAAsDesired", func() {
 			err := dsc.setDRAAsDesired(context.Background(), &ds, &mod)
 			Expect(err).NotTo(HaveOccurred())
 
-			podLabels := map[string]string{
+			dsLabels := map[string]string{
 				constants.ModuleNameLabel: draModuleName,
 				constants.DaemonSetRole:   constants.DRARoleLabelValue,
+			}
+
+			podLabels := map[string]string{
+				constants.ModuleNameLabel:     draModuleName,
+				constants.DaemonSetRole:       constants.DRARoleLabelValue,
+				"app.kubernetes.io/name":      "kmm",
+				"app.kubernetes.io/component": "dra",
+				"app.kubernetes.io/part-of":   "kmm",
 			}
 
 			expectedInitContainer := []v1.Container{
@@ -618,7 +638,7 @@ var _ = Describe("DRAReconciler_setDRAAsDesired", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      dsName,
 					Namespace: namespace,
-					Labels:    podLabels,
+					Labels:    dsLabels,
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							APIVersion:         mod.APIVersion,
@@ -631,7 +651,7 @@ var _ = Describe("DRAReconciler_setDRAAsDesired", func() {
 					},
 				},
 				Spec: appsv1.DaemonSetSpec{
-					Selector: &metav1.LabelSelector{MatchLabels: podLabels},
+					Selector: &metav1.LabelSelector{MatchLabels: dsLabels},
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels:     podLabels,
@@ -1237,5 +1257,55 @@ var _ = Describe("DRAReconciler_deleteDRAResources", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("DaemonSets"))
 		Expect(err.Error()).To(ContainSubstring("DeviceClasses"))
+	})
+})
+
+var _ = Describe("draReconcilerHelper_handleDRANetworkPolicy", func() {
+	var (
+		ctrl   *gomock.Controller
+		mockNP *networkpolicy.MockNetworkPolicy
+		drh    draReconcilerHelper
+		ctx    context.Context
+		mod    *kmmv1beta1.Module
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		mockNP = networkpolicy.NewMockNetworkPolicy(ctrl)
+		ctx = context.Background()
+		drh = draReconcilerHelper{
+			networkPolicyAPI: mockNP,
+		}
+		mod = &kmmv1beta1.Module{
+			ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "dra-module"},
+			Spec: kmmv1beta1.ModuleSpec{
+				DRA: &kmmv1beta1.DRASpec{},
+			},
+		}
+	})
+
+	It("should return nil when DRA is nil", func() {
+		mod.Spec.DRA = nil
+		err := drh.handleDRANetworkPolicy(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should create the DRA NetworkPolicy", func() {
+		policy := &networkingv1.NetworkPolicy{}
+		mockNP.EXPECT().DRANetworkPolicy(mod.Namespace).Return(policy)
+		mockNP.EXPECT().CreateOrAddOwnerReference(ctx, policy, mod).Return(nil)
+
+		err := drh.handleDRANetworkPolicy(ctx, mod)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should return error if CreateOrAddOwnerReference fails", func() {
+		policy := &networkingv1.NetworkPolicy{}
+		mockNP.EXPECT().DRANetworkPolicy(mod.Namespace).Return(policy)
+		mockNP.EXPECT().CreateOrAddOwnerReference(ctx, policy, mod).Return(fmt.Errorf("some error"))
+
+		err := drh.handleDRANetworkPolicy(ctx, mod)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to ensure DRA NetworkPolicy"))
 	})
 })

--- a/internal/controllers/mock_dra_reconciler.go
+++ b/internal/controllers/mock_dra_reconciler.go
@@ -127,6 +127,20 @@ func (mr *MockdraReconcilerHelperAPIMockRecorder) handleDRA(ctx, mod, existingDR
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleDRA", reflect.TypeOf((*MockdraReconcilerHelperAPI)(nil).handleDRA), ctx, mod, existingDRADS)
 }
 
+// handleDRANetworkPolicy mocks base method.
+func (m *MockdraReconcilerHelperAPI) handleDRANetworkPolicy(ctx context.Context, mod *v1beta1.Module) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "handleDRANetworkPolicy", ctx, mod)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// handleDRANetworkPolicy indicates an expected call of handleDRANetworkPolicy.
+func (mr *MockdraReconcilerHelperAPIMockRecorder) handleDRANetworkPolicy(ctx, mod any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "handleDRANetworkPolicy", reflect.TypeOf((*MockdraReconcilerHelperAPI)(nil).handleDRANetworkPolicy), ctx, mod)
+}
+
 // handleDeviceClasses mocks base method.
 func (m *MockdraReconcilerHelperAPI) handleDeviceClasses(ctx context.Context, mod *v1beta1.Module, existingDCs []v10.DeviceClass) error {
 	m.ctrl.T.Helper()

--- a/internal/networkpolicy/mock_networkpolicy.go
+++ b/internal/networkpolicy/mock_networkpolicy.go
@@ -68,6 +68,20 @@ func (mr *MockNetworkPolicyMockRecorder) CreateOrAddOwnerReference(ctx, np, owne
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrAddOwnerReference", reflect.TypeOf((*MockNetworkPolicy)(nil).CreateOrAddOwnerReference), ctx, np, owner)
 }
 
+// DRANetworkPolicy mocks base method.
+func (m *MockNetworkPolicy) DRANetworkPolicy(namespace string) *v1.NetworkPolicy {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DRANetworkPolicy", namespace)
+	ret0, _ := ret[0].(*v1.NetworkPolicy)
+	return ret0
+}
+
+// DRANetworkPolicy indicates an expected call of DRANetworkPolicy.
+func (mr *MockNetworkPolicyMockRecorder) DRANetworkPolicy(namespace any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DRANetworkPolicy", reflect.TypeOf((*MockNetworkPolicy)(nil).DRANetworkPolicy), namespace)
+}
+
 // DevicePluginNetworkPolicy mocks base method.
 func (m *MockNetworkPolicy) DevicePluginNetworkPolicy(namespace string) *v1.NetworkPolicy {
 	m.ctrl.T.Helper()

--- a/internal/networkpolicy/networkpolicy.go
+++ b/internal/networkpolicy/networkpolicy.go
@@ -22,6 +22,7 @@ type NetworkPolicy interface {
 	BuildSignPodsNetworkPolicy(namespace string) *networkingv1.NetworkPolicy
 	PullPodNetworkPolicy(namespace string) *networkingv1.NetworkPolicy
 	DevicePluginNetworkPolicy(namespace string) *networkingv1.NetworkPolicy
+	DRANetworkPolicy(namespace string) *networkingv1.NetworkPolicy
 }
 
 type networkPolicy struct {
@@ -41,6 +42,7 @@ const (
 	buildSignPodsNetworkPolicyName = "kmm-build-and-sign"
 	pullPodNetworkPolicyName       = "kmm-pull"
 	devicePluginNetworkPolicyName  = "kmm-device-plugin"
+	draNetworkPolicyName           = "kmm-dra"
 	defaultNamespace               = "default"
 )
 
@@ -177,6 +179,26 @@ func (np *networkPolicy) DevicePluginNetworkPolicy(namespace string) *networking
 			PodSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app.kubernetes.io/component": "device-plugin",
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeIngress,
+				networkingv1.PolicyTypeEgress,
+			},
+		},
+	}
+}
+
+func (np *networkPolicy) DRANetworkPolicy(namespace string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      draNetworkPolicyName,
+			Namespace: normalizeNamespace(namespace),
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app.kubernetes.io/component": "dra",
 				},
 			},
 			PolicyTypes: []networkingv1.PolicyType{

--- a/internal/networkpolicy/networkpolicy_test.go
+++ b/internal/networkpolicy/networkpolicy_test.go
@@ -252,6 +252,31 @@ var _ = Describe("NetworkPolicy", func() {
 		})
 	})
 
+	Describe("DRANetworkPolicy", func() {
+		It("should return correct NetworkPolicy for DRA pods", func() {
+			result := np.DRANetworkPolicy(testNamespace)
+
+			Expect(result).NotTo(BeNil())
+			Expect(result.Name).To(Equal(draNetworkPolicyName))
+			Expect(result.Namespace).To(Equal(testNamespace))
+
+			Expect(result.Spec.PodSelector.MatchLabels).To(HaveKeyWithValue("app.kubernetes.io/component", "dra"))
+
+			Expect(result.Spec.PolicyTypes).To(ContainElements(
+				networkingv1.PolicyTypeIngress,
+				networkingv1.PolicyTypeEgress,
+			))
+
+			Expect(result.Spec.Ingress).To(BeEmpty())
+			Expect(result.Spec.Egress).To(BeEmpty())
+		})
+
+		It("should use default namespace when empty namespace is provided", func() {
+			result := np.DRANetworkPolicy("")
+			Expect(result.Namespace).To(Equal("default"))
+		})
+	})
+
 	Describe("ensureOwnerReference", func() {
 		var policy *networkingv1.NetworkPolicy
 


### PR DESCRIPTION
DRA pods were the only KMM operand without a NetworkPolicy. Add a deny-all NetworkPolicy (kmm-dra) for them, matching the existing pattern used by worker, build/sign, pull, and device-plugin pods.
Also add app.kubernetes.io labels to DRA
pod templates so the NetworkPolicy selector can target them.

---

/cc @yevgeny-shnaidman @ybettan 
/assign @yevgeny-shnaidman @ybettan 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating a DRA-specific network policy.
  * DRA-related workloads now get more consistent app labels on pod templates.

* **Bug Fixes**
  * Reconciler flow now ensures the DRA network policy is handled during updates.
  * Improved ownership handling so the policy is properly linked to its parent resource.

* **Tests**
  * Expanded coverage for DRA reconciliation and network policy creation, including error cases and default namespace behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->