### PR TITLE
Switch to server-side apply for kubectl install/deploy commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,7 @@ KUSTOMIZE_CONFIG_CRD ?= config/crd
 
 .PHONY: install
 install: manifests ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	oc apply -k $(KUSTOMIZE_CONFIG_CRD)
+	oc apply --server-side --force-conflicts -k $(KUSTOMIZE_CONFIG_CRD)
 
 .PHONY: uninstall
 uninstall: manifests ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
@@ -219,14 +219,14 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG) worker=$(WORKER_IMG)
 	cd config/manager-base && $(KUSTOMIZE) edit set image must-gather=$(GATHER_IMG) signer=$(SIGNER_IMG)
 	cd config/webhook-server && $(KUSTOMIZE) edit set image webhook-server=$(WEBHOOK_IMG)
-	oc apply -k $(KUSTOMIZE_CONFIG_DEFAULT)
+	oc apply --server-side --force-conflicts -k $(KUSTOMIZE_CONFIG_DEFAULT)
 
 .PHONY: deploy-hub
 deploy-hub: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager-hub && $(KUSTOMIZE) edit set image controller=$(HUB_IMG)
 	cd config/manager-base && $(KUSTOMIZE) edit set image must-gather=$(GATHER_IMG) signer=$(SIGNER_IMG)
 	cd config/webhook-server && $(KUSTOMIZE) edit set image webhook-server=$(WEBHOOK_IMG)
-	oc apply -k $(KUSTOMIZE_CONFIG_HUB_DEFAULT)
+	oc apply --server-side --force-conflicts -k $(KUSTOMIZE_CONFIG_HUB_DEFAULT)
 
 .PHONY: undeploy
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ the kernel modules for new incoming kernel versions attached to upgrades.
 ## Getting started
 Install the bleeding edge KMM in one command:
 ```shell
-oc apply -k https://github.com/rh-ecosystem-edge/kernel-module-management/config/default
+oc apply --server-side --force-conflicts -k https://github.com/rh-ecosystem-edge/kernel-module-management/config/default
 ```
 
 ## Documentation and lab

--- a/docs/mkdocs/documentation/hub_spoke.md
+++ b/docs/mkdocs/documentation/hub_spoke.md
@@ -57,7 +57,7 @@ spec:
 The command below installs the bleeding edge version of KMM-Hub.
 
 ```shell
-oc apply -k https://github.com/rh-ecosystem-edge/kernel-module-management/config/default-hub
+oc apply --server-side --force-conflicts -k https://github.com/rh-ecosystem-edge/kernel-module-management/config/default-hub
 ```
 
 ### The `ManagedClusterModule` CRD

--- a/docs/mkdocs/documentation/install.md
+++ b/docs/mkdocs/documentation/install.md
@@ -105,7 +105,7 @@ oc rollout restart deploy/kmm-operator-controller -n openshift-kmm
 The command below installs the bleeding edge version of KMM.
 
 ```shell
-oc apply -k https://github.com/rh-ecosystem-edge/kernel-module-management/config/default
+oc apply --server-side --force-conflicts -k https://github.com/rh-ecosystem-edge/kernel-module-management/config/default
 ```
 
 ### Configuring tolerations with kustomize


### PR DESCRIPTION
Client-side apply stores the full manifest in the
last-applied-configuration annotation, capped at 256KB. The Module and ManagedClusterModule CRDs haven't hit that limit yet, but the pending configurable SecurityContext change (#1323) will push them over it and break kubectl apply.
 Switch to --server-side --force-conflicts preemptively, since it tracks field
ownership on the API server instead and isn't subject to this limit.

---

/cc @yevgeny-shnaidman @ybettan 
fix #1893

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Installation and deployment commands now use server-side application with forced conflict resolution.
  * Updated setup documentation with the revised commands for standard and hub installations.
  * Improves reliability when applying configurations that contain conflicting changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->