### PR TITLE
Add missing RBAC for DRA driver ServiceAccount

### DIFF
--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2026-06-22T10:01:22Z"
+    createdAt: "2026-07-01T07:49:17Z"
     operatorframework.io/suggested-namespace: openshift-kmm-hub
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -47,7 +47,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2026-06-30T14:21:01Z"
+    createdAt: "2026-07-01T07:49:10Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -372,6 +372,22 @@ spec:
           - update
           - patch
           - delete
+        - apiGroups:
+          - resource.k8s.io
+          resources:
+          - resourceclaims
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - watch
         serviceAccountName: kmm-operator-dra
       deployments:
       - label:

--- a/config/rbac/dra_cluster_role.yaml
+++ b/config/rbac/dra_cluster_role.yaml
@@ -23,3 +23,19 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - resource.k8s.io
+  resources:
+  - resourceclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
The kubeletplugin library requires nodes read access to look up the node UID when publishing ResourceSlices, and resourceclaims read access during PrepareResourceClaims. Without these, any DRA driver deployed through KMM fails at runtime.

reference to NVIDIA's rbac for dra driver pod https://github.com/kubernetes-sigs/dra-driver-nvidia-gpu/blob/main/deployments/helm/dra-driver-nvidia-gpu/templates/rbac-kubeletplugin.yaml#L3

---

/cc @yevgeny-shnaidman 
/assign @yevgeny-shnaidman 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded cluster permissions to allow broader access to node and resource claim information, improving compatibility with dynamic resource allocation workflows.

* **Chores**
  * Updated release manifest timestamps to reflect the latest build metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->