### PR TITLE
Add DRA support documentation

### DIFF
--- a/docs/mkdocs/developer/reconciliation_loops.md
+++ b/docs/mkdocs/developer/reconciliation_loops.md
@@ -21,3 +21,20 @@ Each time a new `Module` is created, we need to find to which nodes it applies.
    in the cluster.
 
 ![Modules reconciliation](diagrams/reconciliation-module.png)
+
+## DRA
+
+A separate DRA reconciler watches `Module` resources that have `.spec.dra` set.
+
+1. When a `Module` has `.spec.dra` configured, the DRA reconciler creates a DRA driver `DaemonSet` targeting nodes
+   where the kernel module is loaded.
+
+1. It also creates and manages cluster-scoped `DeviceClass` resources as declared in `.spec.dra.deviceClasses`.
+   DeviceClasses are tracked via labels (`kmm.node.kubernetes.io/module.name` and
+   `kmm.node.kubernetes.io/module.namespace`) since they are cluster-scoped while Modules are namespaced.
+
+1. When `spec.dra` is removed or the `Module` is deleted, the reconciler deletes all associated DRA `DaemonSet` and
+   `DeviceClass` resources.
+
+1. During [ordered upgrades](../documentation/ordered_upgrade.md), a new DRA `DaemonSet` is created for the new module
+   version. Once the old-version `DaemonSet` is no longer scheduled on any node, it is garbage-collected.

--- a/docs/mkdocs/documentation/deploy_kmod.md
+++ b/docs/mkdocs/documentation/deploy_kmod.md
@@ -12,8 +12,8 @@ To be eligible for a `Module`, a `Node` must:
 When KMM needs to reconcile nodes with the desired state as configured in the `Module` resource, it creates worker Pods
 on the target node(s) to run the necessary action.  
 The operator monitors the outcome of those Pods and records that information.
