### PR TITLE
Add DRA e2e CI test

### DIFF
--- a/ci/e2e-dra/dra-consumer-pod.yaml
+++ b/ci/e2e-dra/dra-consumer-pod.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaimTemplate
+metadata:
+  name: dra-test-claim
+spec:
+  spec:
+    devices:
+      requests:
+      - name: gpu
+        exactly:
+          deviceClassName: kmm-ci-test-device
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dra-consumer
+spec:
+  # Prefer nodes WITHOUT the DRA device. This ensures that if the pod
+  # still lands on the labeled node, it is because DRA scheduling overrode
+  # the node preference — not scheduler coincidence.
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+          - key: task
+            operator: NotIn
+            values:
+            - kmm-ci-dra
+  containers:
+  - name: consumer
+    image: busybox:1.36
+    command: ["sh", "-c", "sleep infinity"]
+    resources:
+      claims:
+      - name: gpu
+  resourceClaims:
+  - name: gpu
+    resourceClaimTemplateName: dra-test-claim

--- a/ci/e2e-dra/module-kmm-ci-dra.yaml
+++ b/ci/e2e-dra/module-kmm-ci-dra.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: kmm.sigs.x-k8s.io/v1beta1
+kind: Module
+metadata:
+  name: kmm-ci-dra
+spec:
+  moduleLoader:
+    container:
+      modprobe:
+        moduleName: kmm_ci_a
+        modulesLoadingOrder: [kmm_ci_a, kmm_ci_b]
+      kernelMappings:
+        - regexp: '^.+$'
+          containerImage: image-registry.openshift-image-registry.svc:5000/$MOD_NAMESPACE/$MOD_NAME:$KERNEL_FULL_VERSION
+          build:
+            secrets:
+              - name: build-secret
+            dockerfileConfigMap:
+              name: kmm-kmod-dockerfile
+  dra:
+    driverName: gpu.example.com
+    container:
+      image: registry.k8s.io/dra-example-driver/dra-example-driver:v0.3.0
+      command: ["dra-example-kubeletplugin"]
+      env:
+        - name: DRIVER_NAME
+          value: gpu.example.com
+    deviceClasses:
+      - name: kmm-ci-test-device
+  selector:
+    task: kmm-ci-dra

