### PR TITLE
Gate DRA reconciler on Openshift >= 4.21

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -48,6 +48,7 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/networkpolicy"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/nmc"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/syncronizedmap"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/version"
 	"k8s.io/apimachinery/pkg/api/meta"
 	runtimescheme "k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -126,8 +127,16 @@ func main() {
 	}
 
 	options := cg.GetManagerOptionsFromConfig(cfg, scheme)
+	restCfg := ctrl.GetConfigOrDie()
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
+	ocpVersion, err := version.DiscoverOCPVersion(restCfg)
+	if err != nil {
+		cmd.FatalError(setupLogger, err, "unable to discover Openshift version")
+	}
+
+	setupLogger.Info("Detected Openshift version", "major", ocpVersion.Major, "minor", ocpVersion.Minor)
+
+	mgr, err := ctrl.NewManager(restCfg, options)
 	if err != nil {
 		cmd.FatalError(setupLogger, err, "unable to create manager")
 	}
@@ -195,8 +204,16 @@ func main() {
 		cmd.FatalError(setupLogger, err, "unable to create controller", "name", controllers.PodNodeLabelReconcilerName)
 	}
 
-	if err = controllers.NewDRAReconciler(client, nodeAPI, networkPolicyAPI, scheme, operatorNamespace).SetupWithManager(mgr); err != nil {
-		cmd.FatalError(setupLogger, err, "unable to create controller", "name", controllers.DRAReconcilerName)
+	if ocpVersion.AtLeast(constants.MinOCPMajorForDRA, constants.MinOCPMinorForDRA) {
+		if err = controllers.NewDRAReconciler(client, nodeAPI, networkPolicyAPI, scheme, operatorNamespace).SetupWithManager(mgr); err != nil {
+			cmd.FatalError(setupLogger, err, "unable to create controller", "name", controllers.DRAReconcilerName)
+		}
+	} else {
+		setupLogger.Info(
+			fmt.Sprintf("Skipping DRA controller; requires Openshift >= %d.%d", constants.MinOCPMajorForDRA, constants.MinOCPMinorForDRA),
+			"detectedMajor", ocpVersion.Major,
+			"detectedMinor", ocpVersion.Minor,
+		)
 	}
 
 	if err = controllers.NewNodeLabelModuleVersionReconciler(client).SetupWithManager(mgr); err != nil {

--- a/cmd/webhook-server/main.go
+++ b/cmd/webhook-server/main.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/cmd"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/config"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/version"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/webhook"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/webhook/hub"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -84,7 +85,7 @@ func main() {
 	if enableModule {
 		logger.Info("Enabling Module webhook")
 
-		ocpVersion, err := webhook.DiscoverOCPVersion(restCfg)
+		ocpVersion, err := version.DiscoverOCPVersion(restCfg)
 		if err != nil {
 			cmd.FatalError(setupLogger, err, "unable to discover OpenShift version")
 		}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strconv"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/rest"
+)
+
+var ocpVersionRe = regexp.MustCompile(`^v?(\d+)\.(\d+)`)
+
+// OCPVersion holds the parsed major and minor version of an OpenShift cluster.
+type OCPVersion struct {
+	Major int
+	Minor int
+}
+
+// AtLeast returns true if ov is greater than or equal to the given major.minor version.
+func (ov OCPVersion) AtLeast(major, minor int) bool {
+	return ov.Major > major || (ov.Major == major && ov.Minor >= minor)
+}
+
+// DiscoverOCPVersion queries the OpenShift ClusterVersion resource and returns the cluster version.
+func DiscoverOCPVersion(cfg *rest.Config) (OCPVersion, error) {
+	ocpScheme := runtime.NewScheme()
+	if err := configv1.Install(ocpScheme); err != nil {
+		return OCPVersion{}, fmt.Errorf("failed to register OpenShift config scheme: %v", err)
+	}
+
+	cfgCopy := *cfg
+	cfgCopy.GroupVersion = &schema.GroupVersion{Group: "config.openshift.io", Version: "v1"}
+	cfgCopy.APIPath = "/apis"
+	cfgCopy.NegotiatedSerializer = serializer.NewCodecFactory(ocpScheme)
+
+	client, err := rest.RESTClientFor(&cfgCopy)
+	if err != nil {
+		return OCPVersion{}, fmt.Errorf("failed to create REST client for OpenShift config API: %v", err)
+	}
+
+	cv := &configv1.ClusterVersion{}
+	if err = client.Get().Resource("clusterversions").Name("version").Do(context.Background()).Into(cv); err != nil {
+		return OCPVersion{}, fmt.Errorf("failed to get ClusterVersion: %v", err)
+	}
+
+	return ParseOCPVersion(cv.Status.Desired.Version)
+}
+
+// ParseOCPVersion extracts the major and minor version from an OpenShift
+// version string such as "4.21.0" or "4.21.0-rc.1".
+func ParseOCPVersion(version string) (OCPVersion, error) {
+	m := ocpVersionRe.FindStringSubmatch(version)
+	if m == nil {
+		return OCPVersion{}, fmt.Errorf("cannot parse OpenShift version from %q", version)
+	}
+
+	major, err := strconv.Atoi(m[1])
+	if err != nil {
+		return OCPVersion{}, fmt.Errorf("cannot parse OpenShift major version from %q: %v", version, err)
+	}
+	minor, err := strconv.Atoi(m[2])
+	if err != nil {
+		return OCPVersion{}, fmt.Errorf("cannot parse OpenShift minor version from %q: %v", version, err)
+	}
+	return OCPVersion{Major: major, Minor: minor}, nil
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Version Suite")
+}
+
+var _ = Describe("AtLeast", func() {
+	DescribeTable(
+		"should compare versions correctly",
+		func(major, minor, minMajor, minMinor int, expected bool) {
+			ov := OCPVersion{Major: major, Minor: minor}
+			Expect(ov.AtLeast(minMajor, minMinor)).To(Equal(expected))
+		},
+		Entry("exact match", 4, 21, 4, 21, true),
+		Entry("higher minor", 4, 22, 4, 21, true),
+		Entry("lower minor", 4, 20, 4, 21, false),
+		Entry("higher major, lower minor", 5, 0, 4, 21, true),
+		Entry("lower major", 3, 11, 4, 21, false),
+	)
+})
+
+var _ = Describe("ParseOCPVersion", func() {
+	DescribeTable(
+		"should parse valid version strings",
+		func(version string, expectedMajor, expectedMinor int) {
+			ov, err := ParseOCPVersion(version)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ov.Major).To(Equal(expectedMajor))
+			Expect(ov.Minor).To(Equal(expectedMinor))
+		},
+		Entry("standard version", "4.21.0", 4, 21),
+		Entry("release candidate", "4.21.0-rc.1", 4, 21),
+		Entry("older minor", "4.20.3", 4, 20),
+		Entry("newer minor", "4.22.1", 4, 22),
+		Entry("with v prefix", "v4.21.0", 4, 21),
+		Entry("hypothetical OCP 5.0", "5.0.0", 5, 0),
+	)
+
+	DescribeTable(
+		"should return error for invalid strings",
+		func(version string) {
+			_, err := ParseOCPVersion(version)
+			Expect(err).To(HaveOccurred())
+		},
+		Entry("empty string", ""),
+		Entry("garbage", "invalid"),
+		Entry("no minor", "v4"),
+	)
+})

--- a/internal/webhook/hub/managedclustermodule_webhook.go
+++ b/internal/webhook/hub/managedclustermodule_webhook.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/rh-ecosystem-edge/kernel-module-management/api-hub/v1beta1"
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/version"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/webhook"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -34,7 +35,7 @@ type ManagedClusterModuleValidator struct {
 	m      admission.CustomValidator
 }
 
-func NewManagedClusterModuleValidator(logger logr.Logger, ocpVersion *webhook.OCPVersion) *ManagedClusterModuleValidator {
+func NewManagedClusterModuleValidator(logger logr.Logger, ocpVersion *version.OCPVersion) *ManagedClusterModuleValidator {
 	return &ManagedClusterModuleValidator{
 		logger: logger,
 		m:      webhook.NewModuleValidator(logger, ocpVersion),

--- a/internal/webhook/module.go
+++ b/internal/webhook/module.go
@@ -22,21 +22,17 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/go-logr/logr"
-	configv1 "github.com/openshift/api/config/v1"
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/constants"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/version"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -45,64 +41,13 @@ import (
 // 63 (max label key length after slash) - len("version-schedule-plugin.") = 38
 const maxCombinedLength = 38
 
-var ocpVersionRe = regexp.MustCompile(`^v?(\d+)\.(\d+)`)
-
-// OCPVersion holds the parsed major and minor version of an OpenShift cluster.
-type OCPVersion struct {
-	Major int
-	Minor int
-}
-
 type ModuleValidator struct {
 	logger     logr.Logger
-	ocpVersion *OCPVersion
+	ocpVersion *version.OCPVersion
 }
 
-func NewModuleValidator(logger logr.Logger, ocpVersion *OCPVersion) *ModuleValidator {
+func NewModuleValidator(logger logr.Logger, ocpVersion *version.OCPVersion) *ModuleValidator {
 	return &ModuleValidator{logger: logger, ocpVersion: ocpVersion}
-}
-
-// DiscoverOCPVersion queries the OpenShift ClusterVersion resource and returns the cluster version.
-func DiscoverOCPVersion(cfg *rest.Config) (OCPVersion, error) {
-	ocpScheme := runtime.NewScheme()
-	if err := configv1.Install(ocpScheme); err != nil {
-		return OCPVersion{}, fmt.Errorf("failed to register OpenShift config scheme: %v", err)
-	}
-
-	cfgCopy := *cfg
-	cfgCopy.GroupVersion = &schema.GroupVersion{Group: "config.openshift.io", Version: "v1"}
-	cfgCopy.APIPath = "/apis"
-	cfgCopy.NegotiatedSerializer = serializer.NewCodecFactory(ocpScheme)
-
-	client, err := rest.RESTClientFor(&cfgCopy)
-	if err != nil {
-		return OCPVersion{}, fmt.Errorf("failed to create REST client for OpenShift config API: %v", err)
-	}
-
-	cv := &configv1.ClusterVersion{}
-	if err = client.Get().Resource("clusterversions").Name("version").Do(context.Background()).Into(cv); err != nil {
-		return OCPVersion{}, fmt.Errorf("failed to get ClusterVersion: %v", err)
-	}
-
-	return parseOCPVersion(cv.Status.Desired.Version)
-}
-
-// parseOCPVersion extracts the major and minor version from an OpenShift
-// version string such as "4.21.0" or "4.21.0-rc.1".
-func parseOCPVersion(version string) (OCPVersion, error) {
-	m := ocpVersionRe.FindStringSubmatch(version)
-	if m == nil {
-		return OCPVersion{}, fmt.Errorf("cannot parse OpenShift version from %q", version)
-	}
-	major, err := strconv.Atoi(m[1])
-	if err != nil {
-		return OCPVersion{}, fmt.Errorf("cannot parse OpenShift major version from %q: %v", version, err)
-	}
-	minor, err := strconv.Atoi(m[2])
-	if err != nil {
-		return OCPVersion{}, fmt.Errorf("cannot parse OpenShift minor version from %q: %v", version, err)
-	}
-	return OCPVersion{Major: major, Minor: minor}, nil
 }
 
 func (m *ModuleValidator) SetupWebhookWithManager(mgr ctrl.Manager) error {
@@ -157,7 +102,7 @@ func (m *ModuleValidator) ValidateDelete(ctx context.Context, obj runtime.Object
 	return nil, NotImplemented
 }
 
-func validateModule(mod *kmmv1beta1.Module, ocpVersion *OCPVersion) (admission.Warnings, error) {
+func validateModule(mod *kmmv1beta1.Module, ocpVersion *version.OCPVersion) (admission.Warnings, error) {
 	nameLength := len(mod.Name + mod.Namespace)
 
 	if nameLength > maxCombinedLength {
@@ -204,18 +149,18 @@ func validateModule(mod *kmmv1beta1.Module, ocpVersion *OCPVersion) (admission.W
 	return nil, validateFilesToSign(mod.Spec.ModuleLoader.Container)
 }
 
-func validateDRA(mod *kmmv1beta1.Module, ocpVersion *OCPVersion) error {
+func validateDRA(mod *kmmv1beta1.Module, ocpVersion *version.OCPVersion) error {
 	if mod.Spec.DRA == nil {
 		return nil
 	}
 
-	if ocpVersion != nil {
-		if ocpVersion.Major < constants.MinOCPMajorForDRA || (ocpVersion.Major == constants.MinOCPMajorForDRA && ocpVersion.Minor < constants.MinOCPMinorForDRA) {
-			return fmt.Errorf(
-				"spec.dra requires OpenShift %d.%d or later; current cluster version is %d.%d",
-				constants.MinOCPMajorForDRA, constants.MinOCPMinorForDRA, ocpVersion.Major, ocpVersion.Minor,
-			)
-		}
+	// Skip version gating when ocpVersion is nil (e.g. hub webhook validating
+	// a ManagedClusterModule — the spoke's own webhook will enforce its version).
+	if ocpVersion != nil && !ocpVersion.AtLeast(constants.MinOCPMajorForDRA, constants.MinOCPMinorForDRA) {
+		return fmt.Errorf(
+			"spec.dra requires OpenShift %d.%d or later; current cluster version is %d.%d",
+			constants.MinOCPMajorForDRA, constants.MinOCPMinorForDRA, ocpVersion.Major, ocpVersion.Minor,
+		)
 	}
 	driverName := mod.Spec.DRA.DriverName
 	if driverName == "" {
@@ -261,7 +206,7 @@ func validateHostPathVolumes(fieldPath string, volumes []corev1.Volume) error {
 	for i, vol := range volumes {
 		if vol.HostPath != nil && !isAllowedHostPath(vol.HostPath.Path) {
 			return fmt.Errorf(
-				"%s.volumes[%d]: hostPath %q is not allowed; only /dev, /sys, /var and /opt paths are permitted",
+				"%s.volumes[%d]: hostPath %q is not allowed; only /dev, /sys, /var, /opt and /run paths are permitted",
 				fieldPath, i, vol.HostPath.Path,
 			)
 		}

--- a/internal/webhook/module_test.go
+++ b/internal/webhook/module_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 	kmmv1beta1 "github.com/rh-ecosystem-edge/kernel-module-management/api/v1beta1"
 	"github.com/rh-ecosystem-edge/kernel-module-management/internal/utils"
+	"github.com/rh-ecosystem-edge/kernel-module-management/internal/version"
 )
 
 func getLengthAfterSlash(s string) int {
@@ -53,7 +54,7 @@ var (
 		},
 	}
 
-	moduleWebhook = NewModuleValidator(GinkgoLogr, &OCPVersion{Major: 4, Minor: 21})
+	moduleWebhook = NewModuleValidator(GinkgoLogr, &version.OCPVersion{Major: 4, Minor: 21})
 )
 
 var _ = Describe("maxCombinedLength", func() {
@@ -411,7 +412,7 @@ var _ = Describe("validateModule", func() {
 			mod.Name = name
 			mod.Namespace = ns
 
-			_, err := validateModule(&mod, &OCPVersion{Major: 4, Minor: 21})
+			_, err := validateModule(&mod, &version.OCPVersion{Major: 4, Minor: 21})
 			exp := Expect(err)
 
 			if errExpected {
@@ -426,7 +427,7 @@ var _ = Describe("validateModule", func() {
 	It("should pass when moduleLoader is not defined", func() {
 		mod := validModule
 		mod.Spec.ModuleLoader = nil
-		_, err := validateModule(&mod, &OCPVersion{Major: 4, Minor: 21})
+		_, err := validateModule(&mod, &version.OCPVersion{Major: 4, Minor: 21})
 		Expect(err).NotTo(HaveOccurred())
 	})
 })
@@ -699,35 +700,6 @@ var _ = Describe("validateTolerations", func() {
 	})
 })
 
-var _ = Describe("parseOCPVersion", func() {
-	DescribeTable(
-		"should parse valid version strings",
-		func(version string, expectedMajor, expectedMinor int) {
-			ov, err := parseOCPVersion(version)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(ov.Major).To(Equal(expectedMajor))
-			Expect(ov.Minor).To(Equal(expectedMinor))
-		},
-		Entry("standard version", "4.21.0", 4, 21),
-		Entry("release candidate", "4.21.0-rc.1", 4, 21),
-		Entry("older minor", "4.20.3", 4, 20),
-		Entry("newer minor", "4.22.1", 4, 22),
-		Entry("with v prefix", "v4.21.0", 4, 21),
-		Entry("hypothetical OCP 5.0", "5.0.0", 5, 0),
-	)
-
-	DescribeTable(
-		"should return error for invalid strings",
-		func(version string) {
-			_, err := parseOCPVersion(version)
-			Expect(err).To(HaveOccurred())
-		},
-		Entry("empty string", ""),
-		Entry("garbage", "invalid"),
-		Entry("no minor", "v4"),
-	)
-})
-
 var _ = Describe("validateDRA", func() {
 	validDRASpec := func() *kmmv1beta1.DRASpec {
 		return &kmmv1beta1.DRASpec{
@@ -738,7 +710,7 @@ var _ = Describe("validateDRA", func() {
 		}
 	}
 
-	minValidOCPVersion := &OCPVersion{Major: 4, Minor: 21}
+	minValidOCPVersion := &version.OCPVersion{Major: 4, Minor: 21}
 
 	It("should be a no-op when spec.dra is nil", func() {
 		mod := &kmmv1beta1.Module{}
@@ -747,7 +719,7 @@ var _ = Describe("validateDRA", func() {
 
 	DescribeTable(
 		"OpenShift version gate",
-		func(ov *OCPVersion, shouldFail bool) {
+		func(ov *version.OCPVersion, shouldFail bool) {
 			mod := &kmmv1beta1.Module{
 				Spec: kmmv1beta1.ModuleSpec{
 					DRA: validDRASpec(),
@@ -760,11 +732,11 @@ var _ = Describe("validateDRA", func() {
 				Expect(err).NotTo(HaveOccurred())
 			}
 		},
-		Entry("OCP 4.20 rejects", &OCPVersion{Major: 4, Minor: 20}, true),
-		Entry("OCP 4.21 accepts", &OCPVersion{Major: 4, Minor: 21}, false),
-		Entry("OCP 4.22 accepts", &OCPVersion{Major: 4, Minor: 22}, false),
-		Entry("OCP 5.0 accepts (future major)", &OCPVersion{Major: 5, Minor: 0}, false),
-		Entry("OCP 3.11 rejects (old major)", &OCPVersion{Major: 3, Minor: 11}, true),
+		Entry("OCP 4.20 rejects", &version.OCPVersion{Major: 4, Minor: 20}, true),
+		Entry("OCP 4.21 accepts", &version.OCPVersion{Major: 4, Minor: 21}, false),
+		Entry("OCP 4.22 accepts", &version.OCPVersion{Major: 4, Minor: 22}, false),
+		Entry("OCP 5.0 accepts (future major)", &version.OCPVersion{Major: 5, Minor: 0}, false),
+		Entry("OCP 3.11 rejects (old major)", &version.OCPVersion{Major: 3, Minor: 11}, true),
 		Entry("nil version skips gate (hub webhook)", nil, false),
 	)
 


### PR DESCRIPTION
The DRA reconciler was registered unconditionally, which would crash the entire operator on clusters older than 4.21 because the resource.k8s.io/v1 DeviceClass API does not exist there.

Introduce an internal/version package with OCPVersion, DiscoverOCPVersion, and an AtLeast method to centralise version discovery and comparison. The manager now checks the cluster version at startup and only registers the DRA controller when the minimum version is met. The webhook package is updated to use the shared version package instead of its own local types.

Also fixes a pre-existing bug where /run was missing from the allowed hostPath prefixes error message.


---

/cc @ybettan @yevgeny-shnaidman 
/assign @yevgeny-shnaidman @ybettan 

---

fix #1841

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic OpenShift version detection during startup.
  * DRA-related validation is now applied only on supported cluster versions.

* **Bug Fixes**
  * Improved startup behavior by failing fast when cluster version discovery cannot be completed.
  * Updated module validation to use a shared version format for more consistent checks.
  * Refined host path validation messaging to include `/run` as an allowed path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->