### PR TITLE
Fix DRA nodeSelector for in-tree driver mode

### DIFF
--- a/internal/controllers/dra_reconciler.go
+++ b/internal/controllers/dra_reconciler.go
@@ -543,10 +543,14 @@ func (dsci *draDaemonSetCreatorImpl) setDRAAsDesired(
 		utils.GetKernelModuleReadyNodeLabel(mod.Namespace, mod.Name): "",
 	}
 
-	if mod.Spec.ModuleLoader != nil && mod.Spec.ModuleLoader.Container.Version != "" {
-		versionLabel := utils.GetSchedulePodVersionLabelName(mod.Namespace, mod.Name)
-		standardLabels[versionLabel] = mod.Spec.ModuleLoader.Container.Version
-		nodeSelector[versionLabel] = mod.Spec.ModuleLoader.Container.Version
+	if mod.Spec.ModuleLoader != nil {
+		if mod.Spec.ModuleLoader.Container.Version != "" {
+			versionLabel := utils.GetSchedulePodVersionLabelName(mod.Namespace, mod.Name)
+			standardLabels[versionLabel] = mod.Spec.ModuleLoader.Container.Version
+			nodeSelector[versionLabel] = mod.Spec.ModuleLoader.Container.Version
+		}
+	} else {
+		nodeSelector = mod.Spec.Selector
 	}
 
 	ds.SetLabels(

--- a/internal/controllers/dra_reconciler_test.go
+++ b/internal/controllers/dra_reconciler_test.go
@@ -750,10 +750,8 @@ var _ = Describe("DRAReconciler_setDRAAsDesired", func() {
 									},
 								},
 							},
-							ImagePullSecrets: []v1.LocalObjectReference{repoSecret},
-							NodeSelector: map[string]string{
-								utils.GetKernelModuleReadyNodeLabel(namespace, draModuleName): "",
-							},
+							ImagePullSecrets:   []v1.LocalObjectReference{repoSecret},
+							NodeSelector:       map[string]string{"has-feature-x": "true"},
 							PriorityClassName:  "system-node-critical",
 							HostNetwork:        true,
 							ServiceAccountName: serviceAccountName,


### PR DESCRIPTION
When spec.moduleLoader is nil (in-tree mode), the DRA reconciler's nodeSelector requires the KMM ready label, which is never set because no module loading occurs. Fall back to spec.selector instead, matching the existing behavior in the device plugin reconciler.

---

/cc @ybettan @yevgeny-shnaidman 
/assign @ybettan @yevgeny-shnaidman 

---

fix #1850

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated node selection behavior so workloads now follow the module’s configured selector when no module loader is set.
  * Preserved version-based node selection for module-loader setups when a container version is provided.
  * Adjusted the expected scheduling behavior in automated checks to match the new selection rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->