### PR TITLE
Add default ServiceAccount with RBAC for DRA in operator namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -288,7 +288,7 @@ bundle: operator-sdk manifests kustomize ## Generate bundle manifests and metada
 	cd config/webhook-server && $(KUSTOMIZE) edit set image webhook-server=$(WEBHOOK_IMG)
 
 	OPERATOR_SDK="${OPERATOR_SDK}" \
-	BUNDLE_GEN_FLAGS="${BUNDLE_GEN_FLAGS} --extra-service-accounts kmm-operator-module-loader,kmm-operator-device-plugin" \
+	BUNDLE_GEN_FLAGS="${BUNDLE_GEN_FLAGS} --extra-service-accounts kmm-operator-module-loader,kmm-operator-device-plugin,kmm-operator-dra" \
 	PKG=kernel-module-management \
 	SOURCE_DIR=$(dir $(realpath $(lastword $(MAKEFILE_LIST)))) \
 	./hack/generate-bundle

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -47,7 +47,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2026-06-22T10:01:21Z"
+    createdAt: "2026-06-30T14:21:01Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -351,6 +351,28 @@ spec:
           verbs:
           - create
         serviceAccountName: kmm-operator-controller
+      - rules:
+        - apiGroups:
+          - security.openshift.io
+          resourceNames:
+          - privileged
+          resources:
+          - securitycontextconstraints
+          verbs:
+          - use
+        - apiGroups:
+          - resource.k8s.io
+          resources:
+          - resourceslices
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        serviceAccountName: kmm-operator-dra
       deployments:
       - label:
           app.kubernetes.io/component: kmm

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -195,7 +195,7 @@ func main() {
 		cmd.FatalError(setupLogger, err, "unable to create controller", "name", controllers.PodNodeLabelReconcilerName)
 	}
 
-	if err = controllers.NewDRAReconciler(client, nodeAPI, networkPolicyAPI, scheme).SetupWithManager(mgr); err != nil {
+	if err = controllers.NewDRAReconciler(client, nodeAPI, networkPolicyAPI, scheme, operatorNamespace).SetupWithManager(mgr); err != nil {
 		cmd.FatalError(setupLogger, err, "unable to create controller", "name", controllers.DRAReconcilerName)
 	}
 

--- a/config/rbac/dra_cluster_role.yaml
+++ b/config/rbac/dra_cluster_role.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dra
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - resourceslices
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete

--- a/config/rbac/dra_cluster_role_binding.yaml
+++ b/config/rbac/dra_cluster_role_binding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dra
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dra
+subjects:
+- kind: ServiceAccount
+  name: dra
+  namespace: system

--- a/config/rbac/dra_service_account.yaml
+++ b/config/rbac/dra_service_account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dra
+  namespace: system

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -6,6 +6,9 @@ resources:
   - device_plugin_service_account.yaml
   - device_plugin_cluster_role.yaml
   - device_plugin_role_binding.yaml
+  - dra_service_account.yaml
+  - dra_cluster_role.yaml
+  - dra_cluster_role_binding.yaml
   - module_loader_service_account.yaml
   - module_loader_cluster_role.yaml
   - module_loader_role_binding.yaml

--- a/internal/controllers/dra_reconciler.go
+++ b/internal/controllers/dra_reconciler.go
@@ -66,8 +66,9 @@ func NewDRAReconciler(
 	nodeAPI node.Node,
 	networkPolicyAPI networkpolicy.NetworkPolicy,
 	scheme *runtime.Scheme,
+	operatorNamespace string,
 ) *DRAReconciler {
-	reconHelperAPI := newDRAReconcilerHelper(client, nodeAPI, networkPolicyAPI, scheme)
+	reconHelperAPI := newDRAReconcilerHelper(client, nodeAPI, networkPolicyAPI, scheme, operatorNamespace)
 	return &DRAReconciler{
 		client:         client,
 		reconHelperAPI: reconHelperAPI,
@@ -169,8 +170,9 @@ func newDRAReconcilerHelper(client client.Client,
 	nodeAPI node.Node,
 	networkPolicyAPI networkpolicy.NetworkPolicy,
 	scheme *runtime.Scheme,
+	operatorNamespace string,
 ) draReconcilerHelperAPI {
-	daemonSetHelper := newDRADaemonSetCreator(scheme)
+	daemonSetHelper := newDRADaemonSetCreator(scheme, operatorNamespace)
 	return &draReconcilerHelper{
 		client:           client,
 		daemonSetHelper:  daemonSetHelper,
@@ -425,12 +427,14 @@ type draDaemonSetCreator interface {
 }
 
 type draDaemonSetCreatorImpl struct {
-	scheme *runtime.Scheme
+	scheme            *runtime.Scheme
+	operatorNamespace string
 }
 
-func newDRADaemonSetCreator(scheme *runtime.Scheme) draDaemonSetCreator {
+func newDRADaemonSetCreator(scheme *runtime.Scheme, operatorNamespace string) draDaemonSetCreator {
 	return &draDaemonSetCreatorImpl{
-		scheme: scheme,
+		scheme:            scheme,
+		operatorNamespace: operatorNamespace,
 	}
 }
 
@@ -557,6 +561,15 @@ func (dsci *draDaemonSetCreatorImpl) setDRAAsDesired(
 	podTemplateLabels["app.kubernetes.io/component"] = "dra"
 	podTemplateLabels["app.kubernetes.io/part-of"] = "kmm"
 
+	serviceAccountName := mod.Spec.DRA.ServiceAccountName
+	if serviceAccountName == "" {
+		if mod.Namespace == dsci.operatorNamespace {
+			serviceAccountName = "kmm-operator-dra"
+		} else {
+			log.FromContext(ctx).Info(utils.WarnString("No ServiceAccount set for the DRA DaemonSet"))
+		}
+	}
+
 	ds.Spec = appsv1.DaemonSetSpec{
 		Selector: &metav1.LabelSelector{MatchLabels: standardLabels},
 		Template: v1.PodTemplateSpec{
@@ -571,7 +584,7 @@ func (dsci *draDaemonSetCreatorImpl) setDRAAsDesired(
 				HostNetwork:                  true,
 				ImagePullSecrets:             getPodPullSecrets(mod.Spec.ImageRepoSecret),
 				NodeSelector:                 nodeSelector,
-				ServiceAccountName:           mod.Spec.DRA.ServiceAccountName,
+				ServiceAccountName:           serviceAccountName,
 				Volumes:                      append([]v1.Volume{pluginsVolume, registryVolume, cdiVolume}, mod.Spec.DRA.Volumes...),
 				Tolerations:                  mod.Spec.Tolerations,
 				AutomountServiceAccountToken: mod.Spec.DRA.AutomountServiceAccountToken,

--- a/internal/controllers/dra_reconciler_test.go
+++ b/internal/controllers/dra_reconciler_test.go
@@ -326,7 +326,7 @@ var _ = Describe("DRAReconciler_moduleUpdateDRAStatus", func() {
 		clnt = client.NewMockClient(ctrl)
 		statusWriter = client.NewMockStatusWriter(ctrl)
 		mn = node.NewNode(clnt)
-		drh = newDRAReconcilerHelper(clnt, mn, nil, nil)
+		drh = newDRAReconcilerHelper(clnt, mn, nil, nil, "")
 	})
 
 	ctx := context.Background()
@@ -447,6 +447,7 @@ var _ = Describe("DRAReconciler_setDRAAsDesired", func() {
 	const (
 		draImage      = "dra-image"
 		draModuleName = "dra-module"
+		draOperatorNS = "operatorNamespace"
 	)
 
 	var (
@@ -454,7 +455,7 @@ var _ = Describe("DRAReconciler_setDRAAsDesired", func() {
 	)
 
 	BeforeEach(func() {
-		dsc = newDRADaemonSetCreator(scheme)
+		dsc = newDRADaemonSetCreator(scheme, draOperatorNS)
 	})
 
 	It("should return an error if the DaemonSet is nil", func() {
@@ -497,6 +498,35 @@ var _ = Describe("DRAReconciler_setDRAAsDesired", func() {
 		Expect(ds.Spec.Template.Spec.Volumes[2].Name).To(Equal("cdi"))
 		Expect(ds.Spec.Template.Spec.Volumes[3]).To(Equal(vol))
 	})
+
+	DescribeTable("should set the correct ServiceAccount on the DRA DaemonSet",
+		func(moduleNamespace, specSA, expectedSA string) {
+			mod := kmmv1beta1.Module{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: moduleNamespace,
+				},
+				Spec: kmmv1beta1.ModuleSpec{
+					DRA: &kmmv1beta1.DRASpec{
+						ServiceAccountName: specSA,
+						Container:          kmmv1beta1.CommonContainerSpec{Image: draImage},
+					},
+				},
+			}
+
+			ds := appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: moduleNamespace,
+				},
+			}
+
+			err := dsc.setDRAAsDesired(context.Background(), &ds, &mod)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ds.Spec.Template.Spec.ServiceAccountName).To(Equal(expectedSA))
+		},
+		Entry("not in operator namespace, no SA specified", "some-namespace", "", ""),
+		Entry("in operator namespace, no SA specified", draOperatorNS, "", "kmm-operator-dra"),
+		Entry("in operator namespace, explicit SA specified", draOperatorNS, "custom-sa", "custom-sa"),
+	)
 
 	DescribeTable("should work as expected",
 		func(withInitContainer bool) {


### PR DESCRIPTION
The device plugin reconciler already falls back to a pre-created privileged ServiceAccount (kmm-operator-device-plugin) when the Module is deployed in the operator namespace and no explicit SA is specified. The DRA reconciler was missing this fallback, so DRA pods in the operator namespace would use the default SA without the necessary permissions.

---

/cc @yevgeny-shnaidman 
/assign @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a dedicated DRA service account and permissions for generated workloads.
  * Updated DRA deployment behavior to automatically choose the appropriate service account in the operator namespace, with support for a custom value when provided.

* **Bug Fixes**
  * Improved DRA setup so permissions and service account usage are applied consistently during bundle generation and deployment.

* **Chores**
  * Updated the packaged release metadata to include the new DRA-related resources and permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->