### PR TITLE
Adding network policies for KMM operator

### DIFF
--- a/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
+++ b/bundle-hub/manifests/kernel-module-management-hub.clusterserviceversion.yaml
@@ -37,7 +37,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2026-07-01T07:49:17Z"
+    createdAt: "2026-09-07T15:10:06Z"
     operatorframework.io/suggested-namespace: openshift-kmm-hub
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle-hub/manifests/kmm-operator-hub-controller_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle-hub/manifests/kmm-operator-hub-controller_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,39 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/component: kmm-hub
+    app.kubernetes.io/name: kmm-hub
+    app.kubernetes.io/part-of: kmm
+  name: kmm-operator-hub-controller
+spec:
+  egress:
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+      podSelector:
+        matchLabels:
+          dns.operator.openshift.io/daemonset-dns: default
+  - ports:
+    - port: 6443
+      protocol: TCP
+    - port: 443
+      protocol: TCP
+  ingress:
+  - ports:
+    - port: 8443
+      protocol: TCP
+    - port: 8081
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: controller
+  policyTypes:
+  - Egress
+  - Ingress

--- a/bundle-hub/manifests/kmm-operator-hub-webhook_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle-hub/manifests/kmm-operator-hub-webhook_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/component: kmm-hub
+    app.kubernetes.io/name: kmm-hub
+    app.kubernetes.io/part-of: kmm
+  name: kmm-operator-hub-webhook
+spec:
+  egress:
+  - ports:
+    - port: 6443
+      protocol: TCP
+    - port: 443
+      protocol: TCP
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          policy-group.network.openshift.io/host-network: ""
+    ports:
+    - port: 9443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: webhook-server
+  policyTypes:
+  - Egress
+  - Ingress

--- a/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
+++ b/bundle/manifests/kernel-module-management.clusterserviceversion.yaml
@@ -47,7 +47,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2026-07-01T07:49:10Z"
+    createdAt: "2026-09-07T15:10:05Z"
     operatorframework.io/suggested-namespace: openshift-kmm
     operators.operatorframework.io/builder: operator-sdk-v1.41.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4

--- a/bundle/manifests/kmm-operator-controller_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/manifests/kmm-operator-controller_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,39 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/component: kmm
+    app.kubernetes.io/name: kmm
+    app.kubernetes.io/part-of: kmm
+  name: kmm-operator-controller
+spec:
+  egress:
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+      podSelector:
+        matchLabels:
+          dns.operator.openshift.io/daemonset-dns: default
+  - ports:
+    - port: 6443
+      protocol: TCP
+    - port: 443
+      protocol: TCP
+  ingress:
+  - ports:
+    - port: 8443
+      protocol: TCP
+    - port: 8081
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: controller
+  policyTypes:
+  - Egress
+  - Ingress

--- a/bundle/manifests/kmm-operator-webhook_networking.k8s.io_v1_networkpolicy.yaml
+++ b/bundle/manifests/kmm-operator-webhook_networking.k8s.io_v1_networkpolicy.yaml
@@ -1,0 +1,29 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/component: kmm
+    app.kubernetes.io/name: kmm
+    app.kubernetes.io/part-of: kmm
+  name: kmm-operator-webhook
+spec:
+  egress:
+  - ports:
+    - port: 6443
+      protocol: TCP
+    - port: 443
+      protocol: TCP
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          policy-group.network.openshift.io/host-network: ""
+    ports:
+    - port: 9443
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      control-plane: webhook-server
+  policyTypes:
+  - Egress
+  - Ingress

--- a/config/default-hub/kustomization.yaml
+++ b/config/default-hub/kustomization.yaml
@@ -6,19 +6,12 @@ namespace: openshift-kmm-hub
 
 namePrefix: kmm-operator-hub-
 
-# Labels to add to all resources and selectors.
-
 resources:
 - ../deploy-hub
 
 components:
 - ../webhook-cert
+- ../kmm-hub-labels
 
 configurations:
 - kustomizeconfig.yaml
-labels:
-- includeSelectors: true
-  pairs:
-    app.kubernetes.io/component: kmm-hub
-    app.kubernetes.io/name: kmm-hub
-    app.kubernetes.io/part-of: kmm

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -6,19 +6,12 @@ resources:
 
 components:
 - ../webhook-cert
+- ../kmm-labels
 
 # Adds namespace to all resources.
 namespace: openshift-kmm
 
 namePrefix: kmm-operator-
 
-# Labels to add to all resources and selectors.
-
 configurations:
 - kustomizeconfig.yaml
-labels:
-- includeSelectors: true
-  pairs:
-    app.kubernetes.io/component: kmm
-    app.kubernetes.io/name: kmm
-    app.kubernetes.io/part-of: kmm

--- a/config/deploy-hub/kustomization.yaml
+++ b/config/deploy-hub/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 - ../manager-hub
 - ../webhook-hub
 - ../webhook-server
+- ../network-policy
 
 patches:
 - target:

--- a/config/deploy/kustomization.yaml
+++ b/config/deploy/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
 - ../prometheus
 - ../webhook
 - ../webhook-server
+- ../network-policy
 
 patches:
 - target:

--- a/config/kmm-hub-labels/kustomization.yaml
+++ b/config/kmm-hub-labels/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+- labels-transformer.yaml

--- a/config/kmm-hub-labels/labels-transformer.yaml
+++ b/config/kmm-hub-labels/labels-transformer.yaml
@@ -1,0 +1,21 @@
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: kmm-hub-labels
+labels:
+  app.kubernetes.io/component: kmm-hub
+  app.kubernetes.io/name: kmm-hub
+  app.kubernetes.io/part-of: kmm
+fieldSpecs:
+- path: metadata/labels
+  create: true
+- kind: Service
+  version: v1
+  path: spec/selector
+  create: true
+- kind: Deployment
+  path: spec/selector/matchLabels
+  create: true
+- kind: Deployment
+  path: spec/template/metadata/labels
+  create: true

--- a/config/kmm-labels/kustomization.yaml
+++ b/config/kmm-labels/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+transformers:
+- labels-transformer.yaml

--- a/config/kmm-labels/labels-transformer.yaml
+++ b/config/kmm-labels/labels-transformer.yaml
@@ -1,0 +1,21 @@
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: kmm-labels
+labels:
+  app.kubernetes.io/component: kmm
+  app.kubernetes.io/name: kmm
+  app.kubernetes.io/part-of: kmm
+fieldSpecs:
+- path: metadata/labels
+  create: true
+- kind: Service
+  version: v1
+  path: spec/selector
+  create: true
+- kind: Deployment
+  path: spec/selector/matchLabels
+  create: true
+- kind: Deployment
+  path: spec/template/metadata/labels
+  create: true

--- a/config/manifests-hub/kustomization.yaml
+++ b/config/manifests-hub/kustomization.yaml
@@ -8,9 +8,6 @@ resources:
 - ../olm-hub
 - ../samples-hub
 - ../scorecard
-labels:
-- includeSelectors: true
-  pairs:
-    app.kubernetes.io/component: kmm-hub
-    app.kubernetes.io/name: kmm-hub
-    app.kubernetes.io/part-of: kmm
+
+components:
+- ../kmm-hub-labels

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -8,9 +8,6 @@ resources:
 - ../olm
 - ../samples
 - ../scorecard
-labels:
-- includeSelectors: true
-  pairs:
-    app.kubernetes.io/component: kmm
-    app.kubernetes.io/name: kmm
-    app.kubernetes.io/part-of: kmm
+
+components:
+- ../kmm-labels

--- a/config/network-policy/controller.yaml
+++ b/config/network-policy/controller.yaml
@@ -1,0 +1,36 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: controller
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller
+  policyTypes:
+  - Egress
+  - Ingress
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 8443
+    - protocol: TCP
+      port: 8081
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: openshift-dns
+      podSelector:
+        matchLabels:
+          dns.operator.openshift.io/daemonset-dns: default
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  - ports:
+    - protocol: TCP
+      port: 6443
+    - protocol: TCP
+      port: 443

--- a/config/network-policy/kustomization.yaml
+++ b/config/network-policy/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- controller.yaml
+- webhook.yaml

--- a/config/network-policy/webhook.yaml
+++ b/config/network-policy/webhook.yaml
@@ -1,0 +1,26 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: webhook
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: webhook-server
+  policyTypes:
+  - Egress
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          policy-group.network.openshift.io/host-network: ""
+    ports:
+    - protocol: TCP
+      port: 9443
+  egress:
+  - ports:
+    - protocol: TCP
+      port: 6443
+    - protocol: TCP
+      port: 443

--- a/config/olm-hub/kustomization.yaml
+++ b/config/olm-hub/kustomization.yaml
@@ -3,15 +3,10 @@ kind: Kustomization
 
 namePrefix: kmm-operator-hub-
 
-# Labels to add to all resources and selectors.
-
 # These resources constitute the fully configured set of manifests
 # used to generate the 'manifests/' directory in a bundle.
 resources:
 - ../deploy-hub
-labels:
-- includeSelectors: true
-  pairs:
-    app.kubernetes.io/component: kmm-hub
-    app.kubernetes.io/name: kmm-hub
-    app.kubernetes.io/part-of: kmm
+
+components:
+- ../kmm-hub-labels

--- a/config/olm/kustomization.yaml
+++ b/config/olm/kustomization.yaml
@@ -3,15 +3,10 @@ kind: Kustomization
 
 namePrefix: kmm-operator-
 
-# Labels to add to all resources and selectors.
-
 # These resources constitute the fully configured set of manifests
 # used to generate the 'manifests/' directory in a bundle.
 resources:
 - ../deploy
-labels:
-- includeSelectors: true
-  pairs:
-    app.kubernetes.io/component: kmm
-    app.kubernetes.io/name: kmm
-    app.kubernetes.io/part-of: kmm
+
+components:
+- ../kmm-labels


### PR DESCRIPTION
Adding Network Policies for KMM and KMM-HUB controllers to be deployed via the makefile and via bundle

---

/cc @yevgeny-shnaidman @ybettan 