-It uses it to label `Node` objects when the module was successfully loaded, and to run the device plugin (if
-configured).
+It uses it to label `Node` objects when the module was successfully loaded, and to run the device plugin or DRA driver
+(if configured).
 The label can be found in the node's label with the following format:
 ```
 kmm.node.kubernetes.io/<namespace>.<modulename>.ready
@@ -57,6 +57,92 @@ into device plugin pod, and allow users to mount what they need for the device p
 !!! note
     In this case, it is the user's responsibility to mount the necessary tokens and CAs into the device plugin pods, otherwise the device plugin may not work properly.
 
+### DRA (Dynamic Resource Allocation) driver
+
+If `.spec.dra` is configured in a `Module`, then KMM will create a DRA driver
+[DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) in the cluster.
+DRA is the successor to the Device Plugin API and provides structured parameters, resource claims, and device classes
+for modern hardware orchestration.
+
+!!! note
+    DRA requires Openshift 4.21 or later. The KMM admission webhook rejects `Module` resources with `.spec.dra` on
+    older clusters.
+
+!!! note
+    `.spec.dra` and `.spec.devicePlugin` are mutually exclusive. A `Module` cannot have both fields set.
+
+The DRA DaemonSet will target nodes:
+
+- that match the `Module`'s `.spec.selector`;
+- on which the kernel module is loaded (using the `kmm.node.kubernetes.io/<namespace>.<modulename>.ready` label).
+
+When the DRA driver pod is running and ready on a node, KMM sets the following label:
+```
+kmm.node.kubernetes.io/<namespace>.<modulename>.dra-ready
+```
+It is strongly recommended to use `GetDRANodeLabel` function from the `labels` package in order to construct the correct label.
+
+DRA driver pods run with `hostNetwork: true` and `priorityClassName: system-node-critical`, which ensures they are not
+preempted and have access to the host network.
+KMM also configures a GRPC liveness probe on port `51515` (service `liveness`) with a 30-second initial delay.
+The DRA driver container should implement this GRPC health check endpoint; if it fails, the pod will be restarted.
+
+KMM automatically mounts the following host paths into DRA driver pods:
+
+| Host path | Mount type | Purpose |
+|---|---|---|
+| `/var/lib/kubelet/plugins/` | `HostPathDirectoryOrCreate` | DRA plugin socket registration |
+| `/var/lib/kubelet/plugins_registry/` | `HostPathDirectory` | Kubelet plugin discovery |
+| `/var/run/cdi` | `HostPathDirectoryOrCreate` | CDI device specification files |
+
+The following environment variables are preset in the DRA driver container:
+
+| Variable | Value |
+|---|---|
+| `NODE_NAME` | The name of the node the pod is running on (from `spec.nodeName`) |
+| `POD_UID` | The UID of the pod (from `metadata.uid`) |
+| `CDI_ROOT` | `/var/run/cdi` |
+| `KUBELET_REGISTRAR_DIRECTORY_PATH` | `/var/lib/kubelet/plugins_registry/` |
+| `KUBELET_PLUGINS_DIRECTORY_PATH` | `/var/lib/kubelet/plugins/` |
+| `HEALTHCHECK_PORT` | `51515` |
+
+Users may specify additional volumes and volume mounts via `.spec.dra.volumes` and `.spec.dra.container.volumeMounts`.
+
+!!! note
+    User-supplied hostPath volumes in `.spec.dra.volumes` are restricted to paths under `/dev`, `/sys`, `/var`, `/opt`,
+    or `/run`. The admission webhook rejects volumes with paths outside these prefixes.
+
+There is also support for running an init-container as part of the DRA driver by setting `.spec.dra.initContainer`.
+
+#### DRA driver name
+
+`.spec.dra.driverName` is required and must be a valid
+[DNS subdomain](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names).
+This is the name the DRA driver registers with kubelet.
+
+#### DeviceClasses
+
+`.spec.dra.deviceClasses` is an optional list of
+[DeviceClass](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/#deviceclass)
+resources that KMM will create and manage on behalf of the `Module`.
+
+Each entry requires a `name` (must be a valid DNS subdomain and unique within the list) and may include `selectors` and
+`config` fields matching the `DeviceClass` spec.
+
+KMM tracks ownership of DeviceClasses via labels (`kmm.node.kubernetes.io/module.name` and
+`kmm.node.kubernetes.io/module.namespace`).
+When a `Module` is deleted, all DeviceClasses managed by that Module are automatically deleted.
+Removing an entry from the list deletes the corresponding DeviceClass; editing an entry updates it.
+
+#### Service account token auto-mounting
+
+By default, Openshift auto-mounts the service account token and root CAs into DRA driver pods.
+The `module.spec.dra.automountServiceAccountToken` field can be set to `false` to disable this behavior, allowing users
+to mount their own tokens and CAs as needed.
+
+!!! note
+    When set to `false`, it is the user's responsibility to mount the necessary tokens and CAs into the DRA driver pods.
+
 ## `Module` CRD
 
 The `Module` Custom Resource Definition represents a kernel module that should be loaded on all or select nodes in the
@@ -77,8 +163,10 @@ The reconciliation loop for `Module` runs the following steps:
     2. create a worker Pod pulling the container image determined at the previous step and running `modprobe`;
     3. if `.spec.devicePlugin` is defined, create a device plugin `DaemonSet` using the configuration specified under
        `.spec.devicePlugin.container`;
+    4. if `.spec.dra` is defined, create a DRA driver `DaemonSet` using the configuration specified under
+       `.spec.dra`, and create any `DeviceClass` resources listed in `.spec.dra.deviceClasses`;
 4. garbage-collect:
-    1. obsolete device plugin `DaemonSets` that do not target any node;
+    1. obsolete device plugin and DRA `DaemonSet` that do not target any node;
     2. successful build pods;
     3. successful signing pods.
 
@@ -160,8 +248,9 @@ After the rebuild process completes, KMM updates `.status.imageRebuildTriggerGen
 
 ### Supporting Modules without OOT kmods
 In some cases, there is a need to configure the KMM Module to avoid loading an out-of-tree kernel module and
-instead use the in-tree one, running only the device plugin.
-In such cases, the moduleLoader can be omitted from the Module custom resource, leaving only the devicePlugin section.
+instead use the in-tree one, running only the device plugin or DRA driver.
+In such cases, the moduleLoader can be omitted from the Module custom resource, leaving only the devicePlugin or dra
+section.
 
 ```yaml
 apiVersion: kmm.sigs.x-k8s.io/v1beta1
@@ -174,6 +263,22 @@ spec:
   devicePlugin:
     container:
       image: some.registry/org/my-device-plugin:latest
+```
+
+Or using DRA instead of a device plugin:
+
+```yaml
+apiVersion: kmm.sigs.x-k8s.io/v1beta1
+kind: Module
+metadata:
+  name: my-kmod
+spec:
+  selector:
+    node-role.kubernetes.io/worker: ""
+  dra:
+    driverName: dra.example.com
+    container:
+      image: some.registry/org/my-dra-driver:latest
 ```
 
 ### Example resource
@@ -286,6 +391,73 @@ spec:
   # Optional. Change this value to force KMM to re-verify and potentially rebuild all module images.
   # See "Forcing module image rebuilds" section for details.
   imageRebuildTriggerGeneration: 1
+
+  selector:
+    node-role.kubernetes.io/worker: ""
+```
+
+### Example resource with DRA
+
+Below is an annotated `Module` example using DRA instead of a device plugin.
+Remember that `.spec.dra` and `.spec.devicePlugin` are mutually exclusive.
+
+!!! note
+    DRA requires Openshift 4.21 or later.
+
+```yaml
+apiVersion: kmm.sigs.x-k8s.io/v1beta1
+kind: Module
+metadata:
+  name: my-kmod
+spec:
+  moduleLoader:
+    container:
+      modprobe:
+        moduleName: my-kmod
+      kernelMappings:
+        - regexp: '^.+$'
+          containerImage: "some.registry/org/my-kmod:${KERNEL_FULL_VERSION}"
+
+  dra:
+    driverName: dra.example.com  # Required; must be a valid DNS subdomain
+
+    container:
+      image: some.registry/org/my-dra-driver:latest  # Required
+
+      env:  # Optional
+        - name: MY_DRA_ENV_VAR
+          value: SOME_VALUE
+
+      volumeMounts:  # Optional; appended to the auto-mounted volumes
+        - mountPath: /some/mountPath
+          name: dra-extra-volume
+
+    initContainer:  # Optional
+      image: some.registry/org/my-dra-init:latest
+
+    volumes:  # Optional; appended to the auto-mounted volumes
+      - name: dra-extra-volume
+        configMap:
+          name: some-configmap
+
+    serviceAccountName: sa-dra-driver  # Optional; defaults to the namespace's default ServiceAccount if not set
+
+    deviceClasses:  # Optional; list of DeviceClass resources to create
+      - name: my-device-class
+        selectors:  # Optional; restrict which devices match this class
+          - cel:
+              expression: "device.driver == 'dra.example.com'"
+        config:  # Optional; per-device configuration
+          - opaque:
+              driver: dra.example.com
+              parameters:
+                apiVersion: dra.example.com/v1
+                kind: MyDeviceConfig
+                spec:
+                  mode: default
+
+  imageRepoSecret:  # Optional
+    name: secret-name
 
   selector:
     node-role.kubernetes.io/worker: ""

--- a/docs/mkdocs/documentation/hub_spoke.md
+++ b/docs/mkdocs/documentation/hub_spoke.md
@@ -73,7 +73,8 @@ metadata:
   # No namespace, because this resource is cluster-scoped.
 spec:
   moduleSpec:
-    # Contains moduleLoader and devicePlugin sections, just like in a Module resource.
+    # Contains moduleLoader, devicePlugin and/or dra sections, just like in a Module resource.
+    # Note: devicePlugin and dra are mutually exclusive.
     # Optional. Change this value to force image re-verification and rebuilds.
     imageRebuildTriggerGeneration: 1
     selector:

--- a/docs/mkdocs/documentation/ordered_upgrade.md
+++ b/docs/mkdocs/documentation/ordered_upgrade.md
@@ -12,7 +12,7 @@ In order to successfully upgrade a kernel module to a new version, the currently
 unloaded, and a new kernel module file should be loaded.
 This means that all user-mode application/workloads using the kernel module should be terminated before attempting to
 unload the kernel module.  
-There are 2 type of workloads that can use a kernel module:
+There are 3 types of workloads that can use a kernel module:
 
 - user workload: application running in the cluster that is accessing kernel module.
   It is deployed by the administrator, and it is their responsibility to make sure that the workload is not running on
@@ -20,6 +20,9 @@ There are 2 type of workloads that can use a kernel module:
   kernel module version has been loaded.
 - device plugin managed by KMM.
   The operator will manage the unloading/loading of the device plugin on a node being upgraded.
+- DRA driver managed by KMM.
+  The operator will manage the unloading/loading of the DRA driver on a node being upgraded, following the same
+  lifecycle as the device plugin.
 
 Due to Kubernetes limitations in label names, the combined length of `Module` name and namespace may not exceed 39
 characters.
@@ -69,24 +72,25 @@ It is strongly recommended to use `GetKernelModuleVersionReadyNodeLabel` functio
    When it detects a change in the value of that label, it sets the following internal labels to initiate the upgrade
    process:
      - `beta.kmm.node.kubernetes.io/version-worker-pod.<module-namespace>.<module-name>`
-     - `beta.kmm.node.kubernetes.io/version-device-plugin.<module-namespace>.<module-name>`
+     - `beta.kmm.node.kubernetes.io/version-schedule-pod.<module-namespace>.<module-name>`
 2. The operator manipulates its internal `NodeModulesConfig` resources to create worker Pods that unload the current
    version of a module and load the new one.
-3. The operator creates new device plugin DaemonSets with a new node selector component:
-   `kmm.node.kubernetes.io/version-device-plugin.<module-namespace>.<module-name>`
-   This makes it possible to terminate the device plugin Pod before unloading the current module, and to create them
-   again when the new module is loaded.
+3. The operator creates new device plugin (or DRA driver) DaemonSets with a new node selector component:
+   `beta.kmm.node.kubernetes.io/version-schedule-pod.<module-namespace>.<module-name>`
+   Both device plugin and DRA driver DaemonSets use the same `version-schedule-pod` label.
+   This makes it possible to terminate the device plugin or DRA driver Pod before unloading the current module, and to
+   create them again when the new module is loaded.
 
 ### Flow
 
-1. When the `version` field is modified in the `Module`, a new device plugin DaemonSet is created with the following
-   internal node selector:
-   `beta.kmm.node.kubernetes.io/version-device-plugin.<module-namespace>.<module-name>=$moduleVersion`
+1. When the `version` field is modified in the `Module`, a new device plugin (or DRA driver) DaemonSet is created with
+   the following internal node selector:
+   `beta.kmm.node.kubernetes.io/version-schedule-pod.<module-namespace>.<module-name>=$moduleVersion`
 2. When the `kmm.node.kubernetes.io/version-module.<module-namespace>.<module-name>` label is changed on the node, KMM's
    version label controller removes the
-   `beta.kmm.node.kubernetes.io/version-device-plugin.<module-namespace>.<module-name>` label, which terminates the
-   device plugin Pod;
-3. Once the device plugin Pod is terminated, the controller removes the
+   `beta.kmm.node.kubernetes.io/version-schedule-pod.<module-namespace>.<module-name>` label, which terminates the
+   device plugin (or DRA driver) Pod;
+3. Once the device plugin (or DRA driver) Pod is terminated, the controller removes the
    `beta.kmm.node.kubernetes.io/version-worker-pod.<module-namespace>.<module-name>` label, which removes the entry from
    the corresponding `NodeModulesConfig` resource.
    This results in a worker Pod being created to unload the current kernel module.
@@ -95,5 +99,5 @@ It is strongly recommended to use `GetKernelModuleVersionReadyNodeLabel` functio
    node, which adds back an updated entry into the corresponding `NodeModulesConfig` resource.
    This results in a worker Pod being created to load the new kernel module.
 5. Once the new kernel module is loaded, the controller sets the
-   `beta.kmm.node.kubernetes.io/version-device-plugin.<module-namespace>.<module-name>=$moduleVersion` label on the
-   node, which will cause the device plugin Pod to start again.
+   `beta.kmm.node.kubernetes.io/version-schedule-pod.<module-namespace>.<module-name>=$moduleVersion` label on the
+   node, which will cause the device plugin (or DRA driver) Pod to start again.

--- a/docs/mkdocs/index.md
+++ b/docs/mkdocs/index.md
@@ -3,10 +3,10 @@
 ## Overview
 
 Kernel Module Management (KMM) is an Openshift operator that manages, builds, signs and deploys out-of-tree kernel
-modules and device plugins on Openshift clusters.
+modules, device plugins and DRA (Dynamic Resource Allocation) drivers on Openshift clusters.
 
 KMM adds a new `Module` CRD which describes the desired state of an out-of-tree kernel module and its associated device
-plugin.
+plugin or DRA driver.
 `Module` resources contain fields that configure how to load the module, associates kmod images with kernel versions,
 and optionally instructions to build and sign modules for specific kernel versions.
 KMM is designed to accommodate several kernel versions at once for any kernel module, allowing for seamless node upgrades


### PR DESCRIPTION
Document the new DRA (Dynamic Resource Allocation) driver feature across the user-facing and developer docs.
Also fix inaccurate serviceAccountName comment in the device plugin example (not auto-created; defaults to namespace's default SA).

---

/cc @ybettan @yevgeny-shnaidman 
/assign @ybettan @yevgeny-shnaidman 

---

fix #1853

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added documentation for Dynamic Resource Allocation (DRA) driver support.
  - Documented DRA driver configuration, node targeting, device classes, security settings, and deployment behavior.
  - Added examples for configuring DRA drivers in module resources.

- **Documentation**
  - Updated reconciliation and ordered-upgrade guidance to include DRA-managed workloads.
  - Clarified that device plugins and DRA drivers are mutually exclusive options.
  - Updated product overviews and deployment workflows to describe DRA support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->