--- a/ci/prow/e2e-dra
+++ b/ci/prow/e2e-dra
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+KUBE_MAJOR=$(oc version -o json | jq -r '.serverVersion.major' | tr -d '+')
+KUBE_MINOR=$(oc version -o json | jq -r '.serverVersion.minor' | tr -d '+')
+if [ "${KUBE_MAJOR}" -eq 1 ] && [ "${KUBE_MINOR}" -lt 34 ]; then
+  echo "SKIP: DRA requires Kubernetes >= 1.34, got ${KUBE_MAJOR}.${KUBE_MINOR}"
+  exit 0
+fi
+
+echo "Get a worker node..."
+export NODE=$(oc get nodes -l node-role.kubernetes.io/worker -o jsonpath='{.items[0].metadata.name}')
+
+echo "Label the node to match the Module selector..."
+oc label node "${NODE}" task=kmm-ci-dra
+
+oc project openshift-kmm
+
+oc wait --for=condition=Available deployment/kmm-operator-controller deployment/kmm-operator-webhook
+
+echo "Create a build secret"
+oc create secret generic build-secret --from-literal=ci-build-secret=super-secret-value
+
+echo "Add a configmap that contains the kernel module build dockerfile"
+oc create configmap kmm-kmod-dockerfile --from-file=dockerfile=ci/e2e/Dockerfile
+
+echo "Add a Module with DRA spec"
+timeout 1m bash -c 'until oc apply -f ci/e2e-dra/module-kmm-ci-dra.yaml; do sleep 3; done'
+
+echo "Check that the module gets loaded on the node"
+timeout 10m bash -c 'until oc debug node/${NODE} -- chroot host/ lsmod | grep kmm_ci_a; do sleep 3; done'
+
+echo "Check that the DRA DaemonSet gets created"
+timeout 2m bash -c 'until oc get ds -l kmm.node.kubernetes.io/role=dra,kmm.node.kubernetes.io/module.name=kmm-ci-dra -o name 2>/dev/null | grep -q daemonset; do sleep 3; done'
+
+echo "Check that the DRA DaemonSet pod is ready"
+timeout 5m bash -c 'until [ "$(oc get ds -l kmm.node.kubernetes.io/role=dra,kmm.node.kubernetes.io/module.name=kmm-ci-dra -o jsonpath="{.items[0].status.numberReady}" 2>/dev/null)" = "1" ]; do sleep 3; done'
+
+echo "Check that the DeviceClass was created with correct labels"
+DC_MODULE_NAME=$(oc get deviceclass kmm-ci-test-device -o jsonpath='{.metadata.labels.kmm\.node\.kubernetes\.io/module\.name}')
+DC_MODULE_NS=$(oc get deviceclass kmm-ci-test-device -o jsonpath='{.metadata.labels.kmm\.node\.kubernetes\.io/module\.namespace}')
+[ "${DC_MODULE_NAME}" = "kmm-ci-dra" ]
+[ "${DC_MODULE_NS}" = "openshift-kmm" ]
+
+echo "Check that the DRA node label was set"
+timeout 2m bash -c 'until oc get node ${NODE} -o jsonpath="{.metadata.labels}" | grep "kmm\.node\.kubernetes\.io/openshift-kmm\.kmm-ci-dra\.dra-ready"; do sleep 3; done'
+
+echo "Check that ResourceSlices were published by the driver"
+timeout 2m bash -c 'until [ "$(oc get resourceslice --no-headers 2>/dev/null | grep gpu.example.com | wc -l)" -gt 0 ]; do sleep 3; done'
+
+echo "Check that Module status.dra is populated"
+[ "$(oc get module kmm-ci-dra -o jsonpath='{.status.dra.availableNumber}')" = "1" ]
+
+echo "Deploy a consumer pod requesting DRA hardware"
+oc apply -f ci/e2e-dra/dra-consumer-pod.yaml
+
+echo "Check that the consumer pod is running on the node with the DRA driver"
+oc wait --for=condition=Ready pod/dra-consumer --timeout=2m
+[ "$(oc get pod dra-consumer -o jsonpath='{.spec.nodeName}')" = "${NODE}" ]
+
+echo "Remove the consumer pod"
+oc delete -f ci/e2e-dra/dra-consumer-pod.yaml
+timeout 1m bash -c 'until ! oc get pod dra-consumer 2>/dev/null; do sleep 3; done'
+
+echo "Remove the Module"
+oc delete -f ci/e2e-dra/module-kmm-ci-dra.yaml --wait=false
+
+echo "Check that the DRA DaemonSet gets cleaned up"
+timeout 2m bash -c 'until [ "$(oc get ds -l kmm.node.kubernetes.io/role=dra,kmm.node.kubernetes.io/module.name=kmm-ci-dra --no-headers 2>/dev/null | wc -l)" -eq 0 ]; do sleep 3; done'
+
+echo "Check that the DeviceClass gets cleaned up"
+timeout 1m bash -c 'until ! oc get deviceclass kmm-ci-test-device 2>/dev/null; do sleep 3; done'
+
+echo "Check that the module gets unloaded from the node"
+timeout 1m bash -c 'until ! oc debug node/${NODE} -- chroot host/ lsmod | grep kmm_ci_a; do sleep 3; done'
+
+echo "Wait for the Module to be deleted"
+oc wait --for delete modules.kmm.sigs.x-k8s.io/kmm-ci-dra


### PR DESCRIPTION
Add an end-to-end test that validates the full DRA lifecycle: DaemonSet creation, DeviceClass management, node labeling, status reporting, and cleanup on Module deletion.

---

/cc @yevgeny-shnaidman @ybettan 
/assign @ybettan @yevgeny-shnaidman 

---

fixes #1846

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an end-to-end DRA workflow test for Kernel Module Manager on OpenShift.
  * Added Kubernetes manifests for a DRA-enabled module and a consumer pod that requests the device.
* **Bug Fixes**
  * Improved validation that the DRA driver, DeviceClass, ResourceSlices, and readiness signals appear as expected.
  * Added cleanup checks to confirm test resources are removed and the module unloads correctly.
* **Tests**
  * The new test covers module deployment, DRA scheduling, pod readiness, and teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->