### PR TITLE
Fix DRA NetworkPolicy: allow API server and DNS egress

### DIFF
--- a/internal/networkpolicy/networkpolicy.go
+++ b/internal/networkpolicy/networkpolicy.go
@@ -5,10 +5,13 @@ import (
 	"fmt"
 
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/pod"
+	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -199,6 +202,19 @@ func (np *networkPolicy) DRANetworkPolicy(namespace string) *networkingv1.Networ
 			PodSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app.kubernetes.io/component": "dra",
+				},
+			},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Protocol: ptr.To(v1.ProtocolTCP), Port: ptr.To(intstr.FromInt32(443))},
+					},
+				},
+				{
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Protocol: ptr.To(v1.ProtocolTCP), Port: ptr.To(intstr.FromInt32(53))},
+						{Protocol: ptr.To(v1.ProtocolUDP), Port: ptr.To(intstr.FromInt32(53))},
+					},
 				},
 			},
 			PolicyTypes: []networkingv1.PolicyType{

--- a/internal/networkpolicy/networkpolicy_test.go
+++ b/internal/networkpolicy/networkpolicy_test.go
@@ -10,10 +10,13 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/client"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/pod"
 	"go.uber.org/mock/gomock"
+	v1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -268,7 +271,14 @@ var _ = Describe("NetworkPolicy", func() {
 			))
 
 			Expect(result.Spec.Ingress).To(BeEmpty())
-			Expect(result.Spec.Egress).To(BeEmpty())
+			Expect(result.Spec.Egress).To(HaveLen(2))
+			Expect(result.Spec.Egress[0].Ports).To(ConsistOf(
+				networkingv1.NetworkPolicyPort{Protocol: ptr.To(v1.ProtocolTCP), Port: ptr.To(intstr.FromInt32(443))},
+			))
+			Expect(result.Spec.Egress[1].Ports).To(ConsistOf(
+				networkingv1.NetworkPolicyPort{Protocol: ptr.To(v1.ProtocolTCP), Port: ptr.To(intstr.FromInt32(53))},
+				networkingv1.NetworkPolicyPort{Protocol: ptr.To(v1.ProtocolUDP), Port: ptr.To(intstr.FromInt32(53))},
+			))
 		})
 
 		It("should use default namespace when empty namespace is provided", func() {


### PR DESCRIPTION
The DRA NetworkPolicy (from edbb3a36) declares both Ingress and Egress policy types but has no egress rules, which blocks all outbound traffic from the DRA kubelet plugin pod. This prevents the plugin from reaching the API server to create/update ResourceSlices. This PR allows egress to the API server (TCP 443) and DNS (TCP/UDP 53).

This PR was written in part with the assistance of generative AI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated network access rules for DRA pods to allow only the required outbound connections.
  * Egress traffic is now limited to HTTPS and DNS, improving cluster network security.
* **Tests**
  * Adjusted coverage to verify the new outbound network rules and expected allowed ports/protocols